### PR TITLE
chore: add OCI labels to Dockerfile and pass version from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,14 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=dev" >> "$GITHUB_OUTPUT"
+          fi
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build docker image
@@ -148,3 +156,7 @@ jobs:
         with:
           push: false
           tags: rotki/frontend:latest
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            VERSION=${{ steps.version.outputs.VERSION }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,22 @@ RUN --mount=type=cache,target=/root/.npm/_cacache/ \
 
 FROM node:24-alpine AS production
 
-WORKDIR /app
 ARG GIT_SHA
-ENV GIT_SHA=${GIT_SHA}
+ARG VERSION
+ARG BUILD_DATE
+
+LABEL org.opencontainers.image.title="rotki.com"
+LABEL org.opencontainers.image.description="rotki.com website"
+LABEL org.opencontainers.image.source="https://github.com/rotki/rotki.com"
+LABEL org.opencontainers.image.url="https://rotki.com"
+LABEL org.opencontainers.image.vendor="Rotki Solutions GmbH"
+LABEL org.opencontainers.image.licenses="AGPL-3.0"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${GIT_SHA}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+
+WORKDIR /app
+
 ENV NITRO_HOST=0.0.0.0
 ENV NITRO_PORT=4000
 


### PR DESCRIPTION
## Summary
- Add standard OCI labels to the Dockerfile production stage (`source`, `description`, `licenses`, `revision`, `version`)
- Move `GIT_SHA` from a runtime env var to the `org.opencontainers.image.revision` label in the production stage
- Add a `VERSION` build arg populated from the git tag in CI (falls back to `dev` for non-tag builds)
- Pass `GIT_SHA` and `VERSION` as build-args in the `build-docker` CI job