### PR TITLE
Remove FTX from supported exchanges

### DIFF
--- a/components/features/details/Exchanges.vue
+++ b/components/features/details/Exchanges.vue
@@ -35,7 +35,6 @@ export default defineComponent({
     return {
       column1: ['Kraken', 'KuCoin', 'Binance', 'Binance US', 'Bittrex'],
       column2: [
-        'FTX',
         'Coinbase',
         'Coinbase Pro',
         'Gemini',

--- a/components/features/details/Exchanges.vue
+++ b/components/features/details/Exchanges.vue
@@ -34,12 +34,7 @@ export default defineComponent({
   setup() {
     return {
       column1: ['Kraken', 'KuCoin', 'Binance', 'Binance US', 'Bittrex'],
-      column2: [
-        'Coinbase',
-        'Coinbase Pro',
-        'Gemini',
-        'and many more...',
-      ],
+      column2: ['Coinbase', 'Coinbase Pro', 'Gemini', 'and many more...'],
     }
   },
 })


### PR DESCRIPTION
Took a look at the website recently when recommending Rotki and this jumped out at me. I think it's probably a good idea to go ahead and remove, especially with the API being down, likely permanently.

Keep up the great work!