### PR TITLE
Make payment provider error more obvious

### DIFF
--- a/components/common/status/BaseDisplay.vue
+++ b/components/common/status/BaseDisplay.vue
@@ -74,18 +74,12 @@ const css = useCssModule();
 }
 
 .title {
-  @apply font-sans font-bold flex flex-row justify-center;
+  @apply font-sans font-bold flex flex-row justify-center mb-4 text-2xl leading-7;
 
-  line-height: 29px;
-  font-size: 24px;
   letter-spacing: 0;
-  margin-bottom: 16px;
 }
 
 .message {
-  @apply font-sans break-words;
-
-  font-size: 14px;
-  line-height: 20px;
+  @apply font-sans break-words leading-5 text-lg font-medium;
 }
 </style>


### PR DESCRIPTION
Closes #73 

- [x] increase font size and weight for error/success/warning message display component