### PR TITLE
fix(sponsor): use plain img for image upload preview

### DIFF
--- a/packages/website/app/components/sponsor/ImageUploadPreview.vue
+++ b/packages/website/app/components/sponsor/ImageUploadPreview.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+interface Props {
+  disabled?: boolean;
+  imagePreview?: string;
+  errorMessages?: string[];
+  hint?: string;
+}
+
+const { disabled = false, imagePreview = '', errorMessages = [], hint = '' } = defineProps<Props>();
+
+const emit = defineEmits<{
+  'file-selected': [file: File];
+  'remove': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+function handleImageChange(event: Event): void {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (file) {
+    emit('file-selected', file);
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div
+      v-if="!imagePreview"
+      class="relative mt-3"
+    >
+      <input
+        id="image-upload"
+        type="file"
+        accept="image/jpeg,image/jpg,image/png,image/webp"
+        class="hidden"
+        :disabled="disabled"
+        @change="handleImageChange($event)"
+      />
+      <label
+        for="image-upload"
+        class="flex flex-col items-center justify-center w-full h-32 border border-dashed border-rui-grey-300 dark:border-rui-grey-600 rounded-lg cursor-pointer hover:border-rui-primary transition-colors"
+      >
+        <RuiIcon
+          name="lu-upload"
+          size="24"
+          class="mb-2 text-rui-text-secondary"
+        />
+        <span class="text-sm text-rui-text-secondary">{{ t('sponsor.submit_name.upload_image') }}</span>
+        <span class="text-xs text-rui-text-disabled mt-1">{{ t('sponsor.submit_name.image_requirements') }}</span>
+      </label>
+    </div>
+    <div
+      v-else
+      class="relative flex items-start"
+    >
+      <!-- Plain <img> instead of <NuxtImg> because the src can be a data URL from FileReader, which NuxtImg's image provider cannot process -->
+      <img
+        :src="imagePreview"
+        alt="Profile preview"
+        class="w-32 h-32 object-cover rounded-lg mt-3"
+        width="128"
+        height="128"
+      />
+      <RuiButton
+        icon
+        size="sm"
+        color="error"
+        class="-ml-3"
+        :disabled="disabled"
+        @click="emit('remove')"
+      >
+        <RuiIcon
+          name="lu-x"
+          size="16"
+        />
+      </RuiButton>
+    </div>
+
+    <div
+      v-if="errorMessages.length > 0"
+      class="pt-1 px-3 text-rui-error text-sm text-caption"
+    >
+      <p
+        v-for="errorMsg in errorMessages"
+        :key="errorMsg"
+      >
+        {{ errorMsg }}
+      </p>
+    </div>
+    <div
+      v-else-if="hint"
+      class="pt-1 px-3 text-rui-text-secondary text-sm text-caption"
+    >
+      {{ hint }}
+    </div>
+  </div>
+</template>

--- a/packages/website/app/components/sponsor/NftSubmissionForm.vue
+++ b/packages/website/app/components/sponsor/NftSubmissionForm.vue
@@ -4,6 +4,7 @@ import type { NftSubmission } from '~/types/sponsor';
 import { useVuelidate } from '@vuelidate/core';
 import { email as emailValidation, helpers, maxLength, minLength, numeric, required } from '@vuelidate/validators';
 import { get, set } from '@vueuse/shared';
+import ImageUploadPreview from '~/components/sponsor/ImageUploadPreview.vue';
 import { useNftMetadata } from '~/composables/rotki-sponsorship/use-nft-metadata';
 import { useNftSubmissions } from '~/composables/rotki-sponsorship/use-nft-submissions';
 import { useRotkiSponsorshipPayment } from '~/composables/rotki-sponsorship/use-payment';
@@ -150,14 +151,7 @@ const rules = computed(() => ({
 
 const v$ = useVuelidate(rules, { displayName, imageFile, tokenId, email, atLeastOne: true }, { $autoDirty: true });
 
-function handleImageChange(event: Event): void {
-  const target = event.target as HTMLInputElement;
-  const file = target.files?.[0];
-
-  if (!file) {
-    return;
-  }
-
+function handleImageSelected(file: File): void {
   set(imageFile, file);
 
   // If we're replacing an existing image, we don't need to delete it
@@ -169,8 +163,6 @@ function handleImageChange(event: Event): void {
     set(imagePreview, reader.result as string);
   };
   reader.readAsDataURL(file);
-
-  // Image changed, will need to re-authenticate if needed
 }
 
 function removeImage(): void {
@@ -568,74 +560,14 @@ const [DefineNftIdOption, ReuseNftIdOption] = createReusableTemplate<{
           <span class="text-rui-text-secondary">({{ t('sponsor.submit_name.optional') }})</span>
         </label>
 
-        <div
-          v-if="!imagePreview"
-          class="relative mt-3"
-        >
-          <input
-            id="image-upload"
-            type="file"
-            accept="image/jpeg,image/jpg,image/png,image/webp"
-            class="hidden"
-            :disabled="shouldDisableFields"
-            @change="handleImageChange($event)"
-          />
-          <label
-            for="image-upload"
-            class="flex flex-col items-center justify-center w-full h-32 border border-dashed border-rui-grey-300 dark:border-rui-grey-600 rounded-lg cursor-pointer hover:border-rui-primary transition-colors"
-          >
-            <RuiIcon
-              name="lu-upload"
-              size="24"
-              class="mb-2 text-rui-text-secondary"
-            />
-            <span class="text-sm text-rui-text-secondary">{{ t('sponsor.submit_name.upload_image') }}</span>
-            <span class="text-xs text-rui-text-disabled mt-1">{{ t('sponsor.submit_name.image_requirements') }}</span>
-          </label>
-        </div>
-        <div
-          v-else
-          class="relative flex items-start"
-        >
-          <NuxtImg
-            :src="imagePreview"
-            alt="Profile preview"
-            class="w-32 h-32 object-cover rounded-lg mt-3"
-            width="128"
-            height="128"
-          />
-          <RuiButton
-            icon
-            size="sm"
-            color="error"
-            class="-ml-3"
-            :disabled="shouldDisableFields"
-            @click="removeImage()"
-          >
-            <RuiIcon
-              name="lu-x"
-              size="16"
-            />
-          </RuiButton>
-        </div>
-
-        <div
-          v-if="toMessages(v$.imageFile).length > 0"
-          class="pt-1 px-3 text-rui-error text-sm text-caption"
-        >
-          <p
-            v-for="errorMsg in toMessages(v$.imageFile)"
-            :key="errorMsg"
-          >
-            {{ errorMsg }}
-          </p>
-        </div>
-        <div
-          v-else
-          class="pt-1 px-3 text-rui-text-secondary text-sm text-caption"
-        >
-          {{ nftTier === 'silver' ? t('sponsor.submit_name.image_hint_silver') : t('sponsor.submit_name.image_hint_gold') }}
-        </div>
+        <ImageUploadPreview
+          :image-preview="imagePreview"
+          :disabled="shouldDisableFields"
+          :error-messages="toMessages(v$.imageFile)"
+          :hint="nftTier === 'silver' ? t('sponsor.submit_name.image_hint_silver') : t('sponsor.submit_name.image_hint_gold')"
+          @file-selected="handleImageSelected($event)"
+          @remove="removeImage()"
+        />
       </div>
 
       <RuiTextField

--- a/packages/website/app/components/sponsor/NftSubmissionItem.vue
+++ b/packages/website/app/components/sponsor/NftSubmissionItem.vue
@@ -24,7 +24,8 @@ const currentReleaseName = computed(() => get(sponsorshipData)?.releaseName);
     <div class="flex items-start justify-between">
       <div class="flex-1">
         <NftSubmissionItemChips :submission="submission" />
-        <NuxtImg
+        <!-- Plain <img> instead of <NuxtImg> because the src is a backend API URL that the image provider cannot process -->
+        <img
           v-if="submission.imageUrl"
           :src="submission.imageUrl"
           alt="Submission image"

--- a/packages/website/tests/unit/components/sponsor/ImageUploadPreview.spec.ts
+++ b/packages/website/tests/unit/components/sponsor/ImageUploadPreview.spec.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { describe, expect, it } from 'vitest';
+import ImageUploadPreview from '~/components/sponsor/ImageUploadPreview.vue';
+
+describe('imageUploadPreview', () => {
+  it('shows upload area when no image preview is set', async () => {
+    const wrapper = await mountSuspended(ImageUploadPreview);
+
+    expect(wrapper.find('input[type="file"]').exists()).toBe(true);
+    expect(wrapper.find('img').exists()).toBe(false);
+  });
+
+  it('shows image preview with plain img tag when imagePreview is a data URL', async () => {
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    const wrapper = await mountSuspended(ImageUploadPreview, {
+      props: { imagePreview: dataUrl },
+    });
+
+    const img = wrapper.find('img');
+    expect(img.exists()).toBe(true);
+    expect(img.attributes('src')).toBe(dataUrl);
+    expect(img.element.tagName).toBe('IMG');
+    expect(wrapper.find('input[type="file"]').exists()).toBe(false);
+  });
+
+  it('shows image preview with plain img tag when imagePreview is an HTTP URL', async () => {
+    const httpUrl = 'https://example.com/image.png';
+    const wrapper = await mountSuspended(ImageUploadPreview, {
+      props: { imagePreview: httpUrl },
+    });
+
+    const img = wrapper.find('img');
+    expect(img.exists()).toBe(true);
+    expect(img.attributes('src')).toBe(httpUrl);
+  });
+
+  it('emits remove event when remove button is clicked', async () => {
+    const wrapper = await mountSuspended(ImageUploadPreview, {
+      props: { imagePreview: 'data:image/png;base64,abc' },
+    });
+
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('remove')).toHaveLength(1);
+  });
+
+  it('emits file-selected event when a file is chosen', async () => {
+    const wrapper = await mountSuspended(ImageUploadPreview);
+
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+    const input = wrapper.find('input[type="file"]');
+
+    Object.defineProperty(input.element, 'files', {
+      value: [file],
+      writable: false,
+    });
+    await input.trigger('change');
+
+    expect(wrapper.emitted('file-selected')).toHaveLength(1);
+    expect(wrapper.emitted('file-selected')![0]).toEqual([file]);
+  });
+
+  it('displays error messages when provided', async () => {
+    const errors = ['File too large', 'Invalid type'];
+    const wrapper = await mountSuspended(ImageUploadPreview, {
+      props: { errorMessages: errors },
+    });
+
+    const errorTexts = wrapper.findAll('.text-rui-error p');
+    expect(errorTexts).toHaveLength(2);
+    expect(errorTexts.at(0)?.text()).toBe('File too large');
+    expect(errorTexts.at(1)?.text()).toBe('Invalid type');
+  });
+
+  it('displays hint when no errors are present', async () => {
+    const wrapper = await mountSuspended(ImageUploadPreview, {
+      props: { hint: 'Max 5MB, JPEG/PNG/WebP' },
+    });
+
+    expect(wrapper.find('.text-caption.text-rui-text-secondary').text()).toContain('Max 5MB, JPEG/PNG/WebP');
+  });
+
+  it('disables file input when disabled prop is true', async () => {
+    const wrapper = await mountSuspended(ImageUploadPreview, {
+      props: { disabled: true },
+    });
+
+    expect(wrapper.find('input[type="file"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('uses plain img tag instead of NuxtImg to support data URLs', () => {
+    const componentPath = resolve(__dirname, '../../../../app/components/sponsor/ImageUploadPreview.vue');
+    const source = readFileSync(componentPath, 'utf-8');
+
+    // Strip HTML comments, then check that NuxtImg is not used as a tag.
+    // NuxtImg cannot process data URLs from FileReader.
+    const withoutComments = source.replace(/<!--[\S\s]*?-->/g, '');
+    expect(withoutComments).not.toMatch(/<NuxtImg[\s/>]/);
+    expect(withoutComments).not.toMatch(/<nuxt-img[\s/>]/);
+  });
+});


### PR DESCRIPTION
## Summary
- `NuxtImg` cannot process data URLs from `FileReader`, causing broken image previews when uploading sponsor images
- Extracted the image upload/preview section from `NftSubmissionForm` into a dedicated `ImageUploadPreview` component using a plain `<img>` tag
- Added unit tests with a source-level regression guard to prevent `NuxtImg` from being reintroduced

## Test plan
- [x] Unit tests pass (9 tests covering upload area, preview rendering, events, error/hint display, disabled state, and NuxtImg regression guard)
- [ ] Verify on staging that uploading an image in the sponsor submission form shows a correct preview
- [ ] Verify existing submission images still display correctly when editing