### PR TITLE
fix: share web3 connection state across composable instances

### DIFF
--- a/packages/website/app/composables/web3/use-shared-web3-state.ts
+++ b/packages/website/app/composables/web3/use-shared-web3-state.ts
@@ -1,0 +1,24 @@
+import type { ShallowRef } from 'vue';
+import { createSharedComposable } from '@vueuse/core';
+
+export interface SharedWeb3State {
+  address: ShallowRef<string | undefined>;
+  connected: ShallowRef<boolean>;
+  connectedChainId: ShallowRef<bigint | undefined>;
+  initialized: ShallowRef<boolean>;
+  initializing: ShallowRef<boolean>;
+  isOpen: ShallowRef<boolean>;
+}
+
+/**
+ * Shared web3 connection state. All callers of useWeb3Connection() share the same
+ * reactive refs, preventing state desync when multiple composables create their own instance.
+ */
+export const useSharedWeb3State = createSharedComposable((): SharedWeb3State => ({
+  address: shallowRef<string>(),
+  connected: shallowRef<boolean>(false),
+  connectedChainId: shallowRef<bigint>(),
+  initialized: shallowRef<boolean>(false),
+  initializing: shallowRef<boolean>(false),
+  isOpen: shallowRef<boolean>(false),
+}));

--- a/packages/website/tests/unit/composables/use-siwe-auth.spec.ts
+++ b/packages/website/tests/unit/composables/use-siwe-auth.spec.ts
@@ -1,0 +1,209 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { get } from '@vueuse/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetchWithCsrf = vi.fn();
+const mockSignMessage = vi.fn();
+
+const { useRuntimeConfig } = vi.hoisted(() => ({
+  useRuntimeConfig: vi.fn().mockReturnValue({
+    app: { baseURL: '/', buildId: 'test' },
+    public: {
+      baseUrl: 'http://localhost:3000',
+      testing: true,
+      walletConnect: { projectId: 'test-project-id' },
+    },
+  }),
+}));
+
+mockNuxtImport('useRuntimeConfig', () => useRuntimeConfig);
+
+vi.mock('~/composables/use-fetch-with-csrf', () => ({
+  useFetchWithCsrf: () => ({
+    fetchWithCsrf: mockFetchWithCsrf,
+    setHooks: vi.fn(),
+  }),
+}));
+
+vi.mock('~/composables/web3/use-shared-web3-state', () => ({
+  useSharedWeb3State: () => ({
+    address: ref<string>('0x1234567890abcdef1234567890abcdef12345678'),
+    connected: ref<boolean>(true),
+    connectedChainId: ref<bigint>(),
+    initialized: ref<boolean>(false),
+    initializing: ref<boolean>(false),
+    isOpen: ref<boolean>(false),
+  }),
+}));
+
+vi.mock('~/composables/web3/use-web3-connection', () => ({
+  useWeb3Connection: () => ({
+    address: ref<string>('0x1234567890abcdef1234567890abcdef12345678'),
+    connected: ref<boolean>(true),
+    signMessage: mockSignMessage,
+  }),
+}));
+
+const TEST_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+const TEST_NONCE = 'test-nonce-123';
+const TEST_SIGNATURE = '0xsignature';
+
+describe('useSiweAuth', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('should authenticate successfully', async () => {
+    mockFetchWithCsrf
+      .mockResolvedValueOnce({ nonce: TEST_NONCE })
+      .mockResolvedValueOnce({
+        address: TEST_ADDRESS,
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        ok: true,
+      });
+    mockSignMessage.mockResolvedValueOnce(TEST_SIGNATURE);
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate, isSessionValid } = useSiweAuth();
+
+    const result = await authenticate(TEST_ADDRESS);
+
+    expect(result).toBe(true);
+    expect(isSessionValid(TEST_ADDRESS)).toBe(true);
+
+    expect(mockFetchWithCsrf).toHaveBeenCalledTimes(2);
+    expect(mockSignMessage).toHaveBeenCalledWith(
+      `I am the owner of address ${TEST_ADDRESS}. Nonce: ${TEST_NONCE}`,
+    );
+  });
+
+  it('should set authError when signature is rejected', async () => {
+    mockFetchWithCsrf.mockResolvedValueOnce({ nonce: TEST_NONCE });
+    mockSignMessage.mockRejectedValueOnce({ code: 4001, message: 'User rejected' });
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate, authError } = useSiweAuth();
+
+    const result = await authenticate(TEST_ADDRESS);
+
+    expect(result).toBe(false);
+    expect(get(authError)).toBe('Signature rejected. Please try again.');
+  });
+
+  it('should set authError when sign message fails', async () => {
+    mockFetchWithCsrf.mockResolvedValueOnce({ nonce: TEST_NONCE });
+    mockSignMessage.mockRejectedValueOnce(new Error('Unknown signing error'));
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate, authError } = useSiweAuth();
+
+    const result = await authenticate(TEST_ADDRESS);
+
+    expect(result).toBe(false);
+    expect(get(authError)).toBe('Failed to sign message. Please try again.');
+  });
+
+  it('should set authError when nonce fetch fails', async () => {
+    mockFetchWithCsrf.mockRejectedValueOnce(new Error('Network error'));
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate, authError } = useSiweAuth();
+
+    const result = await authenticate(TEST_ADDRESS);
+
+    expect(result).toBe(false);
+    expect(get(authError)).toBeTruthy();
+  });
+
+  it('should set authError when verification fails', async () => {
+    mockFetchWithCsrf
+      .mockResolvedValueOnce({ nonce: TEST_NONCE })
+      .mockResolvedValueOnce({ ok: false });
+    mockSignMessage.mockResolvedValueOnce(TEST_SIGNATURE);
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate, authError } = useSiweAuth();
+
+    const result = await authenticate(TEST_ADDRESS);
+
+    expect(result).toBe(false);
+    expect(get(authError)).toBe('Authentication failed');
+  });
+
+  it('should reset isAuthenticating after completion', async () => {
+    mockFetchWithCsrf
+      .mockResolvedValueOnce({ nonce: TEST_NONCE })
+      .mockResolvedValueOnce({
+        address: TEST_ADDRESS,
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        ok: true,
+      });
+    mockSignMessage.mockResolvedValueOnce(TEST_SIGNATURE);
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate, isAuthenticating } = useSiweAuth();
+
+    expect(get(isAuthenticating)).toBe(false);
+
+    const promise = authenticate(TEST_ADDRESS);
+    expect(get(isAuthenticating)).toBe(true);
+
+    await promise;
+    expect(get(isAuthenticating)).toBe(false);
+  });
+
+  it('should reset isAuthenticating after failure', async () => {
+    mockFetchWithCsrf.mockRejectedValueOnce(new Error('fail'));
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate, isAuthenticating } = useSiweAuth();
+
+    await authenticate(TEST_ADDRESS);
+
+    expect(get(isAuthenticating)).toBe(false);
+  });
+
+  it('should skip authentication when session is already valid', async () => {
+    const session = {
+      address: TEST_ADDRESS,
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+    localStorage.setItem('siwe_session', JSON.stringify(session));
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { authenticate } = useSiweAuth();
+
+    const result = await authenticate(TEST_ADDRESS);
+
+    expect(result).toBe(true);
+    expect(mockFetchWithCsrf).not.toHaveBeenCalled();
+    expect(mockSignMessage).not.toHaveBeenCalled();
+  });
+
+  it('should reject expired sessions', async () => {
+    const session = {
+      address: TEST_ADDRESS,
+      expiresAt: Math.floor(Date.now() / 1000) - 100,
+    };
+    localStorage.setItem('siwe_session', JSON.stringify(session));
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { isSessionValid } = useSiweAuth();
+
+    expect(isSessionValid(TEST_ADDRESS)).toBe(false);
+  });
+
+  it('should reject sessions for different addresses', async () => {
+    const session = {
+      address: '0xDIFFERENT',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+    localStorage.setItem('siwe_session', JSON.stringify(session));
+
+    const { useSiweAuth } = await import('~/composables/rotki-sponsorship/use-siwe-auth');
+    const { isSessionValid } = useSiweAuth();
+
+    expect(isSessionValid(TEST_ADDRESS)).toBe(false);
+  });
+});

--- a/packages/website/tests/unit/composables/use-web3-connection.spec.ts
+++ b/packages/website/tests/unit/composables/use-web3-connection.spec.ts
@@ -1,0 +1,80 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { get } from '@vueuse/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { useRuntimeConfig } = vi.hoisted(() => ({
+  useRuntimeConfig: vi.fn().mockReturnValue({
+    app: { baseURL: '/', buildId: 'test' },
+    public: {
+      baseUrl: 'http://localhost:3000',
+      testing: true,
+      walletConnect: { projectId: 'test-project-id' },
+    },
+  }),
+}));
+
+mockNuxtImport('useRuntimeConfig', () => useRuntimeConfig);
+
+describe('useWeb3Connection', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('should share reactive state across multiple instances', async () => {
+    const { useWeb3Connection } = await import('~/composables/web3/use-web3-connection');
+    const instance1 = useWeb3Connection();
+    const instance2 = useWeb3Connection();
+
+    expect(get(instance1.connected)).toBe(false);
+    expect(get(instance2.connected)).toBe(false);
+
+    expect(get(instance1.address)).toBeUndefined();
+    expect(get(instance2.address)).toBeUndefined();
+
+    // Both should reference the same underlying ref (toRaw comparison)
+    expect(instance1.connected).toBe(instance2.connected);
+    expect(instance1.address).toBe(instance2.address);
+    expect(instance1.connectedChainId).toBe(instance2.connectedChainId);
+    expect(instance1.initialized).toBe(instance2.initialized);
+  });
+
+  it('should keep per-instance errorMessage separate', async () => {
+    const { useWeb3Connection } = await import('~/composables/web3/use-web3-connection');
+    const instance1 = useWeb3Connection();
+    const instance2 = useWeb3Connection();
+
+    instance1.setError('error from instance 1');
+
+    expect(get(instance1.errorMessage)).toBe('error from instance 1');
+    expect(get(instance2.errorMessage)).toBe('');
+  });
+
+  it('should invoke per-instance onError callback from setError', async () => {
+    const { useWeb3Connection } = await import('~/composables/web3/use-web3-connection');
+    const onError1 = vi.fn();
+    const onError2 = vi.fn();
+
+    const instance1 = useWeb3Connection({ onError: onError1 });
+    useWeb3Connection({ onError: onError2 });
+
+    instance1.setError('test error');
+
+    expect(onError1).toHaveBeenCalledWith('test error');
+    expect(onError2).not.toHaveBeenCalled();
+  });
+
+  it('should throw when signMessage is called without connection', async () => {
+    const { useWeb3Connection } = await import('~/composables/web3/use-web3-connection');
+    const instance = useWeb3Connection();
+
+    await expect(instance.signMessage('test')).rejects.toThrow('Wallet not connected');
+  });
+
+  it('should throw when getSigner is called without connection', async () => {
+    const { useWeb3Connection } = await import('~/composables/web3/use-web3-connection');
+    const instance = useWeb3Connection();
+
+    await expect(instance.getSigner()).rejects.toThrow('Wallet not connected');
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: Multiple calls to `useWeb3Connection()` created independent reactive refs. When `SponsorWalletConnectionCard` connected the wallet, `useSiweAuth`'s `connected` ref stayed `false`, causing `signMessage()` to silently throw "Wallet not connected"
- Extract shared connection state (`connected`, `address`, `connectedChainId`, etc.) into `useSharedWeb3State` composable via `createSharedComposable`, so all callers share the same refs
- Display `authError` in `SponsorWalletConnectionCard` via `RuiAlert` so users see why authentication failed
- Add unit tests for both `useWeb3Connection` (shared state verification) and `useSiweAuth` (full auth flow coverage)

## Test plan
- [x] `pnpm test` — all 60 tests pass (15 new)
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] Manual: connect wallet on `/sponsor/submit-name`, click "Sign in with Ethereum", verify signing prompt appears
- [x] Manual: reject the signature, verify error message is displayed