### PR TITLE
fix(auth): preserve query params on login redirect

### DIFF
--- a/packages/website/app/middleware/authentication.ts
+++ b/packages/website/app/middleware/authentication.ts
@@ -3,8 +3,15 @@ import { get } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
 import { useMainStore } from '~/store';
 
-export default defineNuxtRouteMiddleware(async () => {
+export default defineNuxtRouteMiddleware(async (to) => {
   const { authenticated } = storeToRefs(useMainStore());
-  if (!get(authenticated))
-    return navigateTo('/login');
+  if (!get(authenticated)) {
+    return navigateTo({
+      path: '/login',
+      query: {
+        ...to.query,
+        redirectUrl: to.fullPath,
+      },
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- Preserve UTM and other query parameters when the authentication middleware redirects unauthenticated users to `/login`
- Forward the original `fullPath` as `redirectUrl` so users return to their intended destination after login
- The login form already supports `redirectUrl` — this wires it up from the middleware

## Test plan

- [ ] Visit a protected route with UTM params (e.g. `/home/subscription?utm_source=twitter&utm_medium=social`) while logged out
- [ ] Verify redirect to `/login` preserves UTM params in the URL
- [ ] Verify UTM tracking cookie captures the params
- [ ] Log in and verify redirect back to the original page with params intact