### PR TITLE
chore: bump UI library to 2.8.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 5.2.8
       version: 5.2.8
     '@rotki/ui-library':
-      specifier: 2.8.0
-      version: 2.8.0
+      specifier: 2.8.1
+      version: 2.8.1
     '@tsconfig/node22':
       specifier: 22.0.2
       version: 22.0.2
@@ -149,7 +149,7 @@ importers:
     devDependencies:
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.8.0(@vueuse/core@13.9.0(vue@3.5.22(typescript@5.9.3)))(@vueuse/shared@13.9.0(vue@3.5.22(typescript@5.9.3)))(dayjs@1.11.13)(vue@3.5.22(typescript@5.9.3))
+        version: 2.8.1(@vueuse/core@13.9.0(vue@3.5.22(typescript@5.9.3)))(@vueuse/shared@13.9.0(vue@3.5.22(typescript@5.9.3)))(dayjs@1.11.13)(vue@3.5.22(typescript@5.9.3))
       '@tsconfig/node22':
         specifier: 'catalog:'
         version: 22.0.2
@@ -301,7 +301,7 @@ importers:
         version: 7.4.7(h3@1.15.4)(magicast@0.3.5)(vite@7.1.11(@types/node@24.3.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.43.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.8.0(@vueuse/core@13.9.0(vue@3.5.22(typescript@5.9.3)))(@vueuse/shared@13.9.0(vue@3.5.22(typescript@5.9.3)))(dayjs@1.11.13)(vue@3.5.22(typescript@5.9.3))
+        version: 2.8.1(@vueuse/core@13.9.0(vue@3.5.22(typescript@5.9.3)))(@vueuse/shared@13.9.0(vue@3.5.22(typescript@5.9.3)))(dayjs@1.11.13)(vue@3.5.22(typescript@5.9.3))
       '@types/braintree-web':
         specifier: 'catalog:'
         version: 3.96.17
@@ -2326,8 +2326,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0
 
-  '@rotki/ui-library@2.8.0':
-    resolution: {integrity: sha512-hSA2cWo6EOZaCTMPK+KIJ1wFy8XPQXuNAaq4W2VVn3DzhZcEqKhsSWm42rgnvtN5JYQ7MCzNgciJZ6K3Xw3VPw==}
+  '@rotki/ui-library@2.8.1':
+    resolution: {integrity: sha512-cbTcaLm4eqifmO3qAI2ByYT1hLe53iZlKhJK5WiFSAs5YZ1PNxvdbUDtHzOu3FrEBaS7D4IQTd8ciKKhdb/ieQ==}
     engines: {node: '>=22 <23', pnpm: '>=10 <11'}
     peerDependencies:
       '@vueuse/core': '>13.0.0'
@@ -11015,7 +11015,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.8.0(@vueuse/core@13.9.0(vue@3.5.22(typescript@5.9.3)))(@vueuse/shared@13.9.0(vue@3.5.22(typescript@5.9.3)))(dayjs@1.11.13)(vue@3.5.22(typescript@5.9.3))':
+  '@rotki/ui-library@2.8.1(@vueuse/core@13.9.0(vue@3.5.22(typescript@5.9.3)))(@vueuse/shared@13.9.0(vue@3.5.22(typescript@5.9.3)))(dayjs@1.11.13)(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.22(typescript@5.9.3))
       '@vueuse/shared': 13.9.0(vue@3.5.22(typescript@5.9.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 
 catalog:
   '@fontsource/roboto': 5.2.8
-  '@rotki/ui-library': 2.8.0
+  '@rotki/ui-library': 2.8.1
   '@types/braintree-web': 3.96.17
   '@types/node': 22.18.12
   '@tsconfig/node22': 22.0.2


### PR DESCRIPTION
Closes #(issue_number)

## Checklist
