### PR TITLE
feat: use async subscription resuming

### DIFF
--- a/components/account/home/ResumeSubscriptionDialog.vue
+++ b/components/account/home/ResumeSubscriptionDialog.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import type { Subscription } from '~/types';
-import { get, set } from '@vueuse/core';
+import { get } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
 import { useMainStore } from '~/store';
 
 const modelValue = defineModel<Subscription | undefined>({ required: true });
+
+defineProps<{
+  loading: boolean;
+}>();
 
 const emit = defineEmits<{
   confirm: [val: Subscription];
@@ -14,29 +18,19 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { resumeError } = storeToRefs(useMainStore());
 
-const display = computed({
-  get() {
-    return !!get(modelValue);
-  },
-  set(value) {
-    if (!value)
-      set(modelValue, undefined);
-  },
-});
-
 async function resumeSubscription(): Promise<void> {
   if (!isDefined(modelValue))
     return;
 
   emit('confirm', get(modelValue));
-  set(modelValue, undefined);
 }
 </script>
 
 <template>
   <RuiDialog
-    v-model="display"
+    :model-value="!!modelValue && !loading"
     max-width="900"
+    @close="modelValue = undefined"
   >
     <RuiCard>
       <template #header>

--- a/components/account/home/ResumeSubscriptionDialog.vue
+++ b/components/account/home/ResumeSubscriptionDialog.vue
@@ -24,9 +24,10 @@ const display = computed({
   },
 });
 
-async function resumeSubscription() {
+async function resumeSubscription(): Promise<void> {
   if (!isDefined(modelValue))
     return;
+
   emit('confirm', get(modelValue));
   set(modelValue, undefined);
 }

--- a/composables/use-subscription.ts
+++ b/composables/use-subscription.ts
@@ -8,7 +8,7 @@ import { assert } from '~/utils/assert';
 
 interface UseSubscriptionReturn {
   cancelUserSubscription: (subscription: Subscription, onProgress?: (status: string) => void) => Promise<void>;
-  resumeUserSubscription: (identifier: string) => Promise<void>;
+  resumeUserSubscription: (identifier: string, onProgress?: (status: string) => void) => Promise<void>;
 }
 
 export function useSubscription(): UseSubscriptionReturn {
@@ -18,25 +18,57 @@ export function useSubscription(): UseSubscriptionReturn {
   const { fetchWithCsrf } = useFetchWithCsrf();
   const { pollTaskStatus } = useTaskPolling();
 
-  const resumeUserSubscription = async (identifier: string) => {
+  const resumeUserSubscription = async (identifier: string, onProgress?: (status: string) => void): Promise<void> => {
     const acc = get(account);
     assert(acc);
 
     try {
-      const response = await fetchWithCsrf<ActionResultResponse>(
+      // Step 1: Start the resume task
+      const taskResponse = await fetchWithCsrf<TaskResponse>(
         `/webapi/subscription/${identifier}/resume/`,
         {
           method: 'PATCH',
         },
       );
-      const data = ActionResultResponse.parse(response);
-      if (data.result)
-        await getAccount();
+
+      const { taskId } = TaskResponse.parse(taskResponse);
+
+      if (onProgress)
+        onProgress('pending');
+
+      // Step 2: Poll for task completion
+      const status = await pollTaskStatus(taskId, {
+        onProgress,
+      });
+
+      // Handle the final status
+      if (status.status === 'completed') {
+        if (status.result) {
+          await getAccount();
+        }
+        else {
+          throw new Error('Resume completed but result was false');
+        }
+      }
+      else if (status.status === 'failed') {
+        throw new Error(status.error || 'Resume task failed');
+      }
     }
     catch (error: any) {
+      // Clean up state on any error
+      if (onProgress)
+        onProgress('failed');
+
       let message = error.message;
-      if (error instanceof FetchError && error.status === 404)
-        message = ActionResultResponse.parse(error.data).message;
+      if (error instanceof FetchError) {
+        if (error.status === 404) {
+          message = ActionResultResponse.parse(error.data).message;
+        }
+        else if (error.status === 202) {
+          // This is expected for the initial call, shouldn't happen here
+          message = 'Unexpected response format';
+        }
+      }
 
       logger.error(error);
       set(resumeError, message);

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -113,6 +113,12 @@
         "notification": {
           "title": "Your subscription was successfully resumed."
         },
+        "status": {
+          "pending": "Resume request queued...",
+          "in_progress": "Processing resume...",
+          "completed": "Resume completed successfully",
+          "failed": "Resume failed"
+        },
         "title": "Resume your rotki subscription"
       },
       "resume_hint": "Resume the active billing of your subscription from {date}",


### PR DESCRIPTION
Use async for subscription resuming like we did for cancellation. Written mostly by claude.
