### PR TITLE
feat(account): add documentation link to API Keys section

### DIFF
--- a/packages/website/app/components/account/home/ApiKeys.vue
+++ b/packages/website/app/components/account/home/ApiKeys.vue
@@ -14,8 +14,24 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <div>
     <div class="mb-6 flex justify-between items-center">
-      <div class="text-h6">
+      <div class="text-h6 flex items-center gap-2">
         {{ t('account.api_keys.title') }}
+        <RuiTooltip :open-delay="200">
+          <template #activator>
+            <a
+              href="https://docs.rotki.com/premium/api-keys.html#using-api-credentials-in-the-app"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-rui-text-secondary hover:text-rui-primary"
+            >
+              <RuiIcon
+                name="lu-info"
+                size="18"
+              />
+            </a>
+          </template>
+          {{ t('account.api_keys.docs_hint') }}
+        </RuiTooltip>
       </div>
       <div>
         <RuiButton

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -12,6 +12,7 @@
     "api_keys": {
       "api_key": "API Key",
       "api_secret": "API Secret",
+      "docs_hint": "Learn how to use your API credentials in the rotki app",
       "not_generated": "You haven't generated an API key",
       "title": "API Credentials"
     },


### PR DESCRIPTION
## Summary
- Add an info icon with tooltip next to the "API Credentials" title linking to the docs page on how to use API keys in the rotki app
- Clicking the icon opens https://docs.rotki.com/premium/api-keys.html#using-api-credentials-in-the-app in a new tab

Closes #571

## Test plan
- [ ] Navigate to account dashboard and verify the info icon appears next to "API Credentials"
- [ ] Hover over the icon and verify the tooltip shows
- [ ] Click the icon and verify it opens the docs page in a new tab