### PR TITLE
feat(account): show referral and credit for all verified users

### DIFF
--- a/packages/website/app/pages/home/subscription.vue
+++ b/packages/website/app/pages/home/subscription.vue
@@ -80,9 +80,11 @@ onBeforeMount(() => {
     </template>
 
     <ApiKeys v-if="premium" />
-    <ReferralCode v-if="emailConfirmed && premium" />
-    <AccountCredit v-if="emailConfirmed && premium" />
-    <SubscriptionTable v-if="emailConfirmed" />
+    <template v-if="emailConfirmed">
+      <ReferralCode />
+      <AccountCredit />
+      <SubscriptionTable />
+    </template>
     <PaymentsTable :pending="pending" />
 
     <!-- Unified subscription error notification -->


### PR DESCRIPTION
## Summary
- Remove premium subscription gate from ReferralCode and AccountCredit components
- Any verified user can now see their referral link and credit balance
- Consolidate repeated `v-if="emailConfirmed"` checks into a single `<template>` wrapper

## Test plan
- [ ] Log in as a verified user without premium — confirm referral and credit sections are visible
- [ ] Log in as a verified premium user — confirm everything still works as before
- [ ] Log in with unverified email — confirm referral, credit, and subscription table are hidden