### PR TITLE
fix: error 500 after deploy

### DIFF
--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import process from 'node:process';
 import rotkiTheme from '@rotki/ui-library/theme';
 import {
@@ -13,6 +14,9 @@ import {
 import { removeNoncePlaceholders } from './utils/csp-utils';
 
 const sponsorshipEnabled = process.env.NUXT_PUBLIC_SPONSORSHIP_ENABLED === 'true';
+
+// Build identifier for unique chunk names per deployment
+const buildId = process.env.GIT_SHA?.slice(0, 8) || Date.now();
 
 const sponsorRoutes = [
   '/sponsor',
@@ -140,6 +144,19 @@ export default defineNuxtConfig({
     '@nuxt/image',
     'nuxt-security',
   ],
+
+  vite: {
+    build: {
+      rollupOptions: {
+        output: {
+          // Include build identifier to ensure unique filenames per deployment
+          // Format: _nuxt/chunkName-buildId-contentHash.js
+          chunkFileNames: `_nuxt/[name]-${buildId}.[hash].js`,
+          entryFileNames: `_nuxt/[name]-${buildId}.[hash].js`,
+        },
+      },
+    },
+  },
 
   nitro: {
     devProxy: {


### PR DESCRIPTION
fix this issue:
<img width="3454" height="1724" alt="image" src="https://github.com/user-attachments/assets/32177855-d242-4865-a73f-fdc7fff21e8d" />


```
Failed to find a valid digest in the 'integrity' attribute for resource 'http://localhost:3000/_nuxt/AppShowcaseSlider.mA3x01I4.js' with computed SHA-384 integrity 'rFTgOUYBzqyYEPFqsutjcVsOgtrSdiMusF4xNlicTrfTK/D9uaajP9e5gk8Qc6JJ'. The resource has been blocked.
```