### PR TITLE
fix: verify for finalAmount instead of fullAmount

### DIFF
--- a/packages/website/composables/use-three-d-secure.ts
+++ b/packages/website/composables/use-three-d-secure.ts
@@ -154,7 +154,7 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
       threeDSecureInstance.on('authentication-iframe-available', iframeHandler);
 
       const options: ThreeDSecureVerifyOptions = {
-        amount: params.amount,
+        amount: params.finalAmount,
         bin: params.bin,
         challengeRequested: true,
         nonce: params.nonce,


### PR DESCRIPTION
While the documentation and support of braintree note that when verifying the fullAmount should be used, bank UIs always use wording implying that this amount will be charged leading to user confusion.

Closes #(issue_number)

## Checklist
