### PR TITLE
fix(seo): improve SEO metadata, canonical URLs, and search coverage

### DIFF
--- a/backend/internal/api/routing/routes.go
+++ b/backend/internal/api/routing/routes.go
@@ -101,19 +101,26 @@ func Register(mux *http.ServeMux, cfg *config.Config, logger *slog.Logger, mem *
 // robotsTxtHandler returns a handler that serves a pre-built robots.txt.
 func robotsTxtHandler(cfg *config.Config) http.HandlerFunc {
 	disallowPaths := []string{
-		"/account",
-		"/account/**",
-		"/purchase",
-		"/purchase/**",
-		"/checkout",
-		"/checkout/**",
-		"/activate",
+		"/home/",
+		"/checkout/pay/method",
+		"/checkout/pay/card",
+		"/checkout/pay/crypto",
+		"/checkout/pay/paypal",
+		"/checkout/pay/3d-secure",
+		"/checkout/pay/request-crypto",
+		"/checkout/success",
 		"/login",
 		"/logout",
-		"/login/**",
-		"/logout/**",
-		"/auth",
-		"/auth/**",
+		"/signup",
+		"/activate/",
+		"/activation",
+		"/auth/",
+		"/oauth/",
+		"/password/",
+		"/health",
+		"/maintenance",
+		"/account-deleted",
+		"/sponsor/submit-name",
 	}
 
 	var b strings.Builder

--- a/backend/internal/api/routing/routes_test.go
+++ b/backend/internal/api/routing/routes_test.go
@@ -41,7 +41,7 @@ func TestRobotsTxt(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	for _, s := range []string{"Disallow: /checkout", "Sitemap:"} {
+	for _, s := range []string{"Disallow: /checkout/pay/method", "Disallow: /login", "Disallow: /health", "Sitemap:"} {
 		if !strings.Contains(body, s) {
 			t.Errorf("expected body to contain %q, got:\n%s", s, body)
 		}

--- a/packages/website/app/components/documents/MarkdownContent.vue
+++ b/packages/website/app/components/documents/MarkdownContent.vue
@@ -1,20 +1,10 @@
 <script lang="ts" setup>
-import { get } from '@vueuse/shared';
-import { usePageSeo } from '~/composables/use-page-seo';
-
 const { path } = defineProps<{ path: string }>();
 
 const { data: document } = await useAsyncData(path, () => queryCollection('documents').path(path).first(), { dedupe: 'defer' });
 
 if (!document) {
   showError({ message: `Page not found: ${path}`, status: 404 });
-}
-else {
-  usePageSeo(
-    get(document)?.title ?? '',
-    get(document)?.description ?? '',
-    path,
-  );
 }
 </script>
 

--- a/packages/website/app/composables/use-page-seo.ts
+++ b/packages/website/app/composables/use-page-seo.ts
@@ -8,6 +8,13 @@ interface PageSeoOptions {
 }
 
 /**
+ * Strips trailing slashes from a path, except for the root path "/".
+ */
+function normalizePath(path: string): string {
+  return path === '/' ? path : path.replace(/\/+$/, '');
+}
+
+/**
  * Sets full page SEO metadata including Open Graph and Twitter tags.
  */
 export function usePageSeo(
@@ -17,7 +24,8 @@ export function usePageSeo(
   options?: PageSeoOptions,
 ): void {
   const { public: { baseUrl } } = useRuntimeConfig();
-  const url = `${baseUrl}${path}`;
+  const normalizedPath = normalizePath(path);
+  const url = `${baseUrl}${normalizedPath}`;
   const imageUrl = `${baseUrl}/img/og/${options?.ogImage ?? 'share.png'}`;
 
   useSeoMeta({
@@ -32,11 +40,14 @@ export function usePageSeo(
     twitterTitle: title,
     twitterDescription: description,
     twitterImage: imageUrl,
-    ...(options?.noIndex && { robots: 'noindex' }),
+    ...(options?.noIndex && { robots: 'noindex, nofollow' }),
     ...(options?.keywords && { keywords: options.keywords }),
   });
 
   useHead({
+    ...(!options?.noIndex && {
+      link: [{ rel: 'canonical', href: url }],
+    }),
     meta: [
       { property: 'twitter:url', content: url },
     ],
@@ -50,7 +61,7 @@ export function usePageSeo(
 export function usePageSeoNoIndex(title: MaybeRefOrGetter<string>): void {
   useSeoMeta({
     title,
-    robots: 'noindex',
+    robots: 'noindex, nofollow',
   });
 
   useHead({ ...commonAttrs() });

--- a/packages/website/app/pages/checkout/pay/index.vue
+++ b/packages/website/app/pages/checkout/pay/index.vue
@@ -22,7 +22,11 @@ const ROUTES = {
 
 const { public: { baseUrl } } = useRuntimeConfig();
 
-usePageSeo('Pricing', 'Pricing page for rotki subscription', '/checkout/pay');
+usePageSeo(
+  'Pricing',
+  'Compare rotki premium plans — encrypted backups, multi-device sync, ETH staking tracking, detailed graphs, and more. Starting free.',
+  '/checkout/pay',
+);
 
 useHead({
   script: [{

--- a/packages/website/app/pages/download.vue
+++ b/packages/website/app/pages/download.vue
@@ -8,7 +8,31 @@ import DownloadUpgradeNudge from '~/components/download/DownloadUpgradeNudge.vue
 import { useAppDownload } from '~/composables/use-app-download';
 import { usePageSeo } from '~/composables/use-page-seo';
 
-usePageSeo('Download', 'Download rotki', '/download');
+usePageSeo(
+  'Download',
+  'Download rotki for Linux, macOS, or Windows. Free, open-source portfolio tracking and accounting software that protects your privacy.',
+  '/download',
+);
+
+const { public: { baseUrl } } = useRuntimeConfig();
+useHead({
+  script: [{
+    type: 'application/ld+json',
+    innerHTML: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      'name': 'rotki',
+      'applicationCategory': 'FinanceApplication',
+      'operatingSystem': 'Windows, macOS, Linux',
+      'url': `${baseUrl}/download`,
+      'offers': {
+        '@type': 'Offer',
+        'price': '0',
+        'priceCurrency': 'EUR',
+      },
+    }),
+  }],
+});
 
 const {
   version,

--- a/packages/website/app/pages/health.vue
+++ b/packages/website/app/pages/health.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+import { usePageSeoNoIndex } from '~/composables/use-page-seo';
+
+usePageSeoNoIndex('Health');
+
 const message = 'OK';
 </script>
 

--- a/packages/website/app/pages/impressum.vue
+++ b/packages/website/app/pages/impressum.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 import MarkdownContent from '~/components/documents/MarkdownContent.vue';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+usePageSeo(
+  'Impressum',
+  'Legal disclosure (Impressum) for Rotki Solutions GmbH.',
+  '/impressum',
+);
 
 definePageMeta({
   landing: true,

--- a/packages/website/app/pages/index.vue
+++ b/packages/website/app/pages/index.vue
@@ -17,6 +17,19 @@ privacy,opensource,accounting,asset-management,taxes,tax-reporting`;
 usePageSeo('rotki', description, '', { keywords });
 useHead({ titleTemplate: '' });
 
+const { public: { baseUrl } } = useRuntimeConfig();
+useHead({
+  script: [{
+    type: 'application/ld+json',
+    innerHTML: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      'name': 'rotki',
+      'url': baseUrl,
+    }),
+  }],
+});
+
 const { fetchMessages, activeDashboardMessages } = useDynamicMessages();
 
 onBeforeMount(() => {

--- a/packages/website/app/pages/integrations.vue
+++ b/packages/website/app/pages/integrations.vue
@@ -4,7 +4,11 @@ import { usePageSeo } from '~/composables/use-page-seo';
 
 const { t } = useI18n({ useScope: 'global' });
 
-usePageSeo('Integrations', 'Supported blockchains, exchanges, and protocols in rotki', '/integrations/');
+usePageSeo(
+  'Integrations',
+  'Explore the blockchains, exchanges, and DeFi protocols supported by rotki for seamless crypto portfolio tracking.',
+  '/integrations',
+);
 
 definePageMeta({
   landing: true,

--- a/packages/website/app/pages/jobs/[id].vue
+++ b/packages/website/app/pages/jobs/[id].vue
@@ -21,6 +21,26 @@ else {
   };
 
   usePageSeo(meta.title, meta.description, path);
+
+  if (open) {
+    useHead({
+      script: [{
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'JobPosting',
+          'title': title,
+          'description': description,
+          'hiringOrganization': {
+            '@type': 'Organization',
+            'name': 'Rotki Solutions GmbH',
+            'sameAs': 'https://rotki.com',
+          },
+          'jobLocationType': 'TELECOMMUTE',
+        }),
+      }],
+    });
+  }
 }
 
 definePageMeta({

--- a/packages/website/app/pages/privacy-policy.vue
+++ b/packages/website/app/pages/privacy-policy.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 import MarkdownContent from '~/components/documents/MarkdownContent.vue';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+usePageSeo(
+  'Privacy Policy',
+  'rotki privacy policy — how we collect, use, and protect your personal data.',
+  '/privacy-policy',
+);
 
 definePageMeta({
   landing: true,

--- a/packages/website/app/pages/products/index.vue
+++ b/packages/website/app/pages/products/index.vue
@@ -9,7 +9,11 @@ import ProductsTimeframe from '~/components/products/ProductsTimeframe.vue';
 import ProductsUnlockNudge from '~/components/products/ProductsUnlockNudge.vue';
 import { usePageSeo } from '~/composables/use-page-seo';
 
-usePageSeo('Premium Subscription', 'Features included with a premium rotki subscription', '/products/');
+usePageSeo(
+  'Premium Subscription',
+  'Discover rotki premium features — encrypted data backups, multi-device sync, ETH staking tracking, detailed graphs, and more.',
+  '/products',
+);
 
 definePageMeta({
   landing: true,

--- a/packages/website/app/pages/refund-policy.vue
+++ b/packages/website/app/pages/refund-policy.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 import MarkdownContent from '~/components/documents/MarkdownContent.vue';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+usePageSeo(
+  'Refund Policy',
+  'Refund policy for rotki premium subscriptions — conditions, timeframes, and how to request a refund.',
+  '/refund-policy',
+);
 
 definePageMeta({
   landing: true,

--- a/packages/website/app/pages/sponsor/submit-name.vue
+++ b/packages/website/app/pages/sponsor/submit-name.vue
@@ -5,10 +5,10 @@ import NftSubmissionForm from '~/components/sponsor/NftSubmissionForm.vue';
 import NftSubmissionsList from '~/components/sponsor/NftSubmissionsList.vue';
 import SponsorWalletConnectionCard from '~/components/sponsor/SponsorWalletConnectionCard.vue';
 import { useNftSubmissions } from '~/composables/rotki-sponsorship/use-nft-submissions';
-import { usePageSeo } from '~/composables/use-page-seo';
+import { usePageSeoNoIndex } from '~/composables/use-page-seo';
 import { useWeb3Connection } from '~/composables/web3/use-web3-connection';
 
-usePageSeo('Submit Sponsor Name', 'Submit your name or logo to display in rotki as a sponsor. Connect your wallet and manage your NFT submissions.', '/sponsor/submit-name');
+usePageSeoNoIndex('Submit Sponsor Name');
 
 definePageMeta({
   layout: 'sponsor',

--- a/packages/website/app/pages/tos.vue
+++ b/packages/website/app/pages/tos.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 import MarkdownContent from '~/components/documents/MarkdownContent.vue';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+usePageSeo(
+  'Terms of Service',
+  'Terms of service for rotki premium subscriptions and use of rotki.com.',
+  '/tos',
+);
 
 definePageMeta({
   landing: true,

--- a/packages/website/app/pages/values.vue
+++ b/packages/website/app/pages/values.vue
@@ -5,7 +5,11 @@ import ValueHeading from '~/components/values/ValueHeading.vue';
 import ValueVision from '~/components/values/ValueVision.vue';
 import { usePageSeo } from '~/composables/use-page-seo';
 
-usePageSeo('Our Values', 'Values of rotki', '/values');
+usePageSeo(
+  'Our Values',
+  'The core values behind rotki — privacy, transparency, open source, and putting users first in crypto portfolio management.',
+  '/values',
+);
 
 definePageMeta({
   landing: true,

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -6,14 +6,14 @@ const buildId = process.env.GIT_SHA?.slice(0, 8) || Date.now();
 
 const nonIndexed = [
   '/activation',
-  '/home',
-  '/blank',
+  '/home/**',
   '/maintenance',
   '/health',
-  '/password/changed',
-  '/password/send',
-  '/password/reset',
-  '/checkout/pay',
+  '/login',
+  '/logout',
+  '/signup',
+  '/activate/**',
+  '/password/**',
   '/checkout/pay/method',
   '/checkout/pay/card',
   '/checkout/pay/3d-secure',
@@ -22,12 +22,14 @@ const nonIndexed = [
   '/checkout/pay/request-crypto',
   '/checkout/success',
   '/account-deleted',
+  '/sponsor/submit-name',
   '/md/',
   '/documents/',
   '/api/**',
   '/_nuxt/**',
   '/testimonials/**',
   '/oauth/**',
+  '/auth/**',
 ];
 
 export default defineNuxtConfig({


### PR DESCRIPTION
## Summary

- **Legal pages SEO**: Add `usePageSeo()` to privacy-policy, tos, refund-policy, and impressum (previously had zero meta tags)
- **Canonical URLs**: Emit `<link rel="canonical">` on all indexable pages via `usePageSeo`, with trailing slash normalization
- **robots.txt**: Remove dead routes (`/account`, `/purchase`), add missing private routes (`/home/`, `/signup`, `/activation`, `/password/`, `/health`, `/maintenance`, `/oauth/`, etc.), keep `/checkout/pay` crawlable as the pricing page
- **Sitemap exclusions**: Align with robots.txt — use glob patterns, remove `/blank` (page deleted), remove `/checkout/pay` from exclusion
- **noindex upgrade**: `noindex` → `noindex, nofollow` on all private pages
- **Meta descriptions**: Improve thin descriptions on download, values, pricing, integrations, and products pages
- **Structured data**: Add `WebSite` JSON-LD (homepage), `SoftwareApplication` (download), `JobPosting` (open job details)
- **Cleanup**: Switch `sponsor/submit-name` to `usePageSeoNoIndex`, remove duplicate `usePageSeo` from `MarkdownContent` component (pages now own their own SEO)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (126 tests)
- [x] `cd backend && make check` passes (all Go tests)
- [x] Verified in browser: legal pages have title, description, OG tags, canonical
- [x] Verified canonical URLs have no trailing slashes
- [x] Verified noindex pages have `noindex, nofollow` and no canonical
- [x] Verified JSON-LD present on homepage, download, pricing pages
- [x] Verified `/checkout/pay` is indexable (no robots meta)