### PR TITLE
fix(account): improve premium placeholder tier selection and feature display

### DIFF
--- a/packages/website/app/components/account/home/PremiumPlaceholder.vue
+++ b/packages/website/app/components/account/home/PremiumPlaceholder.vue
@@ -101,10 +101,26 @@ const [DefineFeaturesSkeleton, ReuseFeaturesSkeleton] = createReusableTemplate()
                 size="16"
                 class="text-rui-success mt-0.5 shrink-0"
               />
-              <div class="flex items-baseline gap-1.5">
-                <span>{{ feature.label }}:</span>
-                <span class="font-medium">{{ feature.value }}</span>
-              </div>
+              <span>{{ feature.label }}{{ typeof feature.value !== 'boolean' ? ':' : '' }}</span>
+              <RuiIcon
+                v-if="typeof feature.value === 'boolean' && feature.value"
+                name="lu-circle-check"
+                size="16"
+                color="success"
+                class="shrink-0"
+              />
+              <RuiIcon
+                v-else-if="typeof feature.value === 'boolean' && !feature.value"
+                name="lu-minus"
+                size="16"
+                class="text-rui-text-disabled shrink-0"
+              />
+              <span
+                v-else
+                class="font-medium"
+              >
+                {{ feature.value }}
+              </span>
             </div>
           </div>
           <template #fallback>

--- a/packages/website/app/components/account/home/PremiumPlaceholder.vue
+++ b/packages/website/app/components/account/home/PremiumPlaceholder.vue
@@ -9,11 +9,34 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { tiersInformation, pending: isLoading } = usePremiumTiersInfo();
 
-const basicTier = computed<PremiumTierInfo | undefined>(() => get(tiersInformation)[0]);
+function findEntryTierName(tiers: PremiumTierInfo[]): string | undefined {
+  let minPrice = Number.POSITIVE_INFINITY;
+  let entryName: string | undefined;
 
-const monthlyPrice = computed<string | undefined>(() => get(basicTier)?.monthlyPlan?.price);
+  for (const tier of tiers) {
+    const price = Number.parseFloat(tier.monthlyPlan?.price ?? '0');
+    if (price > 0 && price < minPrice) {
+      minPrice = price;
+      entryName = tier.name;
+    }
+  }
 
-const features = computed<PremiumTierInfoDescription[]>(() => get(basicTier)?.description.slice(0, 4) || []);
+  return entryName;
+}
+
+const suggestedTier = computed<PremiumTierInfo | undefined>(() => {
+  const tiers = get(tiersInformation);
+  if (tiers.length <= 1) {
+    return tiers[0];
+  }
+
+  const entryName = findEntryTierName(tiers);
+  return tiers.find(tier => tier.name !== entryName) ?? tiers[0];
+});
+
+const monthlyPrice = computed<string | undefined>(() => get(suggestedTier)?.monthlyPlan?.price);
+
+const features = computed<PremiumTierInfoDescription[]>(() => get(suggestedTier)?.description.slice(0, 4) || []);
 
 const [DefineFeaturesSkeleton, ReuseFeaturesSkeleton] = createReusableTemplate();
 </script>


### PR DESCRIPTION
## Summary
- Skip the cheapest (entry) tier in the premium upgrade placeholder and suggest the first plan above it, consistent with the pricing page entry-tier differentiation
- Render boolean feature values as icons (green check / minus) instead of literal "true"/"false" text

## Test plan
- [ ] Log in with a free account and verify the premium placeholder shows the Basic tier (not Supporter)
- [ ] Verify boolean features display a green check icon instead of "true"
- [ ] Verify non-boolean features still show label: value format