### PR TITLE
feat: add cancellation feedback form to cancel subscription dialog

### DIFF
--- a/packages/website/app/components/account/home/ActiveSubscriptionCard.vue
+++ b/packages/website/app/components/account/home/ActiveSubscriptionCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Subscription as UserSubscription } from '@rotki/card-payment-common/schemas/subscription';
+import type { CancelSubscriptionConfirmEvent } from '~/components/account/home/CancelSubscription.vue';
 import type {
   CryptoPaymentState,
   OperationState,
@@ -24,11 +25,9 @@ import { useAvailablePlans } from '~/composables/tiers/use-available-plans';
 import { useSubscriptionOperationsStore } from '~/store/subscription-operations';
 import { formatDate } from '~/utils/date';
 
-interface Props {
+const { subscription } = defineProps<{
   subscription: UserSubscription;
-}
-
-const props = defineProps<Props>();
+}>();
 
 const emit = defineEmits<{
   refresh: [];
@@ -39,7 +38,7 @@ const { actionsClasses } = useSubscriptionDisplay();
 const { canUpgradeSubscription } = useSubscriptionActions();
 
 // Subscription status display and styling
-const subscriptionRef = toRef(props, 'subscription');
+const subscriptionRef = toRef(() => subscription);
 const { statusDisplayText, statusCardClass } = useSubscriptionStatus(subscriptionRef);
 
 // Plan information and limits
@@ -72,7 +71,7 @@ const activeActionSubscription = ref<UserSubscription>();
 
 // Computed for renewableSubscriptions
 const renewableSubscriptions = computed<UserSubscription[]>(() =>
-  props.subscription.actions.includes('renew') ? [props.subscription] : [],
+  subscription.actions.includes('renew') ? [subscription] : [],
 );
 
 // Crypto payment composable
@@ -99,26 +98,26 @@ const cryptoPaymentState = computed<CryptoPaymentState>(() => ({
 
 // Relative date calculations using VueUse
 const createdRelative = useTimeAgo(
-  computed<Date>(() => new Date(props.subscription.createdDate)),
+  computed<Date>(() => new Date(subscription.createdDate)),
 );
 
 const nextActionRelative = useTimeAgo(
-  computed<Date>(() => new Date(props.subscription.nextActionDate)),
+  computed<Date>(() => new Date(subscription.nextActionDate)),
 );
 
 // Check if upgrade is pending
-const isUpgradePending = computed<boolean>(() => isSubRequestingUpgrade(props.subscription));
+const isUpgradePending = computed<boolean>(() => isSubRequestingUpgrade(subscription));
 
 // Check if upgrade is available (only if not already pending)
-const isUpgradeAvailable = computed<boolean>(() => !get(isUpgradePending) && canUpgradeSubscription(props.subscription, get(availablePlans)));
+const isUpgradeAvailable = computed<boolean>(() => !get(isUpgradePending) && canUpgradeSubscription(subscription, get(availablePlans)));
 
 // Action handlers using centralized composable
 async function resumeSubscription(subscription: UserSubscription): Promise<void> {
   await performResumeSubscription(subscription, activeAction, activeActionSubscription);
 }
 
-async function cancelSubscription(subscription: UserSubscription): Promise<void> {
-  await performCancelSubscription(subscription, activeAction, activeActionSubscription);
+async function cancelSubscription({ subscription, feedback }: CancelSubscriptionConfirmEvent): Promise<void> {
+  await performCancelSubscription(subscription, activeAction, activeActionSubscription, feedback);
 }
 
 async function cancelUpgrade(subscriptionId: string): Promise<void> {

--- a/packages/website/app/components/account/home/CancelSubscription.vue
+++ b/packages/website/app/components/account/home/CancelSubscription.vue
@@ -1,30 +1,80 @@
 <script setup lang="ts">
 import type { Subscription as UserSubscription } from '@rotki/card-payment-common/schemas/subscription';
-import { get, isDefined } from '@vueuse/shared';
+import { get, isDefined, set } from '@vueuse/shared';
 import ButtonLink from '~/components/common/ButtonLink.vue';
+import { type CancellationFeedbackPayload, useCancellationFeedback } from '~/composables/subscription/use-cancellation-feedback';
 import { formatDate } from '~/utils/date';
+
+export interface CancelSubscriptionConfirmEvent {
+  subscription: UserSubscription;
+  feedback: CancellationFeedbackPayload;
+}
 
 const modelValue = defineModel<UserSubscription | undefined>({ required: true });
 
-defineProps<{
+const { loading } = defineProps<{
   loading: boolean;
 }>();
 
 const emit = defineEmits<{
-  confirm: [val: UserSubscription];
+  confirm: [payload: CancelSubscriptionConfirmEvent];
 }>();
 
-const isPending = computed<boolean>(() => get(modelValue)?.status === 'Pending');
-// Remove store usage since notifications are handled at layout level
+const { t } = useI18n({ useScope: 'global' });
 
-function cancelSubscription() {
+const {
+  reasons,
+  loading: reasonsLoading,
+  selectedReason,
+  comment,
+  isValid,
+  fetchReasons,
+  reset,
+} = useCancellationFeedback();
+
+const isPending = computed<boolean>(() => get(modelValue)?.status === 'Pending');
+
+const OTHER_REASON = 7;
+
+const isOtherSelected = computed<boolean>(() => get(selectedReason) === OTHER_REASON);
+
+const fallbackReasons = computed<Array<{ key: number; label: string }>>(() =>
+  Array.from({ length: 7 }, (_, i) => ({
+    key: i + 1,
+    label: t(`account.subscriptions.cancellation.feedback.reasons.${i + 1}`),
+  })),
+);
+
+const displayReasons = computed<Array<{ key: number; label: string }>>(() => {
+  const fetched = get(reasons);
+  return fetched.length > 0 ? fetched : get(fallbackReasons);
+});
+
+watch(modelValue, (val) => {
+  if (val) {
+    fetchReasons();
+  }
+  else {
+    reset();
+  }
+});
+
+function selectReason(key: number): void {
+  set(selectedReason, key);
+}
+
+function cancelSubscription(): void {
   if (!isDefined(modelValue))
     return;
 
-  emit('confirm', get(modelValue));
+  emit('confirm', {
+    subscription: get(modelValue),
+    feedback: {
+      reason: get(selectedReason)!,
+      feedback: get(comment),
+    },
+  });
 }
-
-const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
@@ -100,6 +150,80 @@ const { t } = useI18n({ useScope: 'global' });
         </i18n-t>
       </div>
 
+      <div class="rounded-lg border border-rui-grey-300 p-4 space-y-3">
+        <div class="flex items-start gap-2.5">
+          <RuiIcon
+            name="lu-message-circle"
+            size="20"
+            class="text-rui-primary shrink-0 mt-0.5"
+          />
+          <div>
+            <h6 class="text-sm font-bold leading-snug">
+              {{ t('account.subscriptions.cancellation.feedback.title') }}
+            </h6>
+            <p class="text-rui-text-secondary text-xs">
+              {{ t('account.subscriptions.cancellation.feedback.description') }}
+            </p>
+          </div>
+        </div>
+
+        <div
+          v-if="reasonsLoading"
+          class="flex justify-center py-4"
+        >
+          <RuiProgress
+            circular
+            variant="indeterminate"
+            color="primary"
+            size="24"
+          />
+        </div>
+
+        <template v-else>
+          <div class="grid grid-cols-2 gap-1.5">
+            <div
+              v-for="reason in displayReasons"
+              :key="reason.key"
+              class="flex items-center rounded-md border px-2.5 py-1.5 cursor-pointer transition-colors"
+              :class="[
+                selectedReason === reason.key
+                  ? 'border-rui-primary bg-rui-primary/5'
+                  : 'border-rui-grey-300 hover:border-rui-grey-400',
+                reason.key === OTHER_REASON && displayReasons.length % 2 !== 0
+                  ? 'col-span-2'
+                  : '',
+              ]"
+              @click="selectReason(reason.key)"
+            >
+              <RuiRadio
+                :model-value="selectedReason"
+                :value="reason.key"
+                :label="reason.label"
+                color="primary"
+                :hide-details="true"
+                size="sm"
+              />
+            </div>
+          </div>
+
+          <Transition name="fade">
+            <RuiTextArea
+              v-if="selectedReason"
+              v-model="comment"
+              :label="isOtherSelected
+                ? t('account.subscriptions.cancellation.feedback.comment_required')
+                : t('account.subscriptions.cancellation.feedback.comment_label')"
+              variant="outlined"
+              color="primary"
+              :rows="2"
+              :error-messages="isOtherSelected && comment.trim().length === 0
+                ? [t('account.subscriptions.cancellation.feedback.comment_required')]
+                : undefined"
+            />
+          </Transition>
+        </template>
+      </div>
+
       <div class="flex justify-end gap-4 pt-4">
         <RuiButton
           color="primary"
@@ -111,6 +235,7 @@ const { t } = useI18n({ useScope: 'global' });
 
         <RuiButton
           color="error"
+          :disabled="!isValid"
           @click="cancelSubscription()"
         >
           {{ t('account.subscriptions.cancellation.actions.yes') }}

--- a/packages/website/app/components/account/home/SubscriptionDialogs.vue
+++ b/packages/website/app/components/account/home/SubscriptionDialogs.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Subscription as UserSubscription } from '@rotki/card-payment-common/schemas/subscription';
-import CancelSubscription from '~/components/account/home/CancelSubscription.vue';
+import CancelSubscription, { type CancelSubscriptionConfirmEvent } from '~/components/account/home/CancelSubscription.vue';
 import CancelUpgradeDialog from '~/components/account/home/CancelUpgradeDialog.vue';
 import ResumeSubscriptionDialog from '~/components/account/home/ResumeSubscriptionDialog.vue';
 import {
@@ -9,25 +9,19 @@ import {
 } from '~/components/account/home/subscription-table/types';
 import UpgradePlanDialog from '~/components/account/home/UpgradePlanDialog.vue';
 
-interface Props {
+const activeSubscription = defineModel<UserSubscription>();
+
+const { activeAction, inProgress, operationType } = defineProps<{
   activeAction?: SubscriptionActionType;
   inProgress: boolean;
   operationType?: SubscriptionActionType;
-}
-
-const activeSubscription = defineModel<UserSubscription>();
-
-defineProps<Props>();
+}>();
 
 const emit = defineEmits<{
-  'cancel-subscription': [subscription: UserSubscription];
+  'cancel-subscription': [payload: CancelSubscriptionConfirmEvent];
   'resume-subscription': [subscription: UserSubscription];
   'cancel-upgrade': [subscriptionId: string];
 }>();
-
-function handleCancelSubscription(subscription: UserSubscription): void {
-  emit('cancel-subscription', subscription);
-}
 
 function handleResumeSubscription(subscription: UserSubscription): void {
   emit('resume-subscription', subscription);
@@ -44,7 +38,7 @@ function handleCancelUpgrade(subscriptionId: string): void {
       v-if="activeAction === SubscriptionAction.CANCEL && activeSubscription"
       v-model="activeSubscription"
       :loading="operationType === SubscriptionAction.CANCEL && inProgress"
-      @confirm="handleCancelSubscription($event)"
+      @confirm="emit('cancel-subscription', $event)"
     />
 
     <ResumeSubscriptionDialog

--- a/packages/website/app/components/account/home/SubscriptionTable.vue
+++ b/packages/website/app/components/account/home/SubscriptionTable.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Subscription as UserSubscription } from '@rotki/card-payment-common/schemas/subscription';
 import type { DataTableColumn, DataTableSortColumn, TablePaginationData } from '@rotki/ui-library';
+import type { CancelSubscriptionConfirmEvent } from '~/components/account/home/CancelSubscription.vue';
 import type {
   CryptoPaymentState,
   OperationState,
@@ -103,8 +104,8 @@ async function resumeSubscription(subscription: UserSubscription): Promise<void>
   await performResumeSubscription(subscription, activeAction, activeSubscription);
 }
 
-async function cancelSubscription(subscription: UserSubscription): Promise<void> {
-  await performCancelSubscription(subscription, activeAction, activeSubscription);
+async function cancelSubscription({ subscription, feedback }: CancelSubscriptionConfirmEvent): Promise<void> {
+  await performCancelSubscription(subscription, activeAction, activeSubscription, feedback);
 }
 
 async function cancelUpgrade(subscriptionId: string): Promise<void> {

--- a/packages/website/app/composables/subscription/use-cancellation-feedback.ts
+++ b/packages/website/app/composables/subscription/use-cancellation-feedback.ts
@@ -1,0 +1,95 @@
+import { get, set } from '@vueuse/shared';
+import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
+import { useLogger } from '~/utils/use-logger';
+
+export interface CancellationReasonChoice {
+  key: number;
+  label: string;
+}
+
+export interface CancellationFeedbackPayload {
+  reason: number;
+  feedback: string;
+}
+
+interface CancellationFeedbackResponse {
+  reasons: CancellationReasonChoice[];
+}
+
+interface UseCancellationFeedbackReturn {
+  reasons: Ref<CancellationReasonChoice[]>;
+  loading: Ref<boolean>;
+  selectedReason: Ref<number | undefined>;
+  comment: Ref<string>;
+  isValid: ComputedRef<boolean>;
+  fetchReasons: () => Promise<void>;
+  submitFeedback: (payload: CancellationFeedbackPayload) => Promise<void>;
+  reset: () => void;
+}
+
+export function useCancellationFeedback(): UseCancellationFeedbackReturn {
+  const { fetchWithCsrf } = useFetchWithCsrf();
+  const logger = useLogger('cancellation-feedback');
+
+  const reasons = ref<CancellationReasonChoice[]>([]);
+  const loading = ref<boolean>(false);
+  const selectedReason = ref<number>();
+  const comment = ref<string>('');
+
+  const OTHER_REASON = 7;
+
+  const isValid = computed<boolean>(() => {
+    const reason = get(selectedReason);
+    if (!reason)
+      return false;
+
+    if (reason === OTHER_REASON && get(comment).trim().length === 0)
+      return false;
+
+    return true;
+  });
+
+  async function fetchReasons(): Promise<void> {
+    set(loading, true);
+    try {
+      const response = await fetchWithCsrf<CancellationFeedbackResponse>(
+        '/webapi/2/subscriptions/cancellation-feedback',
+      );
+      set(reasons, response.reasons);
+    }
+    catch (error: unknown) {
+      logger.error('Failed to fetch cancellation reasons:', error);
+    }
+    finally {
+      set(loading, false);
+    }
+  }
+
+  async function submitFeedback(payload: CancellationFeedbackPayload): Promise<void> {
+    try {
+      await fetchWithCsrf('/webapi/2/subscriptions/cancellation-feedback', {
+        method: 'POST',
+        body: payload,
+      });
+    }
+    catch (error: unknown) {
+      logger.error('Failed to submit cancellation feedback:', error);
+    }
+  }
+
+  function reset(): void {
+    set(selectedReason, undefined);
+    set(comment, '');
+  }
+
+  return {
+    comment,
+    fetchReasons,
+    isValid,
+    loading,
+    reasons,
+    reset,
+    selectedReason,
+    submitFeedback,
+  };
+}

--- a/packages/website/app/composables/subscription/use-subscription-operations.ts
+++ b/packages/website/app/composables/subscription/use-subscription-operations.ts
@@ -1,4 +1,5 @@
 import type { Subscription as UserSubscription } from '@rotki/card-payment-common/schemas/subscription';
+import type { CancellationFeedbackPayload } from '~/composables/subscription/use-cancellation-feedback';
 import { set } from '@vueuse/shared';
 import { SubscriptionAction, type SubscriptionActionType } from '~/components/account/home/subscription-table/types';
 import { useSubscription } from '~/composables/subscription/use-subscription';
@@ -12,7 +13,7 @@ interface UseSubscriptionOperationsOptions {
 interface UseSubscriptionOperationsReturn {
   clearActiveState: (activeAction?: Ref<SubscriptionActionType | undefined>, activeSubscription?: Ref<UserSubscription | undefined>) => void;
   resumeSubscription: (subscription: UserSubscription, activeAction?: Ref<SubscriptionActionType | undefined>, activeSubscription?: Ref<UserSubscription | undefined>) => Promise<void>;
-  cancelSubscription: (subscription: UserSubscription, activeAction?: Ref<SubscriptionActionType | undefined>, activeSubscription?: Ref<UserSubscription | undefined>) => Promise<void>;
+  cancelSubscription: (subscription: UserSubscription, activeAction?: Ref<SubscriptionActionType | undefined>, activeSubscription?: Ref<UserSubscription | undefined>, feedback?: CancellationFeedbackPayload) => Promise<void>;
   cancelUpgrade: (subscriptionId: string, activeAction?: Ref<SubscriptionActionType | undefined>, activeSubscription?: Ref<UserSubscription | undefined>) => Promise<void>;
 }
 
@@ -21,7 +22,7 @@ interface UseSubscriptionOperationsReturn {
  * Centralizes the common logic used by ActiveSubscriptionCard and SubscriptionTable
  */
 export function useSubscriptionOperations(options?: UseSubscriptionOperationsOptions): UseSubscriptionOperationsReturn {
-  const { cancelUserSubscription, resumeUserSubscription } = useSubscription();
+  const { cancelUserSubscription, resumeUserSubscription, submitCancellationFeedback } = useSubscription();
   const paymentApi = useCryptoPaymentApi();
 
   const subscriptionOpsStore = useSubscriptionOperationsStore();
@@ -66,8 +67,13 @@ export function useSubscriptionOperations(options?: UseSubscriptionOperationsOpt
     subscription: UserSubscription,
     activeAction?: Ref<SubscriptionActionType | undefined>,
     activeSubscription?: Ref<UserSubscription | undefined>,
+    feedback?: CancellationFeedbackPayload,
   ): Promise<void> {
     startOperation(SubscriptionAction.CANCEL);
+
+    if (feedback) {
+      submitCancellationFeedback(feedback).catch(() => {});
+    }
 
     await cancelUserSubscription(subscription, (statusMessage: string) => {
       setStatus(statusMessage);

--- a/packages/website/app/composables/subscription/use-subscription.ts
+++ b/packages/website/app/composables/subscription/use-subscription.ts
@@ -1,4 +1,5 @@
 import type { Subscription as UserSubscription } from '@rotki/card-payment-common/schemas/subscription';
+import type { CancellationFeedbackPayload } from '~/composables/subscription/use-cancellation-feedback';
 import { ActionResultResponseSchema } from '@rotki/card-payment-common/schemas/api';
 import { FetchError } from 'ofetch';
 import { useAccountRefresh } from '~/composables/use-app-events';
@@ -33,6 +34,7 @@ function getErrorMessage(error: unknown): string {
 interface UseSubscriptionReturn {
   cancelUserSubscription: (subscription: UserSubscription, onProgress?: (status: string) => void) => Promise<void>;
   resumeUserSubscription: (identifier: UserSubscription, onProgress?: (status: string) => void) => Promise<void>;
+  submitCancellationFeedback: (payload: CancellationFeedbackPayload) => Promise<void>;
 }
 
 export function useSubscription(): UseSubscriptionReturn {
@@ -97,8 +99,21 @@ export function useSubscription(): UseSubscriptionReturn {
     );
   };
 
+  async function submitCancellationFeedback(payload: CancellationFeedbackPayload): Promise<void> {
+    try {
+      await fetchWithCsrf('/webapi/2/subscriptions/cancellation-feedback', {
+        method: 'POST',
+        body: payload,
+      });
+    }
+    catch (error: unknown) {
+      logger.error('Failed to submit cancellation feedback:', error);
+    }
+  }
+
   return {
     cancelUserSubscription,
     resumeUserSubscription,
+    submitCancellationFeedback,
   };
 }

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -135,7 +135,23 @@
           "normal": "Please note that your current subscription, which was created on {start_date}, will run until {end_date}. Until then, you will be able to fully utilize all rotki premium features.",
           "pending": "Please note that your pending subscription, which was created on {start_date} will never be billed if you cancel. We are sad to see you go."
         },
-        "title": "Canceling Your rotki Subscription"
+        "title": "Canceling Your rotki Subscription",
+        "feedback": {
+          "title": "Help us improve",
+          "description": "Please let us know why you're cancelling:",
+          "reason_label": "Reason for cancelling",
+          "comment_label": "Additional comments (optional)",
+          "comment_required": "Please tell us more about your reason",
+          "reasons": {
+            "1": "Not using it anymore",
+            "2": "Price too high",
+            "3": "Missing features",
+            "4": "Technical issues",
+            "5": "Switched to alternative",
+            "6": "Incorrect results",
+            "7": "Other"
+          }
+        }
       },
       "cancelled_but_still_active": {
         "description": "You canceled this subscription, but it will remain active until {date}",


### PR DESCRIPTION
## Summary

- Add cancellation feedback form (reason selector + optional comment) to the cancel subscription dialog
- Integrate with `GET/POST /webapi/2/subscriptions/cancellation-feedback` backend API
- Feedback submission is fire-and-forget — it does not block the cancellation flow
- Apply Vue 3.5+ patterns (destructured props, getter-based `toRef`) to touched files

## Changes

- **New**: `use-cancellation-feedback.ts` composable — fetches available reasons, manages form state, submits feedback
- **Modified**: `CancelSubscription.vue` — card-based 2-column radio grid for reasons, conditional textarea, icon header
- **Modified**: `SubscriptionDialogs.vue`, `ActiveSubscriptionCard.vue`, `SubscriptionTable.vue` — pass feedback payload through event chain
- **Modified**: `use-subscription-operations.ts` — accepts optional feedback, fires POST before cancellation
- **Modified**: `use-subscription.ts` — added `submitCancellationFeedback()` function
- **Modified**: `en.json` — added i18n keys for feedback section

## Test plan

- [ ] Verify cancel dialog opens with benefits content and feedback form
- [ ] Verify reason cards render in 2-column grid, selection highlights correctly
- [ ] Verify textarea appears only after selecting a reason
- [ ] Verify "Other" reason requires a comment before confirming
- [ ] Verify cancellation proceeds regardless of feedback API errors
- [ ] Run `pnpm typecheck`, `pnpm lint`, `pnpm test` — all passing