### PR TITLE
fix(checkout): optimize pricing table layout to prevent cutoff

### DIFF
--- a/packages/website/app/components/pricings/PricingTable.vue
+++ b/packages/website/app/components/pricings/PricingTable.vue
@@ -19,7 +19,7 @@ const { t } = useI18n({ useScope: 'global' });
   <div
     class="grid relative"
     :style="{
-      gridTemplateColumns: `minmax(195px, 250px) repeat(${plans.length}, minmax(195px, 1fr))`,
+      gridTemplateColumns: `minmax(170px, 230px) repeat(${plans.length}, minmax(160px, 1fr))`,
     }"
   >
     <div />
@@ -48,8 +48,8 @@ const { t } = useI18n({ useScope: 'global' });
             {{ plan.displayedName }}
           </div>
           <template v-if="!isCustomPlan(plan)">
-            <div class="flex flex-wrap items-end gap-x-1">
-              <div class="text-h5 xl:text-h4 font-bold">
+            <div class="flex items-end gap-x-1">
+              <div class="text-h5 xl:text-h4 font-bold whitespace-nowrap">
                 {{ plan.mainPriceDisplay }}
               </div>
               <div

--- a/packages/website/app/pages/checkout/pay.vue
+++ b/packages/website/app/pages/checkout/pay.vue
@@ -63,6 +63,8 @@ const step = computed<number>(() => {
   return index + 1;
 });
 
+const isFirstStep = computed<boolean>(() => get(step) === 1);
+
 const { removeStoredRedirectUrl } = useRedirectUrl();
 
 onBeforeMount(() => {
@@ -72,7 +74,7 @@ onBeforeMount(() => {
 
 <template>
   <div class="container flex flex-col lg:flex-row h-full grow py-4 lg:py-8 gap-6 lg:gap-8">
-    <div class="flex grow overflow-hidden min-w-0">
+    <div class="flex grow overflow-x-auto min-w-0">
       <form
         class="flex flex-col justify-between w-full"
         @submit.prevent
@@ -89,7 +91,10 @@ onBeforeMount(() => {
       </form>
     </div>
 
-    <div class="hidden lg:block w-56 shrink-0 sticky top-8 self-start">
+    <div
+      v-if="!isFirstStep"
+      class="hidden lg:block w-48 shrink-0 sticky top-8 self-start"
+    >
       <RuiStepper
         :step="step"
         :steps="steps"


### PR DESCRIPTION
## Summary
- Hide the stepper sidebar on the plan selection step (step 1) so the pricing comparison table gets the full container width, preventing the Custom plan column from being cut off
- Reduce stepper width from `w-56` to `w-48` on subsequent steps for better space utilization
- Adjust grid column minimums (`minmax(170px, 230px)` / `minmax(160px, 1fr)`) for better distribution
- Prevent price + `/mo` text from wrapping by removing `flex-wrap` and adding `whitespace-nowrap`
- Use `overflow-x-auto` instead of `overflow-hidden` as a safety net

## Test plan
- [ ] Verify `/checkout/pay` at 1920x1080 — all plan columns visible, no cutoff
- [ ] Verify stepper is hidden on step 1, visible on steps 2+
- [ ] Verify prices display inline (e.g. "25.00€ /mo" on one line)
- [ ] Check responsive behavior at smaller breakpoints (table switches to tabs below xl)
- [ ] Verify mobile footer stepper still works on small screens