### PR TITLE
fix: deduplicate subscription and payment API calls on /home

### DIFF
--- a/packages/website/app/composables/account/use-user-payments.ts
+++ b/packages/website/app/composables/account/use-user-payments.ts
@@ -15,7 +15,6 @@ export function useUserPayments(): UseUserPaymentsReturn {
   const {
     data: userPayments,
     error,
-    execute,
     pending: loading,
     refresh,
   } = useLazyAsyncData<UserPayment[]>(
@@ -30,8 +29,9 @@ export function useUserPayments(): UseUserPaymentsReturn {
       return UserPayments.parse(response.result);
     },
     {
+      dedupe: 'defer',
       default: () => [] satisfies UserPayment[],
-      immediate: false,
+      server: false,
     },
   );
 
@@ -40,8 +40,6 @@ export function useUserPayments(): UseUserPaymentsReturn {
       logger.error('Failed to fetch payments:', newError);
     }
   });
-
-  onBeforeMount(execute);
 
   return {
     loading: readonly(loading),

--- a/packages/website/app/composables/subscription/use-user-subscriptions.ts
+++ b/packages/website/app/composables/subscription/use-user-subscriptions.ts
@@ -47,6 +47,7 @@ export function useUserSubscriptions(): UseUserSubscriptionsReturn {
       }
     },
     {
+      dedupe: 'defer',
       default: () => [] satisfies UserSubscription[],
       lazy: false,
       server: false,

--- a/packages/website/app/pages/home/subscription.vue
+++ b/packages/website/app/pages/home/subscription.vue
@@ -12,7 +12,6 @@ import ReferralCode from '~/components/account/home/ReferralCode.vue';
 import { SubscriptionAction } from '~/components/account/home/subscription-table/types';
 import SubscriptionTable from '~/components/account/home/SubscriptionTable.vue';
 import UnverifiedEmailWarning from '~/components/account/home/UnverifiedEmailWarning.vue';
-import { useUserPayments } from '~/composables/account/use-user-payments';
 import { useUserSubscriptions } from '~/composables/subscription/use-user-subscriptions';
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { usePageSeoNoIndex } from '~/composables/use-page-seo';
@@ -31,7 +30,6 @@ const { t } = useI18n({ useScope: 'global' });
 const store = useMainStore();
 const { account } = storeToRefs(store);
 const { userSubscriptions, activeOrPendingSubscription, refresh: refreshSubscriptions, initialLoading: initialSubscriptionsLoading } = useUserSubscriptions();
-const { refresh: refreshPayments } = useUserPayments();
 const { requestRefresh } = useAccountRefresh();
 
 const subscriptionOpsStore = useSubscriptionOperationsStore();
@@ -60,9 +58,8 @@ function dismissSubscriptionError(): void {
   setError('');
 }
 
-onBeforeMount(async () => {
+onBeforeMount(() => {
   requestRefresh();
-  await Promise.all([refreshSubscriptions(), refreshPayments()]);
 });
 </script>
 

--- a/packages/website/app/store/index.ts
+++ b/packages/website/app/store/index.ts
@@ -5,7 +5,7 @@ import { get, isClient, set, useTimeoutFn } from '@vueuse/core';
 import { acceptHMRUpdate, defineStore } from 'pinia';
 import { useAccountApi } from '~/composables/account/use-account-api';
 import { useAuthApi } from '~/composables/account/use-auth-api';
-import { useFetchUserSubscriptions } from '~/composables/subscription/use-fetch-user-subscriptions';
+import { useUserSubscriptions } from '~/composables/subscription/use-user-subscriptions';
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { useAuthHintCookie, useEmailConfirmedCookie, useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { usePendingSubscriptionId } from '~/modules/checkout/composables/use-pending-subscription-id';
@@ -28,7 +28,7 @@ export const useMainStore = defineStore('main', () => {
   // API composables
   const accountApi = useAccountApi();
   const authApi = useAuthApi();
-  const { fetchUserSubscriptions } = useFetchUserSubscriptions();
+  const { userSubscriptions, refresh: refreshSubscriptions } = useUserSubscriptions();
   const { onRefresh } = useAccountRefresh();
 
   const updateCanBuy = async (): Promise<void> => {
@@ -49,7 +49,9 @@ export const useMainStore = defineStore('main', () => {
         return;
       }
 
-      const subscriptions = await fetchUserSubscriptions();
+      // Refresh subscriptions via useAsyncData (deduped with other consumers)
+      await refreshSubscriptions();
+      const subscriptions = get(userSubscriptions);
       if (subscriptions.length === 0) {
         set(canBuy, true);
         clearPendingSubscriptionId();


### PR DESCRIPTION
## Summary

- Remove redundant `refreshSubscriptions()` and `refreshPayments()` calls from subscription page `onBeforeMount` — both composables already auto-fetch on mount via `useAsyncData`/`useLazyAsyncData`
- Replace raw `useFetchUserSubscriptions()` in the main store with `useUserSubscriptions()` so `updateCanBuy` shares the same `useAsyncData('user-subscriptions')` cache instead of making a separate HTTP request
- Add `dedupe: 'defer'` to `useAsyncData` calls in `useUserSubscriptions` and `useUserPayments` to prevent concurrent duplicate requests

## Test plan

- [ ] Navigate to `/home/subscription` and verify only 1 call to `/webapi/2/history/subscriptions` in the network tab (was 3)
- [ ] Verify subscription data still loads correctly (active subscription card, table)
- [ ] Verify payments table still loads
- [ ] Verify `canBuy` state updates correctly after account refresh
- [ ] Verify cancel/resume subscription operations still work