### PR TITLE
fix(sponsor): render mint tier example images without ipx

### DIFF
--- a/packages/website/app/components/sponsor/MintBenefitsInfo.vue
+++ b/packages/website/app/components/sponsor/MintBenefitsInfo.vue
@@ -59,13 +59,12 @@ const currentTierContent = computed<TierContent | undefined>(() => tierContent[s
           v-if="showExampleSponsors"
           class="flex flex-wrap gap-2 mt-2"
         >
-          <NuxtImg
+          <img
             v-for="(imageUrl, index) in currentTierContent.example"
             :key="index"
             :src="imageUrl"
             :alt="`Sponsor example ${index + 1}`"
             class="w-full h-auto rounded-md object-cover"
-            sizes="100vw md:800px"
             loading="lazy"
           />
         </div>


### PR DESCRIPTION
## Summary
- Mint page tier benefit example screenshots 404 on live because their URLs come from `@nuxt/content` markdown inside a collapsed `v-if` block, so the prerender crawler never generates `/_ipx/.../sponsorship-example/*` variants. The Go backend has no IPX runtime, so `<NuxtImg>` requests fail.
- Swap `<NuxtImg>` for a plain `<img>` in `MintBenefitsInfo.vue` so the static files in `public/img/sponsorship-example/` are served directly.

## Test plan
- [ ] Build with `pnpm generate` and confirm no `/_ipx/` lookup for sponsorship-example assets
- [ ] On the mint page, expand "see examples" for each tier (bronze/silver/gold) and verify the screenshots load