### PR TITLE
add error renderer page, so it renders like every other page

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,47 @@
+<script lang="ts" setup>
+import { get } from '@vueuse/core';
+import { commonAttrs, noIndex } from '~/utils/metadata';
+
+const error = useError();
+const { t } = useI18n();
+const css = useCssModule();
+
+const pageTitle = computed(() => get(error)?.message);
+const title = computed(() => `${get(pageTitle)} | rotki`);
+
+const handleError = () => clearError({ redirect: '/' });
+
+useHead(() => ({
+  title,
+  meta: [noIndex()],
+  ...commonAttrs(),
+}));
+</script>
+
+<template>
+  <PageContainer>
+    <div v-if="error" :class="css.wrapper">
+      <h1 :class="css.title">{{ error.statusCode }}</h1>
+      <p :class="css.subtitle">{{ pageTitle }}</p>
+      <ActionButton
+        :text="t('actions.go_back_home')"
+        primary
+        small
+        @click="handleError"
+      />
+    </div>
+  </PageContainer>
+</template>
+
+<style module lang="scss">
+.wrapper {
+  @apply text-center my-24;
+}
+.title {
+  @apply block font-serif text-red-500 font-bold text-6xl;
+}
+
+.subtitle {
+  @apply block font-sans font-light text-primary2 my-8 text-3xl;
+}
+</style>

--- a/locales/en.json
+++ b/locales/en.json
@@ -4,7 +4,8 @@
     "get_premium": "Get Premium",
     "get_premium_plan": "Get Premium Plan",
     "get_advanced_plan": "Get Advanced Plan",
-    "get_in_touch": "Get In Touch Now"
+    "get_in_touch": "Get In Touch Now",
+    "go_back_home": "Go back home"
   },
   "supported_defi": {
     "title": "Dedicated DeFi support for",


### PR DESCRIPTION
Closes #77 

- [x] adds error component to render errors while maintaining the app's look and feel.