### PR TITLE
fix: refresh supply and invalidate cache when minting failed

### DIFF
--- a/composables/rotki-sponsorship/metadata-ssr.ts
+++ b/composables/rotki-sponsorship/metadata-ssr.ts
@@ -6,7 +6,6 @@ const logger = useLogger('rotki-sponsorship-metadata-ssr');
 interface TierInfoResponse {
   tiers: Record<number, TierInfoResult | undefined>;
   releaseId: number | undefined;
-  cached: boolean;
 }
 
 /**

--- a/composables/rotki-sponsorship/metadata-ssr.ts
+++ b/composables/rotki-sponsorship/metadata-ssr.ts
@@ -54,7 +54,7 @@ export async function loadNFTImagesAndSupplySSR(tiers: { key: string; tierId: nu
 
     // Add timestamp to force cache bypass when needed
     if (forceRefresh) {
-      params._t = Date.now().toString();
+      params.skipCache = 'true';
     }
 
     const response = await $fetch<TierInfoResponse>('/api/nft/tier-info', {

--- a/pages/sponsor/mint.vue
+++ b/pages/sponsor/mint.vue
@@ -84,7 +84,7 @@ const {
   isLoadingPaymentTokens,
 } = useRotkiSponsorshipPayment();
 
-const { data: sponsorshipData, pending: isLoading } = await useSponsorshipData();
+const { data: sponsorshipData, pending: isLoading, refresh: refreshSponsorshipData } = await useSponsorshipData();
 
 const nftImages = computed(() => get(sponsorshipData)?.nftImages || {});
 const tierSupply = computed(() => get(sponsorshipData)?.tierSupply || {});
@@ -132,6 +132,7 @@ async function handleMint() {
   }
   catch (error) {
     logger.error('Minting failed:', error);
+    await refreshSponsorshipData();
   }
 }
 

--- a/server/api/nft/[token-id].get.ts
+++ b/server/api/nft/[token-id].get.ts
@@ -155,7 +155,7 @@ export default defineEventHandler(async (event): Promise<TokenMetadata> => {
 
     // Check for cache busting parameter
     const query = getQuery(event);
-    const skipCache = !!query._t;
+    const { skipCache } = query;
 
     if (skipCache) {
       // Clear the cache for this specific token

--- a/server/api/nft/[token-id].get.ts
+++ b/server/api/nft/[token-id].get.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { findTierById, normalizeIpfsUrl } from '~/composables/rotki-sponsorship/utils';
 import { CACHE_TTL } from '~/server/utils/cache';
 import { createNftTokenCacheKey } from '~/server/utils/cache-keys';
-import { createCachedFunction } from '~/server/utils/cached-function';
+import { clearCachedFunction, createCachedFunction } from '~/server/utils/cached-function';
 import { handleApiError } from '~/server/utils/errors';
 import { createContract, createProvider, getServerNftConfig } from '~/server/utils/nft-config';
 import { deduplicatedFetch } from '~/server/utils/request-dedup';
@@ -56,7 +56,7 @@ const fetchMetadata = createCachedFunction(async (metadataURI: string): Promise<
 });
 
 // Fetch token data from contract
-async function fetchTokenDataDirect(tokenId: number, config: NftConfig): Promise<TokenMetadata | null> {
+async function fetchTokenData(tokenId: number, config: NftConfig): Promise<TokenMetadata | null> {
   try {
     const provider = createProvider(config.RPC_URL);
     const contract = createContract(provider, config.CONTRACT_ADDRESS);
@@ -134,12 +134,15 @@ async function fetchTokenDataDirect(tokenId: number, config: NftConfig): Promise
   }
 }
 
-// Cached version of token data fetching
-const fetchTokenData = createCachedFunction(fetchTokenDataDirect, {
+// Cache options for token data
+const tokenDataCacheOptions = {
   getKey: (tokenId: number, config: NftConfig) => createNftTokenCacheKey(config.CONTRACT_ADDRESS, tokenId),
   maxAge: CACHE_TTL.TIER_DATA,
-  name: 'fetchTokenData',
-});
+  name: 'fetchCachedTokenData',
+};
+
+// Cached version of token data fetching
+const fetchCachedTokenData = createCachedFunction(fetchTokenData, tokenDataCacheOptions);
 
 export default defineEventHandler(async (event): Promise<TokenMetadata> => {
   try {
@@ -154,10 +157,12 @@ export default defineEventHandler(async (event): Promise<TokenMetadata> => {
     const query = getQuery(event);
     const skipCache = !!query._t;
 
-    // Fetch token data
-    const tokenData = skipCache
-      ? await fetchTokenDataDirect(tokenId, config)
-      : await fetchTokenData(tokenId, config);
+    if (skipCache) {
+      // Clear the cache for this specific token
+      await clearCachedFunction(tokenDataCacheOptions, tokenId, config);
+    }
+
+    const tokenData = await fetchCachedTokenData(tokenId, config);
 
     if (!tokenData) {
       throw createError({

--- a/server/api/nft/image.get.ts
+++ b/server/api/nft/image.get.ts
@@ -12,7 +12,7 @@ const logger = useLogger('nft-image-proxy');
 
 // Request validation schema
 const querySchema = z.object({
-  _invalidate: z.string().optional(), // Force cache invalidation
+  skipCache: z.string().optional(), // Force cache invalidation
   url: z.string().url().refine(
     url =>
       // Only allow IPFS URLs
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event) => {
   try {
     // Validate query parameters
     const query = await getValidatedQuery(event, data => querySchema.parse(data));
-    const { _invalidate, url } = query;
+    const { skipCache, url } = query;
 
     // Normalize the URL
     const normalizedUrl = normalizeIpfsUrl(url);
@@ -36,7 +36,7 @@ export default defineEventHandler(async (event) => {
     const cacheKey = createImageCacheKey(url);
 
     // Check for cache invalidation request
-    if (_invalidate) {
+    if (skipCache) {
       await invalidateImageCache(cacheKey);
       logger.info(`Cache invalidated for: ${url}`);
     }
@@ -51,7 +51,7 @@ export default defineEventHandler(async (event) => {
     }
 
     logger.debug(`Processing image request: ${normalizedUrl}`, {
-      invalidate: !!_invalidate,
+      invalidate: !!skipCache,
     });
 
     // Use request deduplication to prevent multiple concurrent fetches

--- a/server/api/nft/tier-info.get.ts
+++ b/server/api/nft/tier-info.get.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { normalizeIpfsUrl } from '~/composables/rotki-sponsorship/utils';
 import { CACHE_TTL } from '~/server/utils/cache';
 import { createMetadataCacheKey, createNftCurrentReleaseIdKey, createTierCacheKey } from '~/server/utils/cache-keys';
-import { createCachedFunction } from '~/server/utils/cached-function';
+import { clearCachedFunction, createCachedFunction } from '~/server/utils/cached-function';
 import { handleApiError } from '~/server/utils/errors';
 import { Multicall } from '~/server/utils/multicall';
 import { createContract, createProvider, getContractInterface, getServerNftConfig } from '~/server/utils/nft-config';
@@ -22,6 +22,13 @@ const querySchema = z.object({
     return val.split(',').map(id => parseInt(id, 10)).filter(id => !isNaN(id));
   }),
 });
+
+// Cache options for metadata
+const metadataCacheOptions = {
+  getKey: (metadataURI: string) => createMetadataCacheKey(metadataURI),
+  maxAge: CACHE_TTL.METADATA,
+  name: 'fetchMetadata',
+};
 
 // Fetch metadata with caching and deduplication
 const fetchMetadata = createCachedFunction(async (metadataURI: string): Promise<TierMetadata> => {
@@ -45,11 +52,14 @@ const fetchMetadata = createCachedFunction(async (metadataURI: string): Promise<
 
     return response.json();
   });
-}, {
-  getKey: (metadataURI: string) => createMetadataCacheKey(metadataURI),
-  maxAge: CACHE_TTL.METADATA,
-  name: 'fetchMetadata',
-});
+}, metadataCacheOptions);
+
+// Cache options for release ID
+const releaseIdCacheOptions = {
+  getKey: (config: NftConfig) => createNftCurrentReleaseIdKey(config.CONTRACT_ADDRESS),
+  maxAge: CACHE_TTL.RELEASE_ID,
+  name: 'getCurrentReleaseId',
+};
 
 // Get current release ID with caching
 const getCurrentReleaseId = createCachedFunction(async (config: NftConfig): Promise<number> => deduplicatedFetch(`releaseId:${config.CONTRACT_ADDRESS}`, async () => {
@@ -57,14 +67,10 @@ const getCurrentReleaseId = createCachedFunction(async (config: NftConfig): Prom
   const contract = createContract(provider, config.CONTRACT_ADDRESS);
   const releaseId = await contract.currentReleaseId();
   return Number(releaseId);
-}), {
-  getKey: config => createNftCurrentReleaseIdKey(config.CONTRACT_ADDRESS),
-  maxAge: CACHE_TTL.RELEASE_ID,
-  name: 'getCurrentReleaseId',
-});
+}), releaseIdCacheOptions);
 
 // Non-cached version of tier info fetching
-async function fetchSingleTierInfoDirect(tierId: number, releaseId: number, config: NftConfig): Promise<TierInfoResult | undefined> {
+async function fetchSingleTierInfo(tierId: number, releaseId: number, config: NftConfig): Promise<TierInfoResult | undefined> {
   try {
     const provider = createProvider(config.RPC_URL);
     const contract = createContract(provider, config.CONTRACT_ADDRESS);
@@ -118,12 +124,15 @@ async function fetchSingleTierInfoDirect(tierId: number, releaseId: number, conf
   }
 }
 
-// Cached version of tier info fetching
-const fetchSingleTierInfo = createCachedFunction(fetchSingleTierInfoDirect, {
+// Cache options for tier info
+const tierInfoCacheOptions = {
   getKey: (tierId: number, releaseId: number, config: NftConfig) => createTierCacheKey(config.CONTRACT_ADDRESS, releaseId, tierId),
   maxAge: CACHE_TTL.TIER_DATA,
-  name: 'fetchSingleTierInfo',
-});
+  name: 'fetchCachedSingleTierInfo',
+};
+
+// Cached version of tier info fetching
+const fetchCachedSingleTierInfo = createCachedFunction(fetchSingleTierInfo, tierInfoCacheOptions);
 
 // Batch fetch tier info using multicall
 async function fetchTierInfoBatch(tierIds: number[], releaseId: number, config: NftConfig, skipCache = false): Promise<Record<number, TierInfoResult | undefined>> {
@@ -133,13 +142,14 @@ async function fetchTierInfoBatch(tierIds: number[], releaseId: number, config: 
   const uncachedTierIds: number[] = [];
   const cachePromises = tierIds.map(async (tierId) => {
     if (skipCache) {
-      // Skip cache when force refreshing
+      // Clear cache for this tier when force refreshing
+      await clearCachedFunction(tierInfoCacheOptions, tierId, releaseId, config);
       uncachedTierIds.push(tierId);
     }
     else {
       // Try to get from cache using the cached function
       try {
-        const cached = await fetchSingleTierInfo(tierId, releaseId, config);
+        const cached = await fetchCachedSingleTierInfo(tierId, releaseId, config);
         if (cached !== undefined) {
           results[tierId] = cached;
         }
@@ -233,10 +243,8 @@ async function fetchTierInfoBatch(tierIds: number[], releaseId: number, config: 
 
             results[tierId] = tierInfo;
 
-            // Cache the result if not skipping cache
-            if (!skipCache) {
-              await fetchSingleTierInfo(tierId, releaseId, config);
-            }
+            // Cache the result using the cached function (it will update the cache)
+            await fetchCachedSingleTierInfo(tierId, releaseId, config);
           }).catch((error) => {
             logger.error(`Failed to fetch metadata for tier ${tierId}:`, error);
             results[tierId] = undefined;
@@ -257,7 +265,7 @@ async function fetchTierInfoBatch(tierIds: number[], releaseId: number, config: 
     // Fallback to individual fetches if multicall fails
     for (const tierId of uncachedTierIds) {
       try {
-        results[tierId] = await fetchSingleTierInfoDirect(tierId, releaseId, config);
+        results[tierId] = await fetchSingleTierInfo(tierId, releaseId, config);
       }
       catch (error) {
         logger.error(`Failed to fetch tier ${tierId}:`, error);
@@ -287,7 +295,12 @@ export default defineEventHandler(async (event) => {
     // Get config once at the beginning of the request
     const config = await getServerNftConfig();
 
-    // Get current release ID
+    // Clear release ID cache if cache busting
+    if (_t) {
+      await clearCachedFunction(releaseIdCacheOptions, config);
+    }
+
+    // Get current release ID (will fetch fresh if cache was cleared)
     const releaseId = await getCurrentReleaseId(config);
     logger.info(`Current release ID: ${releaseId}`);
 
@@ -303,10 +316,12 @@ export default defineEventHandler(async (event) => {
     else {
       // Single tier fetch
       const tierPromises = tierIds.map(async (tierId) => {
-        // Use direct fetch when cache busting, otherwise use cached version
-        const data = _t
-          ? await fetchSingleTierInfoDirect(tierId, releaseId, config)
-          : await fetchSingleTierInfo(tierId, releaseId, config);
+        if (_t) {
+          // Clear cache when cache busting
+          await clearCachedFunction(tierInfoCacheOptions, tierId, releaseId, config);
+        }
+        // Always use cached version (will fetch fresh data if cache was cleared)
+        const data = await fetchCachedSingleTierInfo(tierId, releaseId, config);
         return { data, tierId };
       });
 

--- a/server/utils/cache-keys.ts
+++ b/server/utils/cache-keys.ts
@@ -22,7 +22,7 @@ export function normalizeUrl(url: string): string {
     // For HTTP(S) URLs
     // Sort query params and remove tracking params
     const params = new URLSearchParams(parsed.search);
-    const allowedParams = ['token', 'network', 'tierIds', '_t']; // whitelist approach
+    const allowedParams = ['token', 'network', 'tierIds', 'skipCache']; // whitelist approach
 
     const filtered = new URLSearchParams();
     const sortedKeys = Array.from(params.keys()).sort();

--- a/server/utils/cached-function.ts
+++ b/server/utils/cached-function.ts
@@ -28,3 +28,12 @@ export function createCachedFunction<T, ArgsT extends unknown[] = any[]>(
     return result;
   };
 }
+
+export async function clearCachedFunction<ArgsT extends unknown[] = any[]>(
+  opts: CacheOptions<ArgsT>,
+  ...args: ArgsT
+): Promise<void> {
+  const cache = getCacheService();
+  const key = opts.getKey(...args);
+  await cache.removeItem(key);
+}


### PR DESCRIPTION
- [x] refresh supply view when the minting is failed
- [x] when the endpoint called with `forceRefresh`, just invalidate the cache so it's updated