### PR TITLE
perf: preload LCP screenshot image on home and download pages

### DIFF
--- a/packages/website/app/pages/download.vue
+++ b/packages/website/app/pages/download.vue
@@ -16,6 +16,7 @@ usePageSeo(
 
 const { public: { baseUrl } } = useRuntimeConfig();
 useHead({
+  link: [{ as: 'image', href: '/img/screenshots/1-sc-dashboard.webp', rel: 'preload', type: 'image/webp' }],
   script: [{
     type: 'application/ld+json',
     innerHTML: JSON.stringify({

--- a/packages/website/app/pages/index.vue
+++ b/packages/website/app/pages/index.vue
@@ -15,7 +15,10 @@ const keywords = `portfolio,portfolio-tracking,cryptocurrency-portfolio-tracker,
 privacy,opensource,accounting,asset-management,taxes,tax-reporting`;
 
 usePageSeo('rotki', description, '', { keywords });
-useHead({ titleTemplate: '' });
+useHead({
+  link: [{ as: 'image', href: '/img/screenshots/1-sc-dashboard.webp', rel: 'preload', type: 'image/webp' }],
+  titleTemplate: '',
+});
 
 const { public: { baseUrl } } = useRuntimeConfig();
 useHead({


### PR DESCRIPTION
## Summary
- Add `<link rel="preload">` for the first carousel screenshot on home and download pages
- Eliminates ~734ms load delay caused by JS-driven image discovery via `import.meta.glob`

## Before/After
- **Before**: LCP 1024ms (734ms load delay waiting for JS to inject the img tag)
- **After**: LCP image discovered immediately from HTML, no longer flagged as an issue

## Test plan
- [ ] Run Lighthouse/performance trace on mobile for home page
- [ ] Run Lighthouse/performance trace on mobile for download page
- [ ] Verify CLS remains 0.00