### PR TITLE
feat: fetch cancellation reasons from backend

### DIFF
--- a/packages/website/app/components/account/home/CancelSubscription.vue
+++ b/packages/website/app/components/account/home/CancelSubscription.vue
@@ -27,28 +27,14 @@ const {
   loading: reasonsLoading,
   selectedReason,
   comment,
+  isOtherReason,
+  isOtherSelected,
   isValid,
   fetchReasons,
   reset,
 } = useCancellationFeedback();
 
 const isPending = computed<boolean>(() => get(modelValue)?.status === 'Pending');
-
-const OTHER_REASON = 7;
-
-const isOtherSelected = computed<boolean>(() => get(selectedReason) === OTHER_REASON);
-
-const fallbackReasons = computed<Array<{ key: number; label: string }>>(() =>
-  Array.from({ length: 7 }, (_, i) => ({
-    key: i + 1,
-    label: t(`account.subscriptions.cancellation.feedback.reasons.${i + 1}`),
-  })),
-);
-
-const displayReasons = computed<Array<{ key: number; label: string }>>(() => {
-  const fetched = get(reasons);
-  return fetched.length > 0 ? fetched : get(fallbackReasons);
-});
 
 watch(modelValue, (val) => {
   if (val) {
@@ -57,10 +43,10 @@ watch(modelValue, (val) => {
   else {
     reset();
   }
-});
+}, { immediate: true });
 
-function selectReason(key: number): void {
-  set(selectedReason, key);
+function selectReason(value: number): void {
+  set(selectedReason, value);
 }
 
 function cancelSubscription(): void {
@@ -182,22 +168,22 @@ function cancelSubscription(): void {
         <template v-else>
           <div class="grid grid-cols-2 gap-1.5">
             <div
-              v-for="reason in displayReasons"
-              :key="reason.key"
+              v-for="reason in reasons"
+              :key="reason.value"
               class="flex items-center rounded-md border px-2.5 py-1.5 cursor-pointer transition-colors"
               :class="[
-                selectedReason === reason.key
+                selectedReason === reason.value
                   ? 'border-rui-primary bg-rui-primary/5'
                   : 'border-rui-grey-300 hover:border-rui-grey-400',
-                reason.key === OTHER_REASON && displayReasons.length % 2 !== 0
+                isOtherReason(reason) && reasons.length % 2 !== 0
                   ? 'col-span-2'
                   : '',
               ]"
-              @click="selectReason(reason.key)"
+              @click="selectReason(reason.value)"
             >
               <RuiRadio
                 :model-value="selectedReason"
-                :value="reason.key"
+                :value="reason.value"
                 :label="reason.label"
                 color="primary"
                 :hide-details="true"

--- a/packages/website/app/composables/subscription/use-cancellation-feedback.ts
+++ b/packages/website/app/composables/subscription/use-cancellation-feedback.ts
@@ -3,7 +3,7 @@ import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { useLogger } from '~/utils/use-logger';
 
 export interface CancellationReasonChoice {
-  key: number;
+  value: number;
   label: string;
 }
 
@@ -21,6 +21,8 @@ interface UseCancellationFeedbackReturn {
   loading: Ref<boolean>;
   selectedReason: Ref<number | undefined>;
   comment: Ref<string>;
+  isOtherReason: (reason: CancellationReasonChoice) => boolean;
+  isOtherSelected: ComputedRef<boolean>;
   isValid: ComputedRef<boolean>;
   fetchReasons: () => Promise<void>;
   submitFeedback: (payload: CancellationFeedbackPayload) => Promise<void>;
@@ -36,17 +38,26 @@ export function useCancellationFeedback(): UseCancellationFeedbackReturn {
   const selectedReason = ref<number>();
   const comment = ref<string>('');
 
-  const OTHER_REASON = 7;
+  const OTHER_LABEL = 'Other';
+
+  function isOtherReason(reason: CancellationReasonChoice): boolean {
+    return reason.label === OTHER_LABEL;
+  }
+
+  const isOtherSelected = computed<boolean>(() => {
+    const reason = get(selectedReason);
+    if (!reason)
+      return false;
+
+    return get(reasons).some(r => r.value === reason && isOtherReason(r));
+  });
 
   const isValid = computed<boolean>(() => {
     const reason = get(selectedReason);
     if (!reason)
       return false;
 
-    if (reason === OTHER_REASON && get(comment).trim().length === 0)
-      return false;
-
-    return true;
+    return !(get(isOtherSelected) && get(comment).trim().length === 0);
   });
 
   async function fetchReasons(): Promise<void> {
@@ -85,6 +96,8 @@ export function useCancellationFeedback(): UseCancellationFeedbackReturn {
   return {
     comment,
     fetchReasons,
+    isOtherReason,
+    isOtherSelected,
     isValid,
     loading,
     reasons,

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -139,18 +139,8 @@
         "feedback": {
           "title": "Help us improve",
           "description": "Please let us know why you're cancelling:",
-          "reason_label": "Reason for cancelling",
           "comment_label": "Additional comments (optional)",
-          "comment_required": "Please tell us more about your reason",
-          "reasons": {
-            "1": "Not using it anymore",
-            "2": "Price too high",
-            "3": "Missing features",
-            "4": "Technical issues",
-            "5": "Switched to alternative",
-            "6": "Incorrect results",
-            "7": "Other"
-          }
+          "comment_required": "Please tell us more about your reason"
         }
       },
       "cancelled_but_still_active": {


### PR DESCRIPTION
## Summary
- Remove hardcoded cancellation reasons and fallback i18n strings
- Fetch reasons dynamically from `GET /webapi/2/subscriptions/cancellation-feedback` (returns `value`/`label` pairs)
- Detect "Other" reason by label instead of hardcoded ID
- Add `{ immediate: true }` to watcher so reasons are fetched on mount