### PR TITLE
feat: track download button clicks in sigil chronicle

### DIFF
--- a/packages/website/app/components/download/DownloadHeading.vue
+++ b/packages/website/app/components/download/DownloadHeading.vue
@@ -2,9 +2,18 @@
 import type { DownloadItemSingle, DownloadItem as DownloadItemType } from '~/types/download';
 import ButtonLink from '~/components/common/ButtonLink.vue';
 import DownloadItem from '~/components/download/DownloadItem.vue';
+import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 
 const props = defineProps<{ version: string; links: DownloadItemType[] }>();
 const { t } = useI18n({ useScope: 'global' });
+const { chronicle } = useSigilEvents();
+
+function onDownloadClick(platform: string): void {
+  chronicle('download_click', {
+    platform,
+    version: props.version || undefined,
+  });
+}
 
 const showAll = ref(false);
 
@@ -82,6 +91,7 @@ const highlightedDownloadItem = computed<DownloadItemSingle[]>(() => {
                 variant="default"
                 size="lg"
                 data-cy="main-download-button"
+                @click="onDownloadClick(item.platform)"
               >
                 <template #prepend>
                   <RuiIcon

--- a/packages/website/app/composables/chronicling/use-sigil-events.ts
+++ b/packages/website/app/composables/chronicling/use-sigil-events.ts
@@ -47,10 +47,16 @@ export interface DownloadSeePlansClickData {
   source: 'download_page_nudge';
 }
 
+export interface DownloadClickData {
+  platform: string;
+  version?: string;
+}
+
 export interface SigilEventMap {
   checkout_error: CheckoutErrorData;
   checkout_method_selected: CheckoutMethodSelectedData;
   checkout_start: CheckoutStartData;
+  download_click: DownloadClickData;
   download_see_plans_click: DownloadSeePlansClickData;
   pricing_view: PricingViewData;
   purchase_success: PurchaseSuccessData;


### PR DESCRIPTION
Add `download_click` event to sigil chronicle capturing platform and version data from the download heading buttons.