### PR TITLE
feat(download): add .deb package option for Linux downloads

### DIFF
--- a/backend/internal/api/releases/handler.go
+++ b/backend/internal/api/releases/handler.go
@@ -281,9 +281,10 @@ func (h *Handler) tryStaleOrRetry(ctx context.Context) *Release {
 // isDownloadableApp checks if an asset is a downloadable app.
 func isDownloadableApp(name string) bool {
 	isWindows := strings.HasSuffix(name, ".exe") && strings.HasPrefix(name, "rotki-win32")
-	isLinux := strings.HasSuffix(name, ".AppImage")
+	isLinuxAppImage := strings.HasSuffix(name, ".AppImage")
+	isLinuxDeb := strings.HasSuffix(name, ".deb") && strings.HasPrefix(name, "rotki-linux")
 	isMacOS := strings.HasSuffix(name, ".dmg") && (strings.Contains(name, "arm64") || strings.Contains(name, "x64"))
-	return isWindows || isLinux || isMacOS
+	return isWindows || isLinuxAppImage || isLinuxDeb || isMacOS
 }
 
 // minimizePayload extracts only needed fields and filters to downloadable assets.

--- a/backend/internal/api/releases/handler_test.go
+++ b/backend/internal/api/releases/handler_test.go
@@ -28,7 +28,10 @@ func TestIsDownloadableApp(t *testing.T) {
 		{"rotki-darwin_electron-1.35.1-x64.dmg", true},
 		{"rotki-1.35.1.tar.gz", false},
 		{"checksums.txt", false},
-		{"rotki-linux-1.35.1.deb", false},
+		{"rotki-linux_amd64-1.35.1.deb", true},
+		{"rotki-linux-1.35.1.deb", true},
+		{"rotki-linux_amd64-1.35.1.deb.sha512", false},
+		{"random-app.deb", false},
 		{"random-app.exe", false},
 		{"rotki-darwin_electron-1.35.1.dmg", false}, // no arm64/x64
 	}
@@ -50,6 +53,7 @@ func TestMinimizePayload(t *testing.T) {
 			{Name: "checksums.txt", BrowserDownloadURL: "https://example.com/checksums.txt"},
 			{Name: "rotki-linux_electron-1.35.1.AppImage", BrowserDownloadURL: "https://example.com/linux.AppImage"},
 			{Name: "rotki-darwin_electron-1.35.1-arm64.dmg", BrowserDownloadURL: "https://example.com/mac-arm.dmg"},
+			{Name: "rotki-linux_amd64-1.35.1.deb", BrowserDownloadURL: "https://example.com/linux.deb"},
 		},
 	}
 
@@ -58,8 +62,8 @@ func TestMinimizePayload(t *testing.T) {
 	if result.TagName != "v1.35.1" {
 		t.Errorf("expected tag v1.35.1, got %s", result.TagName)
 	}
-	if len(result.Assets) != 3 {
-		t.Fatalf("expected 3 assets, got %d", len(result.Assets))
+	if len(result.Assets) != 4 {
+		t.Fatalf("expected 4 assets, got %d", len(result.Assets))
 	}
 	// checksums.txt should be filtered out
 	for _, a := range result.Assets {

--- a/packages/website/app/composables/use-app-download.ts
+++ b/packages/website/app/composables/use-app-download.ts
@@ -12,14 +12,16 @@ export function useAppDownload(fallbackUrl = 'https://github.com/rotki/rotki/rel
   }
 
   const version = computed<string>(() => get(data)?.tag_name ?? '');
-  const linuxUrl = computed<string>(() => findAssetUrl(a => a.name.endsWith('.AppImage')));
+  const linuxAppImageUrl = computed<string>(() => findAssetUrl(a => a.name.endsWith('.AppImage')));
+  const linuxDebUrl = computed<string>(() => findAssetUrl(a => a.name.endsWith('.deb')));
   const windowsUrl = computed<string>(() => findAssetUrl(a => a.name.endsWith('.exe')));
   const macOSUrl = computed<string>(() => findAssetUrl(a => a.name.endsWith('.dmg') && !a.name.includes('arm64')));
   const macOSArmUrl = computed<string>(() => findAssetUrl(a => a.name.includes('arm64')));
   const loading = computed<boolean>(() => get(status) !== 'success' && get(status) !== 'error');
 
   return {
-    linuxUrl,
+    linuxAppImageUrl,
+    linuxDebUrl,
     loading,
     macOSArmUrl,
     macOSUrl,

--- a/packages/website/app/pages/download.vue
+++ b/packages/website/app/pages/download.vue
@@ -36,7 +36,8 @@ useHead({
 
 const {
   version,
-  linuxUrl,
+  linuxAppImageUrl,
+  linuxDebUrl,
   macOSUrl,
   macOSArmUrl,
   windowsUrl,
@@ -44,7 +45,13 @@ const {
 } = useAppDownload();
 
 const links = computed<DownloadItem[]>(() => [
-  { platform: 'LINUX', image: '/img/linux.svg', url: get(linuxUrl) },
+  { platform: 'LINUX', image: '/img/linux.svg', group: true, items: [{
+    name: 'LINUX AppImage',
+    url: get(linuxAppImageUrl),
+  }, {
+    name: 'LINUX deb',
+    url: get(linuxDebUrl),
+  }] },
   { platform: 'MAC', icon: 'lu-os-apple', group: true, items: [{
     name: 'MAC Apple Silicon',
     url: get(macOSArmUrl),

--- a/packages/website/tests/e2e/specs/pages/index.spec.ts
+++ b/packages/website/tests/e2e/specs/pages/index.spec.ts
@@ -6,6 +6,7 @@ const mockRelease = {
     { name: 'rotki-darwin_arm64-v1.41.1.dmg', browser_download_url: 'https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-darwin_arm64-v1.41.1.dmg' },
     { name: 'rotki-darwin_x64-v1.41.1.dmg', browser_download_url: 'https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-darwin_x64-v1.41.1.dmg' },
     { name: 'rotki-linux_x86_64-v1.41.1.AppImage', browser_download_url: 'https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-linux_x86_64-v1.41.1.AppImage' },
+    { name: 'rotki-linux_amd64-v1.41.1.deb', browser_download_url: 'https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-linux_amd64-v1.41.1.deb' },
     { name: 'rotki-win32_x64-v1.41.1.exe', browser_download_url: 'https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-win32_x64-v1.41.1.exe' },
   ],
 };
@@ -147,12 +148,17 @@ test.describe('download page', () => {
       waitUntil: 'networkidle',
     });
 
-    const linuxButton = page.locator('[data-cy="main-download-button"]').filter({ hasText: 'Download for LINUX' });
-    await expect(linuxButton).toBeVisible();
+    const linuxAppImageButton = page.locator('[data-cy="main-download-button"]').filter({ hasText: 'Download for LINUX AppImage' });
+    const linuxDebButton = page.locator('[data-cy="main-download-button"]').filter({ hasText: 'Download for LINUX deb' });
+    await expect(linuxAppImageButton).toBeVisible();
+    await expect(linuxDebButton).toBeVisible();
 
-    // Verify href value
-    const linuxHref = await linuxButton.locator('..').getAttribute('href');
-    expect(linuxHref).toBe('https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-linux_x86_64-v1.41.1.AppImage');
+    // Verify href values
+    const appImageHref = await linuxAppImageButton.locator('..').getAttribute('href');
+    expect(appImageHref).toBe('https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-linux_x86_64-v1.41.1.AppImage');
+
+    const debHref = await linuxDebButton.locator('..').getAttribute('href');
+    expect(debHref).toBe('https://github.com/rotki/rotki/releases/download/v1.41.1/rotki-linux_amd64-v1.41.1.deb');
 
     await context.close();
   });
@@ -196,7 +202,7 @@ test.describe('download page', () => {
     await expect(windowsLink).toBeVisible();
     await expect(page.locator('p').filter({ hasText: 'Latest Release: v' }).first()).toBeVisible();
 
-    // Linux download button
+    // Linux download button (opens menu)
     const linuxButton = linuxLink
       .locator('..')
       .locator('..')
@@ -204,11 +210,24 @@ test.describe('download page', () => {
       .filter({ hasText: 'Download' });
 
     await expect(linuxButton).toBeVisible();
-    await expect(linuxButton).toBeEnabled();
+    await linuxButton.click();
 
-    const linuxHref = await linuxButton.locator('..').getAttribute('href');
-    expect(linuxHref).toContain('rotki-linux');
-    expect(linuxHref).toContain('.AppImage');
+    const linuxMenu = page.locator('[role=menu-content]');
+    await expect(linuxMenu).toBeVisible();
+
+    const linuxAppImageLink = page.getByRole('link', { name: 'LINUX AppImage' });
+    const linuxDebLink = page.getByRole('link', { name: 'LINUX deb' });
+
+    const appImageHref = await linuxAppImageLink.getAttribute('href');
+    expect(appImageHref).toContain('rotki-linux');
+    expect(appImageHref).toContain('.AppImage');
+
+    const debHref = await linuxDebLink.getAttribute('href');
+    expect(debHref).toContain('rotki-linux');
+    expect(debHref).toContain('.deb');
+
+    // Close the menu before proceeding
+    await page.keyboard.press('Escape');
 
     // Windows download button
     const windowsButton = windowsLink


### PR DESCRIPTION
## Summary

- Add `.deb` package as a download option for Linux alongside the existing AppImage
- Linux downloads now show as a grouped dropdown (AppImage + deb), matching the Mac pattern with Apple Silicon / Intel variants
- Backend `isDownloadableApp` filter updated to pass through `.deb` assets from GitHub releases

Closes #567

## Test plan

- [ ] Verify download page shows Linux as a dropdown with AppImage and deb options
- [ ] Verify clicking each option downloads the correct file
- [ ] Verify Mac dropdown still works (Apple Silicon + Intel)
- [ ] Verify Windows and Docker single-item downloads are unaffected
- [ ] Verify auto-detected OS highlight works for Linux users (shows both options)
- [ ] Go backend tests pass (`make test-go`)
- [ ] Frontend typecheck and lint pass