### PR TITLE
fix: change localhost to loopback in healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ EXPOSE ${NITRO_PORT}
 
 CMD ["pm2-runtime", "ecosystem.config.cjs"]
 HEALTHCHECK --start-period=30s --retries=2 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:${NITRO_PORT}/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${NITRO_PORT}/health || exit 1


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

localhost results in connection refused on docker 26