### PR TITLE
feat: add root Makefile with unified dev workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ This is the **rotki.com** website - a Nuxt 3 website for a cryptocurrency portfo
 ### Core Development
 
 ```bash
-pnpm dev          # Start development server
-pnpm build        # Production build with type checking
+make dev          # Start Go backend + Nuxt dev server in parallel
+make dev-go       # Go backend only (port 3000, proxies to Nuxt on 3001)
+make dev-web      # Nuxt dev server only (accepts self-signed certs)
 pnpm preview      # Preview production build
 ```
 
@@ -469,7 +470,7 @@ PROXY_INSECURE=true     # for http proxy in development
 - Standard `go test` with `httptest` for HTTP handlers
 - Table-driven tests for validation and configuration
 - Mock servers for external API testing (OAuth, GitHub)
-- Run with `cd backend && make test` or `make test-race`
+- Run with `make test-go` or `make test-race`
 
 ### E2E Tests (Cypress)
 
@@ -528,11 +529,10 @@ The `backend/` directory contains a Go server that replaces the Node.js SSR laye
 ### Go Development
 
 ```bash
-cd backend
-make check       # vet + lint + test
-make build       # Build production binary
-make run         # Development server
+make build-go    # Build production binary
+make test-go     # Run Go tests
 make coverage    # Test coverage report
+make check       # vet + lint + test (Go + frontend)
 ```
 
 ### Key Go Patterns

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,128 @@
+.PHONY: dev dev-go dev-web \
+       build build-go build-web \
+       test test-go test-web \
+       lint lint-go lint-web lint-fix lint-fix-go lint-fix-web \
+       fmt vet tidy check \
+       coverage typecheck clean docker docker-build help
+
+## help: Show this help message
+help:
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## //' | column -t -s ':'
+
+# ---------------------------------------------------------------------------
+# Development
+# ---------------------------------------------------------------------------
+
+## dev: Run Go backend and Nuxt dev server in parallel
+dev:
+	@trap 'kill 0' INT TERM; \
+	$(MAKE) dev-go & \
+	$(MAKE) dev-web & \
+	wait
+
+## dev-go: Run Go backend in dev mode (port 3000, proxies to Nuxt on 3001)
+dev-go:
+	$(MAKE) -C backend dev
+
+## dev-web: Run Nuxt dev server (accepts self-signed certs)
+dev-web:
+	NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm dev
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+## build: Build Go backend and frontend
+build: build-go build-web
+
+## build-go: Build Go backend binary
+build-go:
+	$(MAKE) -C backend build
+
+## build-web: Build frontend (generate + card payment)
+build-web:
+	pnpm build
+
+## docker: Build and run Docker image locally
+docker:
+	docker compose up --build
+
+## docker-build: Build Docker image only
+docker-build:
+	docker compose build
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+## test: Run all tests (Go + frontend)
+test: test-go test-web
+
+## test-go: Run Go backend tests
+test-go:
+	$(MAKE) -C backend test
+
+## test-race: Run Go backend tests with race detector
+test-race:
+	$(MAKE) -C backend test-race
+
+## test-web: Run frontend tests
+test-web:
+	pnpm test
+
+## coverage: Run Go tests with coverage report
+coverage:
+	$(MAKE) -C backend coverage
+
+# ---------------------------------------------------------------------------
+# Code quality
+# ---------------------------------------------------------------------------
+
+## lint: Run all linters (Go + frontend)
+lint: lint-go lint-web
+
+## lint-go: Run Go linter
+lint-go:
+	$(MAKE) -C backend lint
+
+## lint-web: Run frontend linter
+lint-web:
+	pnpm lint
+
+## lint-fix: Auto-fix all lint issues (Go + frontend)
+lint-fix: lint-fix-go lint-fix-web
+
+## lint-fix-go: Auto-fix Go lint issues
+lint-fix-go:
+	$(MAKE) -C backend lint-fix
+
+## lint-fix-web: Auto-fix frontend lint issues
+lint-fix-web:
+	pnpm lint:fix
+
+## fmt: Format Go files
+fmt:
+	$(MAKE) -C backend fmt
+
+## vet: Run go vet
+vet:
+	$(MAKE) -C backend vet
+
+## tidy: Tidy go.mod
+tidy:
+	$(MAKE) -C backend tidy
+
+## typecheck: Run frontend type checking
+typecheck:
+	pnpm typecheck
+
+## check: Run all checks (vet, lint, test)
+check: vet lint test
+
+# ---------------------------------------------------------------------------
+# Clean
+# ---------------------------------------------------------------------------
+
+## clean: Remove build artifacts
+clean:
+	$(MAKE) -C backend clean

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 $ pnpm install
 
 # serve with hot reload at localhost:3000
-$ pnpm run dev
+$ make dev-web
+
+# or start both Go backend + Nuxt dev server
+$ make dev
 
 # build for production and launch server
 $ pnpm run build
@@ -71,7 +74,14 @@ PROXY_INSECURE=true
 Run with the development server with the following command:
 
 ```bash
-$ pnpm run dev
+# Both Go backend + Nuxt dev server (recommended)
+$ make dev
+
+# Nuxt dev server only (accepts self-signed certs)
+$ make dev-web
+
+# Go backend only (dev mode)
+$ make dev-go
 ```
 
 ## Testing Production Build Locally

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,12 +5,15 @@ A lightweight Go server that serves the static Nuxt-generated site, handles API 
 ## Quick Start
 
 ```bash
-# Development (two terminals)
+# Development (recommended — runs both in parallel from repo root)
+make dev
+
+# Or manually in two terminals:
 # Terminal 1: Start Nuxt dev server on port 3001
-pnpm dev:website
+make dev-web
 
 # Terminal 2: Start Go backend on port 3000, proxying to Nuxt
-cd backend && make dev
+make dev-go
 
 # Open http://localhost:3000 — Go handles API routes, proxies pages/assets to Nuxt
 
@@ -109,25 +112,35 @@ internal/
 
 ## Development
 
+All commands can be run from the **repo root** via the root Makefile:
+
 ```bash
-make dev         # Run in dev mode (port 3000, proxies to Nuxt on 3001)
-make run         # Run the server (requires static files)
-make build       # Build production binary
-make help        # Show all available targets
-make check       # Run vet + lint + tests
-make test        # Run tests
-make test-race   # Run tests with race detector
+make dev         # Run Go backend + Nuxt dev server in parallel
+make dev-go      # Go backend only (port 3000, proxies to Nuxt on 3001)
+make dev-web     # Nuxt dev server only (accepts self-signed certs)
+make build-go    # Build production binary
+make test-go     # Run Go tests
+make test-race   # Run Go tests with race detector
 make coverage    # Generate coverage report
-make lint        # Run golangci-lint
-make lint-fix    # Auto-fix lint issues
-make fmt         # Format with gofumpt
-make tidy        # Tidy go.mod
+make lint-go     # Run golangci-lint
+make lint        # Run all linters (Go + frontend)
+make check       # Run all checks (vet, lint, test)
+make help        # Show all available targets
+```
+
+The backend Makefile (`backend/Makefile`) can still be used directly for Go-only targets:
+
+```bash
+cd backend
+make dev         # Run in dev mode
+make build       # Build production binary
+make check       # Run vet + lint + tests
 make clean       # Remove build artifacts
 ```
 
 ## Dev Mode
 
-`make dev` sets `DEV_MODE=true` which changes defaults for local development:
+`make dev-go` (or `cd backend && make dev`) sets `DEV_MODE=true` which changes defaults for local development:
 
 - **Port 3000** instead of 4000 (matches the URL you use in the browser)
 - **Nuxt proxy** enabled automatically (`NUXT_DEV_URL=http://localhost:3001`) — all non-API requests are forwarded to the Nuxt dev server, including WebSocket for HMR
@@ -168,7 +181,7 @@ Classification is convention-based: patch segment > 0 means patch release. Unpar
 
 ```bash
 # 1. Start the server with a test secret
-GITHUB_WEBHOOK_SECRET=mysecret DEV_MODE=true make dev
+cd backend && GITHUB_WEBHOOK_SECRET=mysecret DEV_MODE=true make dev
 
 # 2. Compute the HMAC signature for a test payload
 PAYLOAD='{"action":"published","release":{"tag_name":"v1.36.0"}}'


### PR DESCRIPTION
## Summary
- Add root `Makefile` that delegates Go targets to `backend/Makefile` via `$(MAKE) -C backend` and wraps `pnpm` commands
- `make dev` runs both Go backend + Nuxt dev server in parallel with proper signal handling (`trap 'kill 0'` on INT/TERM)
- `make dev-web` sets `NODE_TLS_REJECT_UNAUTHORIZED=0` by default for self-signed certs
- Convention: bare targets (`dev`, `build`, `test`, `lint`) run everything; `-go`/`-web` suffixes for individual components
- Backend `Makefile` kept unchanged (used by CI and for direct `cd backend && make` usage)
- Update `README.md`, `backend/README.md`, and `CLAUDE.md` to document new commands

## Test plan
- [ ] `make help` shows all targets
- [ ] `make dev` starts both servers, Ctrl+C kills both
- [ ] `make dev-web` starts Nuxt with TLS rejection disabled
- [ ] `make dev-go` starts Go backend in dev mode
- [ ] `make build` builds both Go binary and frontend
- [ ] `make test` runs both Go and frontend tests
- [ ] CI still passes (backend Makefile unchanged)