### PR TITLE
Replace startup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,24 @@ Make sure the environment file exists
 $ touch .env
 ```
 
+To avoid api call loop, which freezes the app, do not set the variable to `/`
+
+```dotenv
+NUXT_PUBLIC_BASE_URL=http://localhost:3000
+```
+
 And input the RECAPTCHA public key there.
 
-```
+```dotenv
 NUXT_PUBLIC_RECAPTCHA_SITE_KEY=XXXX
 ```
 
-You can get a testing key from [developers google](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do).
+You can get a testing key
+from [developers google](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do).
 
 if you are running behind https make sure to also add:
-```
+
+```dotenv
 NUXT_PUBLIC_BASE_URL=https://localhost
 NODE_TLS_REJECT_UNAUTHORIZED=0
 ```
@@ -41,11 +49,21 @@ Run with
 $ pnpm run dev
 ```
 
-
 ## Lint
 
 To fix any lint errors you have to run
 
 ```bash
 pnpm lint:js --fix
+```
+
+## Tests
+
+to run vitest
+
+```bash
+pnpm test
+
+# run watch mode
+pnpm test:watch
 ```

--- a/components/account/home/AccountOverview.vue
+++ b/components/account/home/AccountOverview.vue
@@ -14,8 +14,6 @@ const username = computed(() => {
   return get(account)?.username;
 });
 
-onMounted(async () => await store.getAccount());
-
 const logout = async () => {
   await store.logout(true);
   await navigateTo('/login');
@@ -28,7 +26,7 @@ const css = useCssModule();
   <PageContainer wide>
     <template #title> Account Management</template>
     <template #links>
-      <LinkText>
+      <LinkText class="cursor-pointer">
         <span @click="logout">Logout</span>
       </LinkText>
     </template>

--- a/middleware/authenticated.ts
+++ b/middleware/authenticated.ts
@@ -5,6 +5,6 @@ export default defineNuxtRouteMiddleware(() => {
   const { account } = storeToRefs(useMainStore());
 
   if (isDefined(account)) {
-    navigateTo('/home');
+    return navigateTo('/home');
   }
 });

--- a/middleware/maintenance.ts
+++ b/middleware/maintenance.ts
@@ -1,6 +1,6 @@
 export default defineNuxtRouteMiddleware(() => {
   const config = useRuntimeConfig();
-  if (config.public.maintenance !== 'false') {
+  if (config.public.maintenance) {
     return navigateTo('/maintenance');
   }
 });

--- a/middleware/pending-payment.ts
+++ b/middleware/pending-payment.ts
@@ -25,7 +25,7 @@ export default defineNuxtRouteMiddleware(async () => {
     }
 
     if (response.result?.transactionStarted) {
-      navigateTo('/home');
+      return navigateTo('/home');
     } else if (response.result.pending) {
       const queryParams: { p: string; c: string; id?: string } = {
         p: durationInMonths.toString(),
@@ -34,7 +34,7 @@ export default defineNuxtRouteMiddleware(async () => {
       if (id) {
         queryParams.id = id;
       }
-      navigateTo({
+      return navigateTo({
         path: '/checkout/pay/crypto',
         query: queryParams,
       });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -124,8 +124,8 @@ export default defineNuxtConfig({
         siteKey: '',
       },
       baseUrl: '',
-      maintenance: 'false',
-      testing: 'false',
+      maintenance: false,
+      testing: false,
     },
   },
 

--- a/plugins/startup.ts
+++ b/plugins/startup.ts
@@ -1,0 +1,17 @@
+import { useMainStore } from '~/store';
+import { SESSION_COOKIE } from '~/utils/api';
+
+export default defineNuxtPlugin(async () => {
+  const { name } = useRoute();
+  if (name === 'health') {
+    return;
+  }
+
+  const sessionId = useCookie(SESSION_COOKIE).value;
+
+  if (sessionId) {
+    const { getAccount } = useMainStore();
+
+    return await getAccount();
+  }
+});

--- a/store/index.ts
+++ b/store/index.ts
@@ -218,6 +218,7 @@ export const useMainStore = defineStore('main', () => {
     );
     const sub = subscriptions[subIndex];
     const { actions, status, nextActionDate } = sub;
+
     function updateSub(
       actions: string[],
       status: SubStatus,

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -63,6 +63,7 @@ export const convertKeys = (
 };
 
 const CSRF_COOKIE = 'csrftoken';
+export const SESSION_COOKIE = 'sessionid';
 const CSRF_HEADER = 'X-CSRFToken';
 
 const logout = ref<() => Promise<void>>();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineVitestConfig({
     globals: true,
     environment: 'nuxt',
     env: {
-      BASE_URL: process.env.BASE_URL || 'http://localhost:3000',
-      BACKEND_URL: process.env.BACKEND_URL || 'https://rotki.com',
+      BASE_URL: process.env.NUXT_PUBLIC_BASE_URL || 'http://localhost:3000',
+      BACKEND_URL: process.env.NUXT_PUBLIC_BACKEND_URL || 'https://rotki.com',
       NODE_ENV: 'test',
     },
     setupFiles: ['./tests/setup.ts'],


### PR DESCRIPTION
Closes #61 

- [x] Navigating to the account management on an active session should not take you to the login page
- [x] Pages that behave differently for logged in users should auto-load the account data on their first load if a user session is already active.