### PR TITLE
fix(navigation): disable pre-render for home route to fix sponsor menu

### DIFF
--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -294,7 +294,7 @@ export default defineNuxtConfig({
 
   routeRules: {
     '/': {
-      prerender: true,
+      prerender: false,
     },
     // Redirect /pricing to /checkout/pay
     '/pricing': { redirect: { to: '/checkout/pay', statusCode: 301 } },


### PR DESCRIPTION
Pre-rendered pages bake runtime config values into the HTML at build time. This means NUXT_PUBLIC_* environment variables set at runtime are not reflected in the client-side hydration payload.

The sponsor menu visibility depends on the NUXT_PUBLIC_SPONSORSHIP_ENABLED env var being read at runtime. With pre-rendering, the client always received the build-time value (false), even when the server had the correct runtime value.

Disabling pre-render for the home route ensures the runtime config is fresh on each request, allowing the sponsor menu to appear when the environment variable is set.

Closes #(issue_number)

## Checklist
