### PR TITLE
fix: bug for auth pages

### DIFF
--- a/components/account/signup/SignupAddress.vue
+++ b/components/account/signup/SignupAddress.vue
@@ -137,7 +137,7 @@ const { t } = useI18n();
         autocomplete="address-line2"
         dense
         :label="t('auth.signup.address.form.address_line_2')"
-        :hint="t('auth.common.required')"
+        :hint="t('auth.common.optional')"
         :error-messages="toMessages(v$.address2)"
         @update:model-value="updateValue('address2', $event)"
         @blur="v$.address2.$touch()"

--- a/components/common/ButtonLink.vue
+++ b/components/common/ButtonLink.vue
@@ -49,6 +49,7 @@ const getColor = (active: boolean, exact: boolean) => {
     <RuiButton
       v-bind="{
         variant: 'text',
+        type: 'button',
         color: getColor(link?.isActive, link?.isExactActive),
         ...attrs,
       }"

--- a/locales/en.json
+++ b/locales/en.json
@@ -21,6 +21,7 @@
         "line_3": "Your password can't be a commonly used password.",
         "line_4": "Your password can't be entirely numeric."
       },
+      "optional": "Optional.",
       "required": "Required."
     },
     "login": {


### PR DESCRIPTION
Fix these
- [x] clicking enter when entering username/password triggers the forgot password instead of the continue button 
- [x] Address line 2 field hint should be optional