### PR TITLE
fix: add more RPC endpoints for Ethereum and Sepolia

### DIFF
--- a/backend/internal/nft/types.go
+++ b/backend/internal/nft/types.go
@@ -109,10 +109,15 @@ var ChainConfigs = map[string]ChainConfig{
 		"https://ethereum-rpc.publicnode.com",
 		"https://eth.drpc.org",
 		"https://rpc.ankr.com/eth",
+		"https://1rpc.io/eth",
+		"https://eth.llamarpc.com",
 	}},
 	"sepolia": {ChainID: 11155111, RPCURLs: []string{
 		"https://ethereum-sepolia-rpc.publicnode.com",
-		"https://rpc.sepolia.org",
+		"https://1rpc.io/sepolia",
+		"https://eth-sepolia.public.blastapi.io",
+		"https://sepolia.drpc.org",
+		"https://rpc.ankr.com/eth_sepolia",
 	}},
 }
 


### PR DESCRIPTION
## Summary

- Add `1rpc.io` and `llamarpc.com` endpoints for Ethereum mainnet (5 total, was 3)
- Replace unreliable `rpc.sepolia.org` with `1rpc.io`, `blastapi.io`, `drpc.org`, and `ankr.com` for Sepolia (5 total, was 2)

Improves reliability of blockchain calls for NFT tier info and metadata fetching.

## Test plan

- [x] `make check` passes (vet + lint + tests)
- [ ] Deploy and verify tier info loads on Sepolia