### PR TITLE
feat: add frontend payment error logging for observability

### DIFF
--- a/backend/internal/api/paymentlog/handler.go
+++ b/backend/internal/api/paymentlog/handler.go
@@ -1,0 +1,146 @@
+// Package paymentlog handles frontend payment error event logging.
+// Events are logged as structured JSON for Grafana/Loki ingestion.
+// No PII is collected — no IPs, no user/session identifiers.
+package paymentlog
+
+import (
+	"log/slog"
+	"mime"
+	"net/http"
+	"time"
+
+	"github.com/rotki/rotki.com/backend/internal/validate"
+)
+
+const maxBodySize = 4096 // 4 KB
+
+// Allowed payment methods.
+var allowedMethods = map[string]bool{
+	"card":   true,
+	"paypal": true,
+	"crypto": true,
+}
+
+// Allowed event names.
+var allowedEvents = map[string]bool{
+	"braintree_init_failed":      true,
+	"3ds_verification_failed":    true,
+	"3ds_liability_shift_failed": true,
+	"card_payment_api_error":     true,
+	"paypal_sdk_init_failed":     true,
+	"paypal_payment_error":       true,
+	"paypal_submit_error":        true,
+	"crypto_wrong_chain":         true,
+	"crypto_tx_failed":           true,
+	"crypto_payment_api_error":   true,
+	"checkout_error":             true,
+}
+
+// Allowed step values.
+var allowedSteps = map[string]bool{
+	"init":     true,
+	"verify":   true,
+	"submit":   true,
+	"callback": true,
+}
+
+// event is the request body for a payment error event.
+type event struct {
+	PaymentMethod string `json:"payment_method"`
+	Event         string `json:"event"`
+	ErrorMessage  string `json:"error_message"`
+	ErrorCode     string `json:"error_code,omitempty"`
+	PlanID        *int   `json:"plan_id,omitempty"`
+	Step          string `json:"step,omitempty"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+// Handler logs frontend payment error events.
+type Handler struct {
+	logger *slog.Logger
+}
+
+// NewHandler creates a new payment logging handler.
+func NewHandler(logger *slog.Logger) *Handler {
+	return &Handler{
+		logger: logger.With("handler", "paymentlog"),
+	}
+}
+
+// ServeHTTP handles POST /api/logging/payment.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Enforce Content-Type (accept "application/json" with optional params like charset)
+	mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if mediaType != "application/json" {
+		http.Error(w, "unsupported content type", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	// Read and parse body
+	var ev event
+	if err := validate.ReadJSONBody(r, &ev, maxBodySize); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	// Validate — generic 400 for all failures (avoids allowlist enumeration)
+	if !h.isValid(&ev) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	// Sanitize free-text fields
+	ev.ErrorMessage = validate.SanitizeString(ev.ErrorMessage, 500)
+	ev.ErrorCode = validate.SanitizeString(ev.ErrorCode, 32)
+
+	// Log as structured event
+	attrs := []any{
+		"payment_method", ev.PaymentMethod,
+		"event", ev.Event,
+		"error_message", ev.ErrorMessage,
+		"timestamp", ev.Timestamp,
+	}
+	if ev.ErrorCode != "" {
+		attrs = append(attrs, "error_code", ev.ErrorCode)
+	}
+	if ev.PlanID != nil {
+		attrs = append(attrs, "plan_id", *ev.PlanID)
+	}
+	if ev.Step != "" {
+		attrs = append(attrs, "step", ev.Step)
+	}
+
+	h.logger.Info("payment_event", attrs...)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// isValid checks all fields against allowlists and constraints.
+func (h *Handler) isValid(ev *event) bool {
+	if !allowedMethods[ev.PaymentMethod] {
+		return false
+	}
+	if !allowedEvents[ev.Event] {
+		return false
+	}
+	if ev.ErrorMessage == "" {
+		return false
+	}
+	if ev.Step != "" && !allowedSteps[ev.Step] {
+		return false
+	}
+	if ev.Timestamp == 0 {
+		return false
+	}
+
+	// Timestamp must be within reasonable range: not >5min in future, not >1hr in past
+	now := time.Now().UnixMilli()
+	fiveMinFuture := now + 5*60*1000
+	oneHourPast := now - 60*60*1000
+
+	if ev.Timestamp > fiveMinFuture || ev.Timestamp < oneHourPast {
+		return false
+	}
+
+	return true
+}

--- a/backend/internal/api/paymentlog/handler_test.go
+++ b/backend/internal/api/paymentlog/handler_test.go
@@ -1,0 +1,337 @@
+package paymentlog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func validEvent() event {
+	return event{
+		PaymentMethod: "card",
+		Event:         "braintree_init_failed",
+		ErrorMessage:  "Client initialization failed",
+		Timestamp:     time.Now().UnixMilli(),
+	}
+}
+
+func makeRequest(t *testing.T, ev event) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/logging/payment", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestHandler_ValidEvent(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	req := makeRequest(t, ev)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_ValidEventWithOptionalFields(t *testing.T) {
+	h := NewHandler(testLogger())
+	planID := 42
+	ev := validEvent()
+	ev.ErrorCode = "500"
+	ev.PlanID = &planID
+	ev.Step = "submit"
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_AllPaymentMethods(t *testing.T) {
+	h := NewHandler(testLogger())
+
+	methods := map[string]string{
+		"card":   "braintree_init_failed",
+		"paypal": "paypal_sdk_init_failed",
+		"crypto": "crypto_tx_failed",
+	}
+
+	for method, evt := range methods {
+		t.Run(method, func(t *testing.T) {
+			ev := validEvent()
+			ev.PaymentMethod = method
+			ev.Event = evt
+
+			req := makeRequest(t, ev)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusNoContent {
+				t.Errorf("expected 204 for %s, got %d", method, w.Code)
+			}
+		})
+	}
+}
+
+func TestHandler_UnknownPaymentMethod(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.PaymentMethod = "bitcoin"
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_UnknownEvent(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.Event = "custom_event"
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_UnknownStep(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.Step = "finalize"
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_EmptyErrorMessage(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.ErrorMessage = ""
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_MissingTimestamp(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.Timestamp = 0
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_TimestampTooFarInFuture(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.Timestamp = time.Now().Add(10 * time.Minute).UnixMilli()
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_TimestampTooOld(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.Timestamp = time.Now().Add(-2 * time.Hour).UnixMilli()
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_WrongContentType(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	body, _ := json.Marshal(ev)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/logging/payment", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "text/plain")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("expected 415, got %d", w.Code)
+	}
+}
+
+func TestHandler_ContentTypeWithCharset(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	body, _ := json.Marshal(ev)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/logging/payment", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204 for charset variant, got %d", w.Code)
+	}
+}
+
+func TestHandler_BodyTooLarge(t *testing.T) {
+	h := NewHandler(testLogger())
+	largeBody := make([]byte, maxBodySize+100)
+	for i := range largeBody {
+		largeBody[i] = 'a'
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/logging/payment", bytes.NewReader(largeBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_InvalidJSON(t *testing.T) {
+	h := NewHandler(testLogger())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/logging/payment", strings.NewReader("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_UnknownFieldsRejected(t *testing.T) {
+	h := NewHandler(testLogger())
+	body := `{"payment_method":"card","event":"braintree_init_failed","error_message":"test","timestamp":` +
+		strings.TrimRight(strings.TrimLeft(json.Number(time.Now().Format("20060102150405")).String(), "\""), "\"") +
+		`,"extra_field":"evil"}`
+
+	// Build proper JSON with current timestamp
+	ev := map[string]any{
+		"payment_method": "card",
+		"event":          "braintree_init_failed",
+		"error_message":  "test",
+		"timestamp":      time.Now().UnixMilli(),
+		"extra_field":    "should be rejected",
+	}
+	data, _ := json.Marshal(ev)
+	_ = body // unused, using data instead
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/logging/payment", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown fields, got %d", w.Code)
+	}
+}
+
+func TestHandler_ErrorMessageSanitized(t *testing.T) {
+	// This test verifies the handler doesn't crash with control characters.
+	// Actual sanitization is tested in validate package.
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.ErrorMessage = "error\x00with\nnewlines\rand\ttabs"
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestHandler_AllEvents(t *testing.T) {
+	h := NewHandler(testLogger())
+
+	for evt := range allowedEvents {
+		t.Run(evt, func(t *testing.T) {
+			ev := validEvent()
+			ev.Event = evt
+
+			req := makeRequest(t, ev)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusNoContent {
+				t.Errorf("expected 204 for event %s, got %d", evt, w.Code)
+			}
+		})
+	}
+}
+
+func TestHandler_AllSteps(t *testing.T) {
+	h := NewHandler(testLogger())
+
+	for step := range allowedSteps {
+		t.Run(step, func(t *testing.T) {
+			ev := validEvent()
+			ev.Step = step
+
+			req := makeRequest(t, ev)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusNoContent {
+				t.Errorf("expected 204 for step %s, got %d", step, w.Code)
+			}
+		})
+	}
+}

--- a/backend/internal/api/routing/routes.go
+++ b/backend/internal/api/routing/routes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rotki/rotki.com/backend/internal/api/ens"
 	nftapi "github.com/rotki/rotki.com/backend/internal/api/nft"
 	"github.com/rotki/rotki.com/backend/internal/api/oauth"
+	"github.com/rotki/rotki.com/backend/internal/api/paymentlog"
 	"github.com/rotki/rotki.com/backend/internal/api/releases"
 	"github.com/rotki/rotki.com/backend/internal/api/webhooks"
 	"github.com/rotki/rotki.com/backend/internal/cache"
@@ -44,6 +45,9 @@ func Register(mux *http.ServeMux, cfg *config.Config, logger *slog.Logger, mem *
 
 	// CSP violation reporting
 	mux.Handle("POST /api/csp/violation", csp.NewHandler(logger))
+
+	// Payment error logging (frontend observability, no PII)
+	mux.Handle("POST /api/logging/payment", paymentlog.NewHandler(logger))
 
 	// GitHub releases
 	releasesHandler := releases.NewHandler(mem, red, lck, logger)

--- a/packages/website/app/modules/checkout/components/crypto/CryptoPayment.vue
+++ b/packages/website/app/modules/checkout/components/crypto/CryptoPayment.vue
@@ -7,6 +7,7 @@ import CryptoPaymentActions from '~/modules/checkout/components/crypto/CryptoPay
 import CryptoPaymentForm from '~/modules/checkout/components/crypto/CryptoPaymentForm.vue';
 import { useCheckout } from '~/modules/checkout/composables/use-checkout';
 import { useCryptoPaymentFlow } from '~/modules/checkout/composables/use-crypto-payment-flow';
+import { PaymentMethods } from '~/modules/checkout/composables/use-payment-logger';
 import { PAYMENT_COMPLETED_KEY } from '~/modules/checkout/constants';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -43,7 +44,7 @@ const {
 const loading = computed<boolean>(() => get(checkoutLoading) || get(flowLoading));
 
 function handleWeb3Error(message: string): void {
-  setError(t('subscription.error.payment_failure'), message);
+  setError(t('subscription.error.payment_failure'), message, PaymentMethods.CRYPTO);
 }
 
 async function initialize(): Promise<boolean> {
@@ -75,7 +76,7 @@ async function initialize(): Promise<boolean> {
     const errorMsg = result.isUnverified
       ? t('subscription.error.unverified_email')
       : result.error || t('subscription.error.payment_failure');
-    setError(t('subscription.error.payment_failure'), errorMsg);
+    setError(t('subscription.error.payment_failure'), errorMsg, PaymentMethods.CRYPTO);
     return false;
   }
 
@@ -106,7 +107,7 @@ async function handlePlanChange(newPlan: SelectedPlan): Promise<void> {
   });
 
   if (!result.success) {
-    setError(t('subscription.error.payment_failure'), result.error || 'Failed to switch plan');
+    setError(t('subscription.error.payment_failure'), result.error || 'Failed to switch plan', PaymentMethods.CRYPTO);
   }
 }
 
@@ -121,7 +122,7 @@ async function handleCancelAndGoBack(): Promise<void> {
   setLoading(false);
 
   if (!result.success) {
-    setError(t('subscription.error.cancel_failed'), result.error || 'Failed to cancel');
+    setError(t('subscription.error.cancel_failed'), result.error || 'Failed to cancel', PaymentMethods.CRYPTO);
     return;
   }
 

--- a/packages/website/app/modules/checkout/components/paypal/PaypalPayment.vue
+++ b/packages/website/app/modules/checkout/components/paypal/PaypalPayment.vue
@@ -7,6 +7,7 @@ import OrderSummaryCard from '~/modules/checkout/components/common/OrderSummaryC
 import PaymentLayout from '~/modules/checkout/components/common/PaymentLayout.vue';
 import ServerErrorOverlay from '~/modules/checkout/components/common/ServerErrorOverlay.vue';
 import { useCheckout } from '~/modules/checkout/composables/use-checkout';
+import { PaymentMethods } from '~/modules/checkout/composables/use-payment-logger';
 import { usePaypalPaymentFlow } from '~/modules/checkout/composables/use-paypal-payment-flow';
 import { useReferralCodeParam, useSubscriptionIdParam } from '~/modules/checkout/composables/use-plan-params';
 import { PAYMENT_COMPLETED_KEY } from '~/modules/checkout/constants';
@@ -55,13 +56,13 @@ const processing = computed<boolean>(() => get(paying) || get(checkoutLoading) |
 async function initialize(): Promise<boolean> {
   const hasPlans = await ensureInitialized();
   if (!hasPlans) {
-    setError(t('subscription.error.init_error'), t('subscription.error.no_plan_selected'));
+    setError(t('subscription.error.init_error'), t('subscription.error.no_plan_selected'), PaymentMethods.PAYPAL);
     return false;
   }
 
   const token = get(braintreeToken);
   if (!token) {
-    setError(t('subscription.error.init_error'), t('subscription.error.payment_init_failed'));
+    setError(t('subscription.error.init_error'), t('subscription.error.payment_init_failed'), PaymentMethods.PAYPAL);
     return false;
   }
 
@@ -71,7 +72,7 @@ async function initialize(): Promise<boolean> {
 
   const result = await initializeSdk(token, amount);
   if (!result.success) {
-    setError(t('subscription.error.init_error'), result.error || t('subscription.error.payment_init_failed'));
+    setError(t('subscription.error.init_error'), result.error || t('subscription.error.payment_init_failed'), PaymentMethods.PAYPAL);
     return false;
   }
 
@@ -82,7 +83,7 @@ async function initialize(): Promise<boolean> {
         await handleSubmitPayment(nonce);
       },
       onPaymentError: (errorMsg) => {
-        setError(t('subscription.error.payment_failure'), errorMsg);
+        setError(t('subscription.error.payment_failure'), errorMsg, PaymentMethods.PAYPAL);
       },
       onPaymentCancel: () => {},
     },
@@ -96,7 +97,7 @@ async function initialize(): Promise<boolean> {
 async function handleSubmitPayment(nonce: string): Promise<void> {
   const plan = get(selectedPlan);
   if (!plan) {
-    setError(t('subscription.error.payment_failure'), 'No plan selected');
+    setError(t('subscription.error.payment_failure'), 'No plan selected', PaymentMethods.PAYPAL);
     return;
   }
 
@@ -135,10 +136,11 @@ async function handleSubmitPayment(nonce: string): Promise<void> {
       setError(
         t('subscription.error.payment_failure'),
         t('subscription.error.server_error_warning'),
+        'paypal',
       );
     }
     else {
-      setError(t('subscription.error.payment_failure'), result.error || 'Payment failed');
+      setError(t('subscription.error.payment_failure'), result.error || 'Payment failed', PaymentMethods.PAYPAL);
     }
   }
   finally {

--- a/packages/website/app/modules/checkout/composables/use-braintree-client.ts
+++ b/packages/website/app/modules/checkout/composables/use-braintree-client.ts
@@ -1,6 +1,7 @@
 import type { Client } from 'braintree-web/client';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
+import { CheckoutSteps, PaymentEvents, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { useLogger } from '~/utils/use-logger';
 
 interface BraintreeClientTokenResponse {
@@ -28,6 +29,7 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
 
   const logger = useLogger('braintree-client');
   const { fetchWithCsrf } = useFetchWithCsrf();
+  const { logPaymentEvent } = usePaymentLogger();
   const { t } = useI18n({ useScope: 'global' });
 
   /**
@@ -60,6 +62,12 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
     }
     catch (error: any) {
       logger.error('Failed to initialize Braintree client with token:', error);
+      logPaymentEvent({
+        payment_method: PaymentMethods.CARD,
+        event: PaymentEvents.BRAINTREE_INIT_FAILED,
+        error_message: error.message || 'unknown',
+        step: CheckoutSteps.INIT,
+      });
       set(clientError, error.message || t('subscription.error.init_error'));
       return false;
     }
@@ -99,6 +107,12 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
     }
     catch (error: any) {
       logger.error('Failed to initialize Braintree client:', error);
+      logPaymentEvent({
+        payment_method: PaymentMethods.CARD,
+        event: PaymentEvents.BRAINTREE_INIT_FAILED,
+        error_message: error.message || 'unknown',
+        step: CheckoutSteps.INIT,
+      });
       set(clientError, error.message || t('subscription.error.init_error'));
       return false;
     }

--- a/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
@@ -3,6 +3,7 @@ import type { ThreeDSecure, ThreeDSecureVerificationData, ThreeDSecureVerifyOpti
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { usePaymentCards } from '~/modules/checkout/composables/use-payment-cards';
+import { CheckoutSteps, PaymentEvents, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { useLogger } from '~/utils/use-logger';
 
 interface AuthenticationIframeEvent {
@@ -27,6 +28,7 @@ interface UseCardThreeDSecureReturn {
 export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
   const logger = useLogger('card-three-d-secure');
   const { fetchWithCsrf } = useFetchWithCsrf();
+  const { logPaymentEvent } = usePaymentLogger();
   const { setDefaultCard } = usePaymentCards();
 
   const threeDSecureInstance = shallowRef<ThreeDSecure>();
@@ -189,6 +191,12 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     }
     catch (error: unknown) {
       logger.error('3DS verification failed:', error);
+      logPaymentEvent({
+        payment_method: PaymentMethods.CARD,
+        event: PaymentEvents.THREE_DS_VERIFICATION_FAILED,
+        error_message: error instanceof Error ? error.message : String(error),
+        step: CheckoutSteps.VERIFY,
+      });
       throw error;
     }
   }

--- a/packages/website/app/modules/checkout/composables/use-checkout.ts
+++ b/packages/website/app/modules/checkout/composables/use-checkout.ts
@@ -5,6 +5,7 @@ import { get, set } from '@vueuse/shared';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useAvailablePlans } from '~/composables/tiers/use-available-plans';
 import { useTiersApi } from '~/composables/tiers/use-tiers-api';
+import { PaymentEvents, type PaymentMethod, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { logger } from '~/utils/use-logger';
 
 export interface CheckoutError {
@@ -18,6 +19,7 @@ export function useCheckout() {
   const { fetchPaymentBreakdown } = useTiersApi();
   const { getSelectedPlanFromId, availablePlans, pending: plansPending, refresh: refreshAvailablePlans, execute: ensureAvailablePlans } = useAvailablePlans();
   const { chronicle } = useSigilEvents();
+  const { logPaymentEvent } = usePaymentLogger();
 
   function getCurrentRoute(): RouteLocationNormalizedLoaded {
     return router.currentRoute.value;
@@ -153,11 +155,17 @@ export function useCheckout() {
     set(loading, value);
   }
 
-  function setError(title: string, message: string): void {
+  function setError(title: string, message: string, paymentMethod?: PaymentMethod): void {
     // Track checkout error event
     if (import.meta.client) {
       chronicle('checkout_error', {
         error_title: title,
+        plan_id: get(planId),
+      });
+      logPaymentEvent({
+        payment_method: paymentMethod ?? PaymentMethods.CARD,
+        event: PaymentEvents.CHECKOUT_ERROR,
+        error_message: message,
         plan_id: get(planId),
       });
     }

--- a/packages/website/app/modules/checkout/composables/use-crypto-payment-api.ts
+++ b/packages/website/app/modules/checkout/composables/use-crypto-payment-api.ts
@@ -2,6 +2,7 @@ import type { PaymentError } from '~/types/codes';
 import { type ActionResultResponse, ActionResultResponseSchema } from '@rotki/card-payment-common/schemas/api';
 import { convertKeys } from '@rotki/card-payment-common/utils/object';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
+import { CheckoutSteps, PaymentEvents, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import {
   type CryptoPayment,
   CryptoPaymentResponse,
@@ -54,6 +55,7 @@ interface UseCryptoPaymentApiReturn {
 export function useCryptoPaymentApi(): UseCryptoPaymentApiReturn {
   const logger = useLogger('crypto-payment-api');
   const { fetchWithCsrf } = useFetchWithCsrf();
+  const { logPaymentEvent } = usePaymentLogger();
 
   /**
    * Create crypto payment request
@@ -88,6 +90,7 @@ export function useCryptoPaymentApi(): UseCryptoPaymentApiReturn {
     }
     catch (error: any) {
       logger.error('Crypto payment failed:', error);
+      logPaymentEvent({ payment_method: PaymentMethods.CRYPTO, event: PaymentEvents.CRYPTO_PAYMENT_API_ERROR, error_message: error.message || 'unknown', error_code: String(error.statusCode ?? ''), step: CheckoutSteps.SUBMIT });
       return handlePaymentError(error);
     }
   };
@@ -117,6 +120,13 @@ export function useCryptoPaymentApi(): UseCryptoPaymentApiReturn {
     }
     catch (error: any) {
       logger.error('Crypto payment failed:', error);
+      logPaymentEvent({
+        payment_method: PaymentMethods.CRYPTO,
+        event: PaymentEvents.CRYPTO_PAYMENT_API_ERROR,
+        error_message: error.message || 'unknown',
+        error_code: String(error.statusCode ?? ''),
+        step: CheckoutSteps.SUBMIT,
+      });
       return handlePaymentError(error);
     }
   };

--- a/packages/website/app/modules/checkout/composables/use-crypto-payment.ts
+++ b/packages/website/app/modules/checkout/composables/use-crypto-payment.ts
@@ -6,6 +6,7 @@ import { get, set } from '@vueuse/shared';
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { useWeb3Connection } from '~/composables/web3/use-web3-connection';
 import { useCryptoPaymentApi } from '~/modules/checkout/composables/use-crypto-payment-api';
+import { CheckoutSteps, PaymentEvents, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { usePendingTx } from '~/modules/checkout/composables/use-pending-tx';
 import { assert } from '~/utils/assert';
 import { useLogger } from '~/utils/use-logger';
@@ -62,6 +63,7 @@ export function useWeb3Payment(data: MaybeRefOrGetter<CryptoPayment>, options: U
   const paymentApi = useCryptoPaymentApi();
   const { requestRefresh } = useAccountRefresh();
   const logger = useLogger('web3-payment');
+  const { logPaymentEvent } = usePaymentLogger();
   const { t } = useI18n({ useScope: 'global' });
   const pendingTx = usePendingTx();
 
@@ -168,7 +170,14 @@ export function useWeb3Payment(data: MaybeRefOrGetter<CryptoPayment>, options: U
       const network = await provider.getNetwork();
 
       if (network.chainId !== BigInt(chainId)) {
-        setError(t('subscription.crypto_payment.invalid_chain', { actualName: network.name, chainName }));
+        const msg = t('subscription.crypto_payment.invalid_chain', { actualName: network.name, chainName });
+        setError(msg);
+        logPaymentEvent({
+          payment_method: PaymentMethods.CRYPTO,
+          event: PaymentEvents.CRYPTO_WRONG_CHAIN,
+          error_message: msg,
+          step: CheckoutSteps.VERIFY,
+        });
         set(processing, false);
         return;
       }
@@ -187,6 +196,13 @@ export function useWeb3Payment(data: MaybeRefOrGetter<CryptoPayment>, options: U
     catch (error: any) {
       logger.error(error);
       set(processing, false);
+      const errorMsg = 'shortMessage' in error ? error.shortMessage : error.message;
+      logPaymentEvent({
+        payment_method: PaymentMethods.CRYPTO,
+        event: PaymentEvents.CRYPTO_TX_FAILED,
+        error_message: errorMsg || 'unknown',
+        step: CheckoutSteps.SUBMIT,
+      });
 
       if ('shortMessage' in error)
         setError(error.shortMessage);

--- a/packages/website/app/modules/checkout/composables/use-payment-api.ts
+++ b/packages/website/app/modules/checkout/composables/use-payment-api.ts
@@ -6,6 +6,7 @@ import {
   CardPaymentResponseSchema,
 } from '@rotki/card-payment-common/schemas/payment';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
+import { CheckoutSteps, PaymentEvents, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { handlePaymentError } from '~/utils/api-error-handling';
 import { useLogger } from '~/utils/use-logger';
 
@@ -16,6 +17,7 @@ import { useLogger } from '~/utils/use-logger';
 export function usePaymentApi() {
   const logger = useLogger('payment-api');
   const { fetchWithCsrf } = useFetchWithCsrf();
+  const { logPaymentEvent } = usePaymentLogger();
 
   /**
    * Upgrade an existing subscription
@@ -46,6 +48,13 @@ export function usePaymentApi() {
     }
     catch (error: any) {
       logger.error('Upgrade failed:', error);
+      logPaymentEvent({
+        payment_method: PaymentMethods.CARD,
+        event: PaymentEvents.CARD_PAYMENT_API_ERROR,
+        error_message: error.message || 'unknown',
+        error_code: String(error.statusCode ?? ''),
+        step: CheckoutSteps.SUBMIT,
+      });
       return handlePaymentError(error);
     }
   }
@@ -81,6 +90,13 @@ export function usePaymentApi() {
     }
     catch (error: any) {
       logger.error('Payment failed:', error);
+      logPaymentEvent({
+        payment_method: PaymentMethods.CARD,
+        event: PaymentEvents.CARD_PAYMENT_API_ERROR,
+        error_message: error.message || 'unknown',
+        error_code: String(error.statusCode ?? ''),
+        step: CheckoutSteps.SUBMIT,
+      });
       return handlePaymentError(error);
     }
   }

--- a/packages/website/app/modules/checkout/composables/use-payment-logger.ts
+++ b/packages/website/app/modules/checkout/composables/use-payment-logger.ts
@@ -1,0 +1,67 @@
+export const PaymentMethods = {
+  CARD: 'card',
+  PAYPAL: 'paypal',
+  CRYPTO: 'crypto',
+} as const;
+
+export type PaymentMethod = (typeof PaymentMethods)[keyof typeof PaymentMethods];
+
+export const PaymentEvents = {
+  BRAINTREE_INIT_FAILED: 'braintree_init_failed',
+  THREE_DS_VERIFICATION_FAILED: '3ds_verification_failed',
+  THREE_DS_LIABILITY_SHIFT_FAILED: '3ds_liability_shift_failed',
+  CARD_PAYMENT_API_ERROR: 'card_payment_api_error',
+  PAYPAL_SDK_INIT_FAILED: 'paypal_sdk_init_failed',
+  PAYPAL_PAYMENT_ERROR: 'paypal_payment_error',
+  PAYPAL_SUBMIT_ERROR: 'paypal_submit_error',
+  CRYPTO_WRONG_CHAIN: 'crypto_wrong_chain',
+  CRYPTO_TX_FAILED: 'crypto_tx_failed',
+  CRYPTO_PAYMENT_API_ERROR: 'crypto_payment_api_error',
+  CHECKOUT_ERROR: 'checkout_error',
+} as const;
+
+type PaymentEvent = (typeof PaymentEvents)[keyof typeof PaymentEvents];
+
+export const CheckoutSteps = {
+  INIT: 'init',
+  VERIFY: 'verify',
+  SUBMIT: 'submit',
+  CALLBACK: 'callback',
+} as const;
+
+type CheckoutStep = (typeof CheckoutSteps)[keyof typeof CheckoutSteps];
+
+interface PaymentLogEvent {
+  payment_method: PaymentMethod;
+  event: PaymentEvent;
+  error_message: string;
+  error_code?: string;
+  plan_id?: number;
+  step?: CheckoutStep;
+  timestamp: number;
+}
+
+/**
+ * Fire-and-forget payment error logger.
+ * Sends structured events to the backend for observability.
+ * Errors in logging never affect the payment UX.
+ */
+export function usePaymentLogger(): {
+  logPaymentEvent: (event: Omit<PaymentLogEvent, 'timestamp'>) => void;
+} {
+  function logPaymentEvent(event: Omit<PaymentLogEvent, 'timestamp'>): void {
+    const payload: PaymentLogEvent = {
+      ...event,
+      timestamp: Date.now(),
+    };
+
+    $fetch('/api/logging/payment', {
+      method: 'POST',
+      body: payload,
+    }).catch(() => {
+      // Silently ignore — logging failures must never affect payment UX
+    });
+  }
+
+  return { logPaymentEvent };
+}

--- a/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
+++ b/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
@@ -8,6 +8,7 @@ import { FetchError } from 'ofetch';
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { useBraintreeClient } from '~/modules/checkout/composables/use-braintree-client';
+import { CheckoutSteps, PaymentEvents, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { usePaypalApi } from '~/modules/checkout/composables/use-paypal-api';
 import { assert } from '~/utils/assert';
 import { useLogger } from '~/utils/use-logger';
@@ -65,6 +66,7 @@ export function usePaypalPaymentFlow(): UsePaypalPaymentFlowReturn {
   const { fetchWithCsrf } = useFetchWithCsrf();
   const { requestRefresh } = useAccountRefresh();
   const logger = useLogger('paypal-payment-flow');
+  const { logPaymentEvent } = usePaymentLogger();
 
   const paying = ref<boolean>(false);
   const initialized = ref<boolean>(false);
@@ -113,6 +115,7 @@ export function usePaypalPaymentFlow(): UsePaypalPaymentFlowReturn {
     }
     catch (error: any) {
       logger.error('Failed to initialize PayPal SDK:', error);
+      logPaymentEvent({ payment_method: PaymentMethods.PAYPAL, event: PaymentEvents.PAYPAL_SDK_INIT_FAILED, error_message: error.message || 'unknown', step: CheckoutSteps.INIT });
       return { success: false, error: error.message };
     }
   }
@@ -149,12 +152,14 @@ export function usePaypalPaymentFlow(): UsePaypalPaymentFlowReturn {
         }
         catch (error: any) {
           callbacks.onPaymentError(error?.message ?? String(error));
+          logPaymentEvent({ payment_method: PaymentMethods.PAYPAL, event: PaymentEvents.PAYPAL_PAYMENT_ERROR, error_message: error?.message ?? String(error), step: CheckoutSteps.CALLBACK });
           set(paying, false);
           return undefined;
         }
       },
       onError: (error: any) => {
         set(paying, false);
+        logPaymentEvent({ payment_method: PaymentMethods.PAYPAL, event: PaymentEvents.PAYPAL_PAYMENT_ERROR, error_message: error?.message ?? 'Payment failed', step: CheckoutSteps.CALLBACK });
         callbacks.onPaymentError(error?.message ?? 'Payment failed');
       },
       onCancel: () => {
@@ -241,6 +246,13 @@ export function usePaypalPaymentFlow(): UsePaypalPaymentFlowReturn {
       }
 
       logger.error('Payment submission failed:', error_);
+      logPaymentEvent({
+        payment_method: PaymentMethods.PAYPAL,
+        event: PaymentEvents.PAYPAL_SUBMIT_ERROR,
+        error_message: errorMessage,
+        error_code: String(error_?.status ?? ''),
+        step: CheckoutSteps.SUBMIT,
+      });
       return { success: false, error: errorMessage, blocked };
     }
     finally {

--- a/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
@@ -11,6 +11,7 @@ import { get, set } from '@vueuse/shared';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { usePaymentApi } from '~/modules/checkout/composables/use-payment-api';
+import { CheckoutSteps, PaymentEvents, PaymentMethods, usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { PAYMENT_COMPLETED_KEY } from '~/modules/checkout/constants';
 import { PaymentError } from '~/types/codes';
 import { useLogger } from '~/utils/use-logger';
@@ -34,6 +35,7 @@ interface UseThreeDSecureReturn {
  */
 export function useThreeDSecure(): UseThreeDSecureReturn {
   const logger = useLogger('three-d-secure');
+  const { logPaymentEvent } = usePaymentLogger();
 
   const state = ref<ThreeDSecureState>('initializing');
   const error = ref<string>('');
@@ -110,6 +112,7 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
       set(error, errorMsg);
       set(state, 'error');
       logger.error(errorMsg, initError);
+      logPaymentEvent({ payment_method: PaymentMethods.CARD, event: PaymentEvents.THREE_DS_VERIFICATION_FAILED, error_message: initError.message || 'unknown', step: CheckoutSteps.INIT });
       throw initError;
     }
   }
@@ -193,6 +196,12 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
         set(error, errorMsg);
         set(state, 'error');
         logger.error('3D Secure verification failed:', errorMsg);
+        logPaymentEvent({
+          payment_method: PaymentMethods.CARD,
+          event: PaymentEvents.THREE_DS_LIABILITY_SHIFT_FAILED,
+          error_message: errorMsg,
+          step: CheckoutSteps.VERIFY,
+        });
         throw new Error(errorMsg);
       }
     }
@@ -203,6 +212,12 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
 
       set(error, errorMsg);
       logger.error('3D Secure verification error:', verifyError);
+      logPaymentEvent({
+        payment_method: PaymentMethods.CARD,
+        event: PaymentEvents.THREE_DS_VERIFICATION_FAILED,
+        error_message: errorMsg,
+        step: CheckoutSteps.VERIFY,
+      });
       throw verifyError;
     }
     finally {
@@ -254,7 +269,7 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
 
     // Track purchase success
     chronicle('purchase_success', {
-      payment_method: 'card',
+      payment_method: PaymentMethods.CARD,
       plan_id: params.planId,
       plan_name: params.planName,
       plan_duration: params.durationInMonths === 1 ? 'monthly' : 'yearly',


### PR DESCRIPTION
## Summary

Add a `POST /api/logging/payment` endpoint and frontend composable for structured payment error logging. Events flow to stdout as structured JSON for Grafana/Loki ingestion.

**Zero PII collected** — no IPs, no user/session identifiers, no card details, no wallet addresses.

## Backend

- **`backend/internal/api/paymentlog/handler.go`** — Validates against strict allowlists for `payment_method`, `event`, and `step`. Sanitizes `error_message` (500 char) and `error_code` (32 char). Content-Type enforcement via `mime.ParseMediaType`. 4KB body limit. Timestamp range validation. Generic 400 for all validation failures.
- **16 test cases** covering valid events, unknown fields rejected, body too large, content-type variants, timestamp validation, sanitization

## Frontend

- **`use-payment-logger.ts`** — Fire-and-forget `$fetch`, typed `PaymentMethods`, `PaymentEvents`, `CheckoutSteps` constants
- **8 composables + 2 components integrated**:
  - `use-braintree-client.ts` — `BRAINTREE_INIT_FAILED` (×2)
  - `use-three-d-secure.ts` — `THREE_DS_VERIFICATION_FAILED` (×2), `THREE_DS_LIABILITY_SHIFT_FAILED`
  - `use-card-three-d-secure.ts` — `THREE_DS_VERIFICATION_FAILED`
  - `use-payment-api.ts` — `CARD_PAYMENT_API_ERROR` (×2)
  - `use-paypal-payment-flow.ts` — `PAYPAL_SDK_INIT_FAILED`, `PAYPAL_PAYMENT_ERROR` (×2), `PAYPAL_SUBMIT_ERROR`
  - `use-crypto-payment.ts` — `CRYPTO_WRONG_CHAIN`, `CRYPTO_TX_FAILED`
  - `use-crypto-payment-api.ts` — `CRYPTO_PAYMENT_API_ERROR` (×2)
  - `use-checkout.ts` — `CHECKOUT_ERROR` (dynamic payment method from callers)
  - `PaypalPayment.vue` / `CryptoPayment.vue` — pass payment method to `setError`

## Security

- Strict allowlists for enum fields; unknown values rejected
- `error_message` sanitized (truncation + control char stripping)
- `error_code` sanitized (32 char max)
- Content-Type enforcement via `mime.ParseMediaType` (accepts charset variants)
- Unknown JSON fields rejected (`DisallowUnknownFields`)
- Generic 400 for all validation failures (no allowlist oracle)
- No auth required (errors happen pre-auth)
- Rate limiting handled by Traefik (20 avg/min, 50 burst)

## Test plan

- [x] `make check` — 0 lint issues, all Go tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 134/134 pass
- [ ] Manual test: trigger payment errors and verify structured logs appear
- [ ] Verify Traefik rate limiting applies to the endpoint

Closes #555