### PR TITLE
feat: add VAT warning to checkout pages

### DIFF
--- a/packages/card-payment-common/src/schemas/account.ts
+++ b/packages/card-payment-common/src/schemas/account.ts
@@ -5,6 +5,13 @@ import { z } from 'zod';
  * These schemas represent the common data structures used across both applications
  */
 
+export enum VatIdStatus {
+  NOT_CHECKED = 'Not checked',
+  VALID = 'Valid',
+  NOT_VALID = 'Not valid',
+  NON_EU_ID = 'ID outside the EU',
+}
+
 // Comprehensive address schema that supports both package needs
 export const AddressSchema = z.object({
   address1: z.string(),

--- a/packages/card-payment/src/App.vue
+++ b/packages/card-payment/src/App.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Account } from '@rotki/card-payment-common/schemas/account';
 import type { SavedCard } from '@rotki/card-payment-common/schemas/payment';
 import type { PaymentBreakdownResponse, SelectedPlan } from '@rotki/card-payment-common/schemas/plans';
 import { useHead } from '@unhead/vue';
@@ -70,6 +71,7 @@ const selectedPlan = ref<SelectedPlan>();
 const selectedCard = ref<SavedCard>();
 
 const cards = ref<SavedCard[]>([]);
+const accountData = ref<Account>();
 
 const steps = [{
   title: 'Plan Selection',
@@ -117,11 +119,12 @@ async function load() {
     // Check user authentication
     set(loadingMessage, 'Checking authentication...');
 
-    const canBuy = await canBuyNewSubscription();
+    const { canBuy, account } = await canBuyNewSubscription();
     const upgradeId = getUrlParam('upgradeSubId');
     const refParam = getUrlParam('ref');
     set(upgradeSubId, upgradeId);
     set(referralCode, refParam);
+    set(accountData, account);
 
     if (!canBuy && !upgradeId) {
       navigation.goToSubscription();
@@ -224,6 +227,8 @@ onMounted(async () => {
         :plan-data="planData"
         :selected-plan="selectedPlan"
         :upgrade-sub-id="upgradeSubId"
+        :vat-id-status="accountData?.vatIdStatus"
+        :country="accountData?.address.country"
         @payment-success="navigation.goTo3DSecure(upgradeSubId)"
         @go-back="back()"
         @refresh-card="refreshCard()"

--- a/packages/card-payment/src/utils/navigation-guard.ts
+++ b/packages/card-payment/src/utils/navigation-guard.ts
@@ -1,24 +1,25 @@
+import type { Account } from '@rotki/card-payment-common/schemas/account';
 import { getAccount } from '@/utils/api';
 
-export async function canBuyNewSubscription(): Promise<boolean> {
+export async function canBuyNewSubscription(): Promise<{ canBuy: boolean; account?: Account }> {
   const account = await getAccount();
 
   if (!account) {
     console.warn('User not authenticated, redirecting to subscription page');
-    return false;
+    return { canBuy: false };
   }
 
   if (!account.emailConfirmed) {
     console.warn('User email not confirmed, redirecting to subscription page');
-    return false;
+    return { canBuy: false };
   }
 
   // Card payments are only for new subscriptions, not renewals
   // Users with active subscriptions should use crypto payments for renewals
   if (account.hasActiveSubscription) {
     console.warn('User has active subscription, card payment not available - use crypto for renewals');
-    return false;
+    return { canBuy: false };
   }
 
-  return true;
+  return { canBuy: true, account };
 }

--- a/packages/website/app/types/account.ts
+++ b/packages/website/app/types/account.ts
@@ -1,6 +1,8 @@
 import { DiscountType } from '@rotki/card-payment-common/schemas/discount';
 import { z } from 'zod';
 
+export { VatIdStatus } from '@rotki/card-payment-common/schemas/account';
+
 export interface PasswordChangePayload {
   readonly currentPassword: string;
   readonly newPassword: string;
@@ -21,13 +23,6 @@ export interface ProfilePayload {
 
 export interface DeleteAccountPayload {
   username: string;
-}
-
-export enum VatIdStatus {
-  NOT_CHECKED = 'Not checked',
-  VALID = 'Valid',
-  NOT_VALID = 'Not valid',
-  NON_EU_ID = 'ID outside the EU',
 }
 
 export const UserDevice = z.object({

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -370,6 +370,7 @@
         "invalid": "VAT ID is invalid. Please enter your correct VAT ID.",
         "not_verified": "VAT ID not verified. Please verify your VAT ID before updating your customer information",
         "timer": "VAT ID verification cooldown in progress. Please try again in {time}",
+        "vat_invalid_checkout_warning": "No VAT Reverse charge applied. Your VAT ID could not be verified. Update it in {link}.",
         "verified": "Your VAT ID is successfully verified!",
         "verify": "Verify"
       }


### PR DESCRIPTION
## Summary
- Display a warning alert on both card-payment and website checkout flows when the user's VAT ID could not be verified
- Link users to the Customer Information page to update their VAT ID
- Use RUI warning theme colors and outlined variant for consistent styling
- Shorten the warning message for clarity

## Test plan
- [x] Verify VAT warning appears on card-payment checkout when `vatIdStatus` is `Not valid` and country is not `DE`
- [x] Verify VAT warning appears on website OrderSummaryCard under the same conditions
- [x] Verify links navigate to `/home/customer-information`
- [x] Verify warning does not appear when VAT ID is valid or not checked