### PR TITLE
chore(backend): accept self-signed certificates in dev mode

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -29,7 +29,7 @@ run:
 
 ## dev: Run in dev mode (port 3000, proxies to Nuxt on 3001)
 dev:
-	-DEV_MODE=true go run ./cmd/server $(ARGS)
+	-DEV_MODE=true TLS_SKIP_VERIFY=true go run ./cmd/server $(ARGS)
 
 ## test: Run all tests
 test:


### PR DESCRIPTION
## Summary
- Set `TLS_SKIP_VERIFY=true` by default in `make dev` so the Go backend accepts self-signed certificates without extra env configuration

## Test plan
- [ ] Run `make dev` and verify it connects to a backend with a self-signed certificate without errors