### PR TITLE
fix(pricing): differentiate plan buttons and fix activation redirect

### DIFF
--- a/packages/website/app/components/account/activation/AccountActivate.vue
+++ b/packages/website/app/components/account/activation/AccountActivate.vue
@@ -132,7 +132,6 @@ onBeforeMount(async () => {
             {{ t('auth.activation.success.continue_payment') }}
           </span>
           <RuiButton
-            :to="lastPaymentLink"
             color="primary"
             class="inline-flex py-0 !px-1 !text-[1em]"
             variant="text"

--- a/packages/website/app/components/pricings/PricingTableButton.vue
+++ b/packages/website/app/components/pricings/PricingTableButton.vue
@@ -4,7 +4,7 @@ import type { MappedPlan } from '~/components/pricings/type';
 import type { PricingPeriod } from '~/types/tiers';
 import { get } from '@vueuse/shared';
 import ButtonLink from '~/components/common/ButtonLink.vue';
-import { isCustomPlan, isFreePlan } from '~/components/pricings/utils';
+import { isCustomPlan, isEntryTierPlan, isFreePlan } from '~/components/pricings/utils';
 import { useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
 import { buildQueryParams } from '~/utils/query';
 import { toTitleCase } from '~/utils/text';
@@ -68,7 +68,7 @@ const checkoutLink = computed<RouteLocationRaw>(() => {
   <ButtonLink
     v-else
     class="w-full py-2 xl:text-[1rem]"
-    variant="default"
+    :variant="isEntryTierPlan(plan) ? 'outlined' : 'default'"
     color="primary"
     :to="checkoutLink"
   >

--- a/packages/website/app/components/pricings/type.ts
+++ b/packages/website/app/components/pricings/type.ts
@@ -13,6 +13,7 @@ export interface MappedPlan {
   mainPriceDisplay: string;
   type: PlanType;
   isMostPopular: boolean;
+  isEntryTier: boolean;
   hidden: boolean;
   loading?: boolean;
   secondaryPriceDisplay?: string;

--- a/packages/website/app/components/pricings/utils.ts
+++ b/packages/website/app/components/pricings/utils.ts
@@ -6,6 +6,10 @@ export function isMostPopularPlan(plan: MappedPlan): boolean {
   return plan.isMostPopular;
 }
 
+export function isEntryTierPlan(plan: MappedPlan): boolean {
+  return plan.isEntryTier;
+}
+
 export function isFreePlan(plan: PlanBase): boolean {
   return plan.type === 'free';
 }

--- a/packages/website/app/composables/use-pricing-comparison.ts
+++ b/packages/website/app/composables/use-pricing-comparison.ts
@@ -103,6 +103,7 @@ function createPlaceholderPlans(): MappedPlan[] {
       mainPriceDisplay: '',
       type: 'free',
       isMostPopular: false,
+      isEntryTier: false,
       hidden: false,
       loading: true,
       features: [...emptyFeatures],
@@ -113,6 +114,7 @@ function createPlaceholderPlans(): MappedPlan[] {
       mainPriceDisplay: '',
       type: 'regular',
       isMostPopular: false,
+      isEntryTier: false,
       hidden: false,
       loading: true,
       features: [...emptyFeatures],
@@ -123,6 +125,7 @@ function createPlaceholderPlans(): MappedPlan[] {
       mainPriceDisplay: '',
       type: 'regular',
       isMostPopular: true,
+      isEntryTier: false,
       hidden: false,
       loading: true,
       features: [...emptyFeatures],
@@ -133,6 +136,7 @@ function createPlaceholderPlans(): MappedPlan[] {
       mainPriceDisplay: '',
       type: 'custom',
       isMostPopular: false,
+      isEntryTier: false,
       hidden: false,
       loading: true,
       features: [...emptyFeatures],
@@ -168,6 +172,9 @@ export function usePricingComparison(options: UsePricingComparisonOptions) {
   const regularPlans = computed<PlanBase[]>(() => {
     const yearly = get(isYearly);
     const plans: PlanBase[] = [];
+    let minPrice = Number.POSITIVE_INFINITY;
+    let minPriceIndex = -1;
+
     for (const availablePlan of toValue(options.availablePlans)) {
       const targetPlan = yearly ? availablePlan.yearlyPlan : availablePlan.monthlyPlan;
       if (!targetPlan) {
@@ -176,6 +183,11 @@ export function usePricingComparison(options: UsePricingComparisonOptions) {
 
       const price = Number.parseFloat(targetPlan.price);
       const formattedPrice = formatCurrency(price);
+
+      if (price < minPrice && !availablePlan.isCustom) {
+        minPrice = price;
+        minPriceIndex = plans.length;
+      }
 
       plans.push({
         id: targetPlan.planId,
@@ -188,7 +200,14 @@ export function usePricingComparison(options: UsePricingComparisonOptions) {
         type: 'regular',
         hidden: availablePlan.isCustom || false,
         isMostPopular: availablePlan.isMostPopular || false,
+        isEntryTier: false,
       });
+    }
+
+    // Mark the cheapest non-custom plan as entry tier
+    const entryPlan = minPriceIndex >= 0 && plans.length > 1 ? plans[minPriceIndex] : undefined;
+    if (entryPlan) {
+      entryPlan.isEntryTier = true;
     }
 
     return plans;
@@ -217,6 +236,7 @@ export function usePricingComparison(options: UsePricingComparisonOptions) {
         type: 'free',
         hidden: false,
         isMostPopular: false,
+        isEntryTier: false,
       },
       ...get(regularPlans).filter(x => !x.hidden),
       {
@@ -226,6 +246,7 @@ export function usePricingComparison(options: UsePricingComparisonOptions) {
         type: 'custom',
         hidden: false,
         isMostPopular: false,
+        isEntryTier: false,
       },
     ];
 

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -315,7 +315,7 @@ export default defineNuxtConfig({
   sitemap: {
     exclude: nonIndexed,
   },
-  ssr: true,
+  ssr: false,
 
   typescript: {
     tsConfig: {

--- a/packages/website/tests/e2e/specs/pages/payment-redirect.spec.ts
+++ b/packages/website/tests/e2e/specs/pages/payment-redirect.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '@playwright/test';
+
+const mockAvailableTiers = {
+  settings: {
+    is_authenticated: false,
+    country: null,
+  },
+  tiers: [
+    { tier_name: 'Free', monthly_plan: null, yearly_plan: null },
+    { tier_name: 'Basic', monthly_plan: { plan_id: 3, price: '25.00' }, yearly_plan: { plan_id: 4, price: '250.00' } },
+    { tier_name: 'Advanced', monthly_plan: { plan_id: 1, price: '45.00' }, yearly_plan: { plan_id: 2, price: '450.00' } },
+  ],
+};
+
+const mockAuthenticatedAccount = {
+  result: {
+    username: 'testuser',
+    email: 'test@example.com',
+    email_confirmed: true,
+    has_active_subscription: false,
+    can_use_premium: false,
+    api_key: '',
+    api_secret: '',
+    date_now: new Date().toISOString(),
+    vat: 0,
+    vat_id_status: 'Not checked',
+    address: {
+      address1: '',
+      address2: '',
+      city: '',
+      company_name: '',
+      country: '',
+      first_name: 'Test',
+      last_name: 'User',
+      moved_offline: false,
+      postcode: '',
+      vat_id: '',
+    },
+  },
+};
+
+const REDIRECT_STORAGE_KEY = 'rotki.redirect_url';
+
+function randomPlanId(): number {
+  return Math.floor(Math.random() * 9) + 1;
+}
+
+async function setupUnauthenticatedMocks(page: import('@playwright/test').Page): Promise<void> {
+  await page.route('**/webapi/2/available-tiers', async route => route.fulfill({ json: mockAvailableTiers }));
+  await page.route('**/webapi/csrf/**', async route => route.fulfill({ json: { detail: 'CSRF cookie set' } }));
+  await page.route('**/webapi/account/', async route => route.fulfill({ status: 401, json: { message: 'Not authenticated' } }));
+}
+
+test.describe('payment redirect after signup', () => {
+  test('unauthenticated user on checkout method page is redirected to login with redirectUrl', async ({ page }) => {
+    const planId = randomPlanId();
+    await setupUnauthenticatedMocks(page);
+    await page.goto(`/checkout/pay/method?planId=${planId}`);
+    await page.waitForURL('**/login**');
+
+    const url = new URL(page.url());
+    const redirectUrl = url.searchParams.get('redirectUrl');
+    expect(redirectUrl).toBeTruthy();
+    expect(redirectUrl).toContain('/checkout/pay/method');
+    expect(redirectUrl).toContain(`planId=${planId}`);
+  });
+
+  test('login page passes redirectUrl to signup link', async ({ page }) => {
+    const planId = randomPlanId();
+    await setupUnauthenticatedMocks(page);
+    const paymentPath = `/checkout/pay/method?planId=${planId}`;
+    await page.goto(`/login?redirectUrl=${encodeURIComponent(paymentPath)}`);
+    await page.waitForLoadState('networkidle');
+
+    const signupLink = page.getByRole('link', { name: /sign up/i });
+    await expect(signupLink).toBeVisible();
+
+    const href = await signupLink.getAttribute('href');
+    expect(href).toContain('/signup');
+    expect(href).toContain('redirectUrl');
+    expect(decodeURIComponent(href ?? '')).toContain(`planId=${planId}`);
+  });
+
+  test('signup page preserves redirectUrl through form steps', async ({ page }) => {
+    const planId = randomPlanId();
+    await setupUnauthenticatedMocks(page);
+
+    await page.route('**/webapi/countries/', async (route) => {
+      await route.fulfill({
+        status: 200,
+        json: { result: [{ code: 'DE', name: 'Germany' }] },
+      });
+    });
+
+    const paymentPath = `/checkout/pay/card?planId=${planId}`;
+    await page.goto(`/signup?redirectUrl=${encodeURIComponent(paymentPath)}`);
+    await page.waitForLoadState('networkidle');
+
+    // Step 1: Introduction — click Next
+    await page.locator('[data-cy=next-button]').click();
+    expect(new URL(page.url()).searchParams.get('redirectUrl')).toBe(paymentPath);
+
+    // Step 2: Account form — fill and advance
+    await page.locator('input#username').first().fill('testuser');
+    await page.locator('input#email').first().fill('test@example.com');
+    await page.locator('input#password').first().fill('SecureP4ss!');
+    await page.locator('input#password-confirmation').first().fill('SecureP4ss!');
+    await page.locator('button[data-cy=next-button]').first().click();
+
+    // Verify redirectUrl survives step navigation
+    expect(new URL(page.url()).searchParams.get('redirectUrl')).toBe(paymentPath);
+  });
+
+  test('activation page shows payment continue button that navigates to checkout with planId', async ({ page }) => {
+    const planId = randomPlanId();
+    const paymentPath = `/checkout/pay/card?planId=${planId}`;
+
+    // Mock activation and account API calls
+    await page.route('**/webapi/activate/**', async route => route.fulfill({ json: { result: true } }));
+    await page.route('**/webapi/account/', async route => route.fulfill({ json: mockAuthenticatedAccount }));
+    await page.route('**/webapi/csrf/**', async route => route.fulfill({ json: { detail: 'CSRF cookie set' } }));
+
+    // Seed localStorage before navigating to activation page
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.evaluate(({ key, username, url }) => {
+      localStorage.setItem(key, JSON.stringify({ username, url }));
+    }, { key: REDIRECT_STORAGE_KEY, username: 'testuser', url: paymentPath });
+
+    // Navigate to activation page
+    await page.goto('/activate/test-uid/test-token');
+    await page.waitForLoadState('networkidle');
+
+    // Verify activation succeeded
+    await expect(page.getByText('Welcome to rotki').first()).toBeVisible({ timeout: 10000 });
+
+    // Verify payment continue section appears
+    const paymentSection = page.getByText('Or continue your payment');
+    await expect(paymentSection.first()).toBeVisible({ timeout: 10000 });
+
+    const continueButton = paymentSection.locator('..').getByRole('button', { name: 'here' });
+    await expect(continueButton).toBeVisible();
+
+    // Click the button and verify it navigates to the correct checkout URL.
+    // handlePaymentRedirect() uses window.location.href, so we capture the
+    // outgoing page request to verify the target URL.
+    const navigationTarget = page.waitForRequest(
+      request => request.url().includes('/checkout/pay/card'),
+      { timeout: 15000 },
+    );
+
+    await continueButton.click({ noWaitAfter: true });
+
+    const request = await navigationTarget;
+    const requestUrl = new URL(request.url());
+    expect(requestUrl.pathname).toBe('/checkout/pay/card');
+    expect(requestUrl.searchParams.get('planId')).toBe(String(planId));
+  });
+});

--- a/packages/website/tests/unit/composables/use-pricing-comparison.spec.ts
+++ b/packages/website/tests/unit/composables/use-pricing-comparison.spec.ts
@@ -6,15 +6,15 @@ import { parseTiersInfo, resolveFeatureValue } from '~/composables/use-pricing-c
 const CUSTOM_LABELS = { support: 'Bespoke support', negotiable: 'Negotiable' };
 
 function freePlan(): PlanBase {
-  return { name: 'starter', displayedName: 'Starter', mainPriceDisplay: 'Free', type: 'free', hidden: false, isMostPopular: false };
+  return { name: 'starter', displayedName: 'Starter', mainPriceDisplay: 'Free', type: 'free', hidden: false, isMostPopular: false, isEntryTier: false };
 }
 
 function customPlan(): PlanBase {
-  return { name: 'custom', displayedName: 'Custom', mainPriceDisplay: 'Contact us', type: 'custom', hidden: false, isMostPopular: false };
+  return { name: 'custom', displayedName: 'Custom', mainPriceDisplay: 'Contact us', type: 'custom', hidden: false, isMostPopular: false, isEntryTier: false };
 }
 
 function regularPlan(name = 'pro'): PlanBase {
-  return { name, displayedName: 'Pro', mainPriceDisplay: '10€', type: 'regular', hidden: false, isMostPopular: false };
+  return { name, displayedName: 'Pro', mainPriceDisplay: '10€', type: 'regular', hidden: false, isMostPopular: false, isEntryTier: false };
 }
 
 describe('parseTiersInfo', () => {


### PR DESCRIPTION
## Summary
- Differentiate entry-tier (Supporter) plan button with outlined style while Basic/Advanced use filled primary buttons, creating a clear visual hierarchy to reduce accidental Supporter purchases
- Fix activation page's payment continue button that silently failed due to conflicting `:to` and `@click` handlers
- Set `ssr: false` in nuxt config so dev mode matches production SSG behavior

## Test plan
- [ ] Verify Supporter button appears outlined on pricing page (desktop + mobile)
- [ ] Verify Basic and Advanced buttons appear as filled primary
- [ ] Create a new account, activate it, and verify the "continue payment" button navigates correctly
- [ ] Run `npx playwright test` — all 16 e2e tests should pass
- [ ] Run `pnpm test` — all 126 unit tests should pass