### PR TITLE
fix: dynamically switch RPC URLs based on chain from config API

### DIFF
--- a/backend/internal/nft/blockchain.go
+++ b/backend/internal/nft/blockchain.go
@@ -20,6 +20,11 @@ func NewBlockchainService(rpc *RPCClient, logger *slog.Logger) *BlockchainServic
 	}
 }
 
+// UpdateRPCURLs updates the underlying RPC client's URL list.
+func (s *BlockchainService) UpdateRPCURLs(urls []string) {
+	s.rpc.UpdateURLs(urls)
+}
+
 // GetCurrentReleaseID fetches the current release ID from the contract.
 func (s *BlockchainService) GetCurrentReleaseID(ctx context.Context, cfg *Config) (int, error) {
 	// Try multicall first

--- a/backend/internal/nft/blockchain_test.go
+++ b/backend/internal/nft/blockchain_test.go
@@ -1,0 +1,237 @@
+package nft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestBlockchainService_UpdateRPCURLs(t *testing.T) {
+	rpcClient := newTestRPCClient([]string{"http://old.example.com"})
+	svc := NewBlockchainService(rpcClient, slog.Default())
+
+	newURLs := []string{"http://new1.example.com", "http://new2.example.com"}
+	svc.UpdateRPCURLs(newURLs)
+
+	rpcClient.mu.RLock()
+	defer rpcClient.mu.RUnlock()
+	if len(rpcClient.urls) != 2 {
+		t.Fatalf("expected 2 URLs, got %d", len(rpcClient.urls))
+	}
+	if rpcClient.urls[0] != "http://new1.example.com" {
+		t.Errorf("expected new1, got %s", rpcClient.urls[0])
+	}
+}
+
+// rpcHandler returns an HTTP handler that dispatches based on the eth_call "to" address.
+// multicallResult is returned for calls to Multicall3Address.
+// directResult is returned for calls to any other address.
+func rpcHandler(t *testing.T, multicallResult, directResult string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
+		// Extract the "to" field from the JSON-RPC params
+		var req struct {
+			Params []json.RawMessage `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		hexResult := directResult
+		if len(req.Params) > 0 {
+			var callObj map[string]string
+			_ = json.Unmarshal(req.Params[0], &callObj)
+			if strings.EqualFold(callObj["to"], Multicall3Address) {
+				hexResult = multicallResult
+			}
+		}
+
+		resp := rpcResponse{JSONRPC: "2.0", ID: 1}
+		resp.Result, _ = json.Marshal(hexResult)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// mockRPCServer creates an httptest.Server that responds to all eth_calls with the given hex data.
+func mockRPCServer(t *testing.T, hexResult string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := rpcResponse{JSONRPC: "2.0", ID: 1}
+		resp.Result, _ = json.Marshal(hexResult)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestFetchTierInfo_AfterURLSwitch(t *testing.T) {
+	// Server that returns empty for everything (simulates wrong chain)
+	emptySrv := mockRPCServer(t, "0x")
+	defer emptySrv.Close()
+
+	// Server that returns empty for multicall (let it fall back) but valid tier info for direct calls
+	metadataURI := "ipfs://test"
+	validHex := buildTierInfoHex(100, 5, metadataURI)
+	validSrv := httptest.NewServer(rpcHandler(t, "0x", validHex))
+	defer validSrv.Close()
+
+	// Start with the empty (wrong-chain) server
+	rpcClient := newTestRPCClient([]string{emptySrv.URL})
+	blockchainSvc := NewBlockchainService(rpcClient, slog.Default())
+
+	cfg := &Config{
+		ContractAddress: "0x9C4Ac51128b3B29c8c4C76c960a07c17b8290557",
+	}
+
+	// Should fail — empty results from wrong chain
+	info, err := blockchainSvc.FetchTierInfo(context.Background(), cfg, 2, 0)
+	if err == nil && info != nil {
+		t.Fatal("expected failure or nil info from wrong-chain server")
+	}
+
+	// Switch to the correct chain's RPC
+	blockchainSvc.UpdateRPCURLs([]string{validSrv.URL})
+
+	// Should succeed now — multicall returns empty, falls back to direct call which works
+	info, err = blockchainSvc.FetchTierInfo(context.Background(), cfg, 2, 0)
+	if err != nil {
+		t.Fatalf("expected success after URL switch, got: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil tier info")
+	}
+	if info.MaxSupply != 100 {
+		t.Errorf("expected maxSupply=100, got %d", info.MaxSupply)
+	}
+	if info.CurrentSupply != 5 {
+		t.Errorf("expected currentSupply=5, got %d", info.CurrentSupply)
+	}
+	if info.MetadataURI != metadataURI {
+		t.Errorf("expected metadataURI=%q, got %q", metadataURI, info.MetadataURI)
+	}
+}
+
+func TestGetCurrentReleaseID_Success(t *testing.T) {
+	// Return uint256(2) — direct call returns 32 bytes, multicall returns empty
+	hexResult := fmt.Sprintf("0x%064x", 2)
+	srv := httptest.NewServer(rpcHandler(t, "0x", hexResult))
+	defer srv.Close()
+
+	rpcClient := newTestRPCClient([]string{srv.URL})
+	blockchainSvc := NewBlockchainService(rpcClient, slog.Default())
+
+	cfg := &Config{ContractAddress: "0x1234"}
+	releaseID, err := blockchainSvc.GetCurrentReleaseID(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if releaseID != 2 {
+		t.Errorf("expected release ID 2, got %d", releaseID)
+	}
+}
+
+func TestGetCurrentReleaseID_EmptyResponse(t *testing.T) {
+	srv := mockRPCServer(t, "0x")
+	defer srv.Close()
+
+	rpcClient := newTestRPCClient([]string{srv.URL})
+	blockchainSvc := NewBlockchainService(rpcClient, slog.Default())
+
+	cfg := &Config{ContractAddress: "0x1234"}
+	_, err := blockchainSvc.GetCurrentReleaseID(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error for empty response")
+	}
+}
+
+func TestFetchMultipleTierInfo_AllEmpty_FallsBack(t *testing.T) {
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		resp := rpcResponse{JSONRPC: "2.0", ID: 1}
+		resp.Result, _ = json.Marshal("0x")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	rpcClient := newTestRPCClient([]string{srv.URL})
+	blockchainSvc := NewBlockchainService(rpcClient, slog.Default())
+
+	cfg := &Config{ContractAddress: "0x1234"}
+	result, err := blockchainSvc.FetchMultipleTierInfo(context.Background(), cfg, 2, []int{0, 1, 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have entries for all tiers (nil values since server returns empty)
+	if len(result) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(result))
+	}
+	for _, tierID := range []int{0, 1, 2} {
+		if result[tierID] != nil {
+			t.Errorf("expected nil for tier %d, got %+v", tierID, result[tierID])
+		}
+	}
+
+	// At least: 1 batch multicall (empty) + 3 individual tiers × (1 multicall + 1 direct) = 7
+	if callCount.Load() < 4 {
+		t.Errorf("expected at least 4 RPC calls, got %d", callCount.Load())
+	}
+}
+
+func TestFetchTierInfo_DirectCallSuccess(t *testing.T) {
+	// Multicall returns empty, direct call returns valid data
+	metadataURI := "ipfs://bronze"
+	validHex := buildTierInfoHex(100, 5, metadataURI)
+	srv := httptest.NewServer(rpcHandler(t, "0x", validHex))
+	defer srv.Close()
+
+	rpcClient := newTestRPCClient([]string{srv.URL})
+	blockchainSvc := NewBlockchainService(rpcClient, slog.Default())
+
+	cfg := &Config{ContractAddress: "0x1234"}
+	info, err := blockchainSvc.FetchTierInfo(context.Background(), cfg, 2, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil tier info")
+	}
+	if info.MaxSupply != 100 {
+		t.Errorf("expected maxSupply=100, got %d", info.MaxSupply)
+	}
+	if info.CurrentSupply != 5 {
+		t.Errorf("expected currentSupply=5, got %d", info.CurrentSupply)
+	}
+	if info.MetadataURI != metadataURI {
+		t.Errorf("expected metadataURI=%q, got %q", metadataURI, info.MetadataURI)
+	}
+}
+
+// buildTierInfoHex builds an ABI-encoded getTierInfo response.
+// getTierInfo returns (uint256 maxSupply, uint256 currentSupply, string metadataURI)
+func buildTierInfoHex(maxSupply, currentSupply int, metadataURI string) string {
+	data := make([]byte, 0, 256)
+	data = append(data, encodeUint256(maxSupply)...)
+	data = append(data, encodeUint256(currentSupply)...)
+	// String offset: points to byte 96 (3 * 32)
+	data = append(data, encodeUint256(96)...)
+	// String length
+	data = append(data, encodeUint256(len(metadataURI))...)
+	// String data (padded to 32 bytes)
+	strBytes := []byte(metadataURI)
+	padded := make([]byte, ((len(strBytes)+31)/32)*32)
+	copy(padded, strBytes)
+	data = append(data, padded...)
+
+	return "0x" + fmt.Sprintf("%x", data)
+}

--- a/backend/internal/nft/config.go
+++ b/backend/internal/nft/config.go
@@ -100,5 +100,6 @@ func (s *ConfigService) Fetch(ctx context.Context) (*Config, error) {
 		ContractAddress:    raw.ContractAddress,
 		ReleaseID:          raw.ReleaseID,
 		HasContractChanged: hasChanged,
+		RPCURLs:            chainCfg.RPCURLs,
 	}, nil
 }

--- a/backend/internal/nft/config_test.go
+++ b/backend/internal/nft/config_test.go
@@ -1,0 +1,142 @@
+package nft
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConfigServiceFetch_SepoliaChain(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/webapi/nfts/release/current/" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := map[string]any{
+			"chain":            "sepolia",
+			"contract_address": "0x9C4Ac51128b3B29c8c4C76c960a07c17b8290557",
+			"release_id":       2,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc := NewConfigService(srv.URL, false, slog.Default())
+	cfg, err := svc.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ChainID != 11155111 {
+		t.Errorf("expected sepolia chain ID 11155111, got %d", cfg.ChainID)
+	}
+	if cfg.ContractAddress != "0x9C4Ac51128b3B29c8c4C76c960a07c17b8290557" {
+		t.Errorf("unexpected contract address: %s", cfg.ContractAddress)
+	}
+	if cfg.ReleaseID != 2 {
+		t.Errorf("expected release ID 2, got %d", cfg.ReleaseID)
+	}
+	if len(cfg.RPCURLs) == 0 {
+		t.Fatal("expected RPCURLs to be populated from sepolia chain config")
+	}
+	// Verify URLs match the sepolia config
+	sepoliaCfg := ChainConfigs["sepolia"]
+	if len(cfg.RPCURLs) != len(sepoliaCfg.RPCURLs) {
+		t.Errorf("expected %d RPC URLs, got %d", len(sepoliaCfg.RPCURLs), len(cfg.RPCURLs))
+	}
+	for i, url := range cfg.RPCURLs {
+		if url != sepoliaCfg.RPCURLs[i] {
+			t.Errorf("RPC URL[%d] = %s, want %s", i, url, sepoliaCfg.RPCURLs[i])
+		}
+	}
+}
+
+func TestConfigServiceFetch_EthereumChain(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]any{
+			"chain":            "ethereum",
+			"contract_address": "0x1234567890abcdef1234567890abcdef12345678",
+			"release_id":       1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc := NewConfigService(srv.URL, false, slog.Default())
+	cfg, err := svc.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ChainID != 1 {
+		t.Errorf("expected ethereum chain ID 1, got %d", cfg.ChainID)
+	}
+	if len(cfg.RPCURLs) == 0 {
+		t.Fatal("expected RPCURLs to be populated from ethereum chain config")
+	}
+	ethCfg := ChainConfigs["ethereum"]
+	if len(cfg.RPCURLs) != len(ethCfg.RPCURLs) {
+		t.Errorf("expected %d RPC URLs, got %d", len(ethCfg.RPCURLs), len(cfg.RPCURLs))
+	}
+}
+
+func TestConfigServiceFetch_UnsupportedChain(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]any{
+			"chain":            "polygon",
+			"contract_address": "0x1234",
+			"release_id":       1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc := NewConfigService(srv.URL, false, slog.Default())
+	_, err := svc.Fetch(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unsupported chain")
+	}
+}
+
+func TestConfigServiceFetch_DetectsContractChange(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		addr := "0xAAAA"
+		if callCount > 1 {
+			addr = "0xBBBB"
+		}
+		resp := map[string]any{
+			"chain":            "ethereum",
+			"contract_address": addr,
+			"release_id":       1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	svc := NewConfigService(srv.URL, false, slog.Default())
+	ctx := context.Background()
+
+	cfg1, err := svc.Fetch(ctx)
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if cfg1.HasContractChanged {
+		t.Error("first fetch should not report contract changed")
+	}
+
+	cfg2, err := svc.Fetch(ctx)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if !cfg2.HasContractChanged {
+		t.Error("second fetch should report contract changed")
+	}
+}

--- a/backend/internal/nft/core.go
+++ b/backend/internal/nft/core.go
@@ -94,6 +94,11 @@ func (s *CoreService) GetConfig(ctx context.Context) (*Config, error) {
 		return nil, err
 	}
 
+	// Update RPC URLs to match the chain from the config API
+	if len(cfg.RPCURLs) > 0 {
+		s.blockchain.UpdateRPCURLs(cfg.RPCURLs)
+	}
+
 	s.mu.Lock()
 	s.cachedConfig = cfg
 	s.configFetchedAt = time.Now()

--- a/backend/internal/nft/rpc.go
+++ b/backend/internal/nft/rpc.go
@@ -45,6 +45,14 @@ func NewRPCClient(urls []string, logger *slog.Logger) *RPCClient {
 
 const circuitBreakerCooldown = 60 * time.Second
 
+// UpdateURLs replaces the RPC URL list and resets the circuit breaker state.
+func (c *RPCClient) UpdateURLs(urls []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.urls = urls
+	c.failures = make(map[string]time.Time)
+}
+
 // isAvailable checks if an RPC URL is not in circuit breaker cooldown.
 func (c *RPCClient) isAvailable(url string) bool {
 	c.mu.RLock()

--- a/backend/internal/nft/rpc_test.go
+++ b/backend/internal/nft/rpc_test.go
@@ -1,0 +1,192 @@
+package nft
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestRPCClient creates an RPCClient that uses the default HTTP transport
+// (no safedialer) so it can connect to httptest.Server on localhost.
+func newTestRPCClient(urls []string) *RPCClient {
+	return &RPCClient{
+		urls: urls,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+		logger:   slog.Default(),
+		failures: make(map[string]time.Time),
+	}
+}
+
+func TestUpdateURLs_ReplacesURLsAndResetsFailures(t *testing.T) {
+	client := newTestRPCClient([]string{"http://old1.example.com", "http://old2.example.com"})
+
+	// Mark a URL as failed
+	client.markFailed("http://old1.example.com")
+	if client.isAvailable("http://old1.example.com") {
+		t.Fatal("expected old1 to be unavailable after marking failed")
+	}
+
+	// Update URLs
+	newURLs := []string{"http://new1.example.com", "http://new2.example.com"}
+	client.UpdateURLs(newURLs)
+
+	// Verify URLs were replaced
+	client.mu.RLock()
+	defer client.mu.RUnlock()
+	if len(client.urls) != 2 {
+		t.Fatalf("expected 2 URLs, got %d", len(client.urls))
+	}
+	if client.urls[0] != "http://new1.example.com" {
+		t.Errorf("expected new1, got %s", client.urls[0])
+	}
+	if client.urls[1] != "http://new2.example.com" {
+		t.Errorf("expected new2, got %s", client.urls[1])
+	}
+
+	// Verify failures were reset
+	if len(client.failures) != 0 {
+		t.Errorf("expected failures to be empty, got %d entries", len(client.failures))
+	}
+}
+
+func TestUpdateURLs_EmptySlice(t *testing.T) {
+	client := newTestRPCClient([]string{"http://old.example.com"})
+
+	client.UpdateURLs([]string{})
+
+	client.mu.RLock()
+	defer client.mu.RUnlock()
+	if len(client.urls) != 0 {
+		t.Errorf("expected 0 URLs, got %d", len(client.urls))
+	}
+}
+
+func TestEthCall_UsesUpdatedURLs(t *testing.T) {
+	// Start a mock RPC server that returns a valid response
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		val := fmt.Sprintf("0x%064x", 42)
+		resp := rpcResponse{JSONRPC: "2.0", ID: 1}
+		resp.Result, _ = json.Marshal(val)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	// Start with a bad URL (port 1 — nothing listens there)
+	client := newTestRPCClient([]string{"http://127.0.0.1:1"})
+
+	// This should fail since the URL is unreachable
+	_, err := client.EthCall(context.Background(), "0x1234", []byte{0x01})
+	if err == nil {
+		t.Fatal("expected error with bad URL")
+	}
+
+	// Update to the working mock server
+	client.UpdateURLs([]string{srv.URL})
+
+	// Now it should succeed
+	result, err := client.EthCall(context.Background(), "0x1234", []byte{0x01})
+	if err != nil {
+		t.Fatalf("expected success after URL update, got: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call to mock server, got %d", callCount)
+	}
+}
+
+func TestEthCall_FallbackOnFailure(t *testing.T) {
+	// First server always fails
+	failSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failSrv.Close()
+
+	// Second server succeeds
+	okSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		val := fmt.Sprintf("0x%064x", 1)
+		resp := rpcResponse{JSONRPC: "2.0", ID: 1}
+		resp.Result, _ = json.Marshal(val)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer okSrv.Close()
+
+	client := newTestRPCClient([]string{failSrv.URL, okSrv.URL})
+
+	result, err := client.EthCall(context.Background(), "0x1234", []byte{0x01})
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result from fallback")
+	}
+}
+
+func TestEthCall_EmptyHexResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := rpcResponse{JSONRPC: "2.0", ID: 1}
+		resp.Result, _ = json.Marshal("0x")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestRPCClient([]string{srv.URL})
+
+	result, err := client.EthCall(context.Background(), "0x1234", []byte{0x01})
+	if err != nil {
+		t.Fatalf("expected nil result without error for empty hex, got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result for empty hex response, got: %s", hex.EncodeToString(result))
+	}
+}
+
+func TestEthCall_RPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"error":   map[string]any{"code": -32000, "message": "execution reverted"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestRPCClient([]string{srv.URL})
+
+	_, err := client.EthCall(context.Background(), "0x1234", []byte{0x01})
+	if err == nil {
+		t.Fatal("expected error for RPC error response")
+	}
+	if !strings.Contains(err.Error(), "execution reverted") {
+		t.Errorf("expected 'execution reverted' in error, got: %v", err)
+	}
+}
+
+func TestEthCall_NoEndpoints(t *testing.T) {
+	client := newTestRPCClient([]string{})
+
+	_, err := client.EthCall(context.Background(), "0x1234", []byte{0x01})
+	if err == nil {
+		t.Fatal("expected error with no endpoints")
+	}
+	if !strings.Contains(err.Error(), "no RPC endpoints available") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/backend/internal/nft/types.go
+++ b/backend/internal/nft/types.go
@@ -2,10 +2,11 @@ package nft
 
 // Config holds the NFT contract configuration fetched from the backend API.
 type Config struct {
-	ChainID            int    `json:"chain_id"`
-	ContractAddress    string `json:"contract_address"`
-	ReleaseID          int    `json:"release_id"`
-	HasContractChanged bool   `json:"has_contract_changed"`
+	ChainID            int      `json:"chain_id"`
+	ContractAddress    string   `json:"contract_address"`
+	ReleaseID          int      `json:"release_id"`
+	HasContractChanged bool     `json:"has_contract_changed"`
+	RPCURLs            []string `json:"-"` // populated from ChainConfigs lookup, not serialized
 }
 
 // TierInfo holds raw blockchain tier data.


### PR DESCRIPTION
## Summary
- The `RPCClient` was initialized at startup with hardcoded ethereum mainnet RPCs, but the config API (`/webapi/nfts/release/current/`) can return a different chain (e.g. `sepolia`). This caused all NFT blockchain calls to return empty data since the contract was unreachable on the wrong network.
- Added `RPCURLs` to the `Config` struct (populated from `ChainConfigs` lookup), `UpdateURLs()` to `RPCClient`, and wired it into `CoreService.GetConfig()` so RPC URLs automatically match the chain from the backend API.
- Added comprehensive tests for RPC client URL switching, config service chain resolution, and blockchain service fallback behavior (15 new tests across 3 test files).

## Test plan
- [x] `make check` passes (0 lint issues, all tests green)
- [ ] Deploy and verify `/api/nft/tier-info?tierIds=0,1,2` returns tier data when config API returns `chain: "sepolia"`
- [ ] Verify chain switch from ethereum to sepolia (and vice versa) works without restart