### PR TITLE
feat: add upgrade nudge block to download page

### DIFF
--- a/packages/website/app/components/download/DownloadHeading.vue
+++ b/packages/website/app/components/download/DownloadHeading.vue
@@ -67,7 +67,7 @@ const highlightedDownloadItem = computed<DownloadItemSingle[]>(() => {
 </script>
 
 <template>
-  <div class="py-10 lg:py-20">
+  <div class="pt-6 pb-10 lg:pt-10 lg:pb-20">
     <div class="container flex flex-col">
       <div class="flex flex-col items-start gap-y-4">
         <h6 class="text-rui-light-primary text-h6 font-medium">

--- a/packages/website/app/components/download/DownloadUpgradeNudge.vue
+++ b/packages/website/app/components/download/DownloadUpgradeNudge.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import ButtonLink from '~/components/common/ButtonLink.vue';
+import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
+
+const { t } = useI18n({ useScope: 'global' });
+const { chronicle } = useSigilEvents();
+</script>
+
+<template>
+  <div class="bg-rui-primary/[0.06] py-6 lg:py-8">
+    <div class="container">
+      <div class="flex flex-col lg:flex-row lg:items-center gap-6 lg:gap-12">
+        <div class="flex-1">
+          <h4 class="text-rui-light-primary text-h6 font-medium mb-3">
+            {{ t('download.upgrade_nudge.title') }}
+          </h4>
+          <ul class="text-rui-text-secondary text-body-1 space-y-2">
+            <li class="flex items-start gap-2">
+              <span class="text-rui-success">✓</span>
+              <span>{{ t('download.upgrade_nudge.bullet_1') }}</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="text-rui-success">✓</span>
+              <span>{{ t('download.upgrade_nudge.bullet_2') }}</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="text-rui-success">✓</span>
+              <span>{{ t('download.upgrade_nudge.bullet_3') }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="flex flex-col items-start lg:items-end gap-3">
+          <div class="flex flex-wrap gap-3">
+            <ButtonLink
+              to="/checkout/pay"
+              color="primary"
+              variant="default"
+              data-cy="see-plans-button"
+              @click="chronicle('download_see_plans_click', { source: 'download_page_nudge' })"
+            >
+              {{ t('download.upgrade_nudge.see_plans') }}
+            </ButtonLink>
+            <ButtonLink
+              to="/products"
+              color="primary"
+              variant="outlined"
+              data-cy="what-do-i-get-button"
+            >
+              {{ t('download.upgrade_nudge.what_do_i_get') }}
+            </ButtonLink>
+          </div>
+          <p class="text-rui-text-secondary text-body-2">
+            {{ t('download.upgrade_nudge.tagline') }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/website/app/composables/chronicling/use-sigil-events.ts
+++ b/packages/website/app/composables/chronicling/use-sigil-events.ts
@@ -43,10 +43,15 @@ export interface PurchaseSuccessData {
   discount?: 'referral' | 'discount';
 }
 
+export interface DownloadSeePlansClickData {
+  source: 'download_page_nudge';
+}
+
 export interface SigilEventMap {
   checkout_error: CheckoutErrorData;
   checkout_method_selected: CheckoutMethodSelectedData;
   checkout_start: CheckoutStartData;
+  download_see_plans_click: DownloadSeePlansClickData;
   pricing_view: PricingViewData;
   purchase_success: PurchaseSuccessData;
 }

--- a/packages/website/app/pages/download.vue
+++ b/packages/website/app/pages/download.vue
@@ -4,6 +4,7 @@ import { get } from '@vueuse/core';
 import DownloadDocs from '~/components/download/DownloadDocs.vue';
 import DownloadHeading from '~/components/download/DownloadHeading.vue';
 import DownloadPreview from '~/components/download/DownloadPreview.vue';
+import DownloadUpgradeNudge from '~/components/download/DownloadUpgradeNudge.vue';
 import { useAppDownload } from '~/composables/use-app-download';
 import { commonAttrs, getMetadata } from '~/utils/metadata';
 
@@ -43,6 +44,7 @@ definePageMeta({
 </script>
 
 <template>
+  <DownloadUpgradeNudge />
   <DownloadHeading
     :links="links"
     :version="version"

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -459,6 +459,15 @@
   },
   "download": {
     "action": "Download",
+    "upgrade_nudge": {
+      "title": "When should you upgrade?",
+      "bullet_1": "You track multiple wallets/exchanges and want higher limits",
+      "bullet_2": "You want detailed staking insights and reward tracking",
+      "bullet_3": "You want advanced analytics and deeper historical insights",
+      "see_plans": "See plans",
+      "what_do_i_get": "What do I get?",
+      "tagline": "Start free anytime, upgrade when you hit these needs."
+    },
     "documentation": {
       "action": "View all documentation",
       "description": "On our documentation page you have a user guide that will help you introduce yourself and clarify any doubts that may arise during the process.",


### PR DESCRIPTION
## Summary
- Adds a "When should you upgrade?" block at the top of `/download` to surface paid plans to high-intent traffic
- Adjusts spacing on download heading for better visual flow

## Test plan
- [x] Visit `/download` and verify nudge is visible without scrolling
- [x] Click "See plans" → `/checkout/pay`
- [x] Click "What do I get?" → `/products`