### PR TITLE
refactor: bundle integration images at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,12 @@ jobs:
       - name: Install dependencies 👨🏻‍💻
         run: pnpm install --frozen-lockfile
 
+      - name: Cache integration images
+        uses: actions/cache@v5
+        with:
+          path: packages/website/public/img/integrations
+          key: ${{ runner.os }}-integration-images-${{ hashFiles('packages/website/public/integrations/all.json') }}
+
       - name: Setup Go (for e2e — backend serves the app)
         uses: actions/setup-go@v6
         with:

--- a/packages/website/.gitignore
+++ b/packages/website/.gitignore
@@ -6,3 +6,4 @@ coverage
 playwright-report
 tests/e2e/test-results
 tests/e2e/mock-api/.nitro
+public/img/integrations

--- a/packages/website/app/composables/use-integrations-data.ts
+++ b/packages/website/app/composables/use-integrations-data.ts
@@ -1,75 +1,58 @@
-import { convertKeys } from '@rotki/card-payment-common/utils/object';
-import { get } from '@vueuse/shared';
 import LocalIntegrationData from '~~/public/integrations/all.json';
-import { useAppConfig } from '~/composables/use-app-config';
 import { IntegrationData, type IntegrationItem } from '~/types/integrations';
-import { logger } from '~/utils/use-logger';
 
-export const useIntegrationsData = createSharedComposable(() => {
-  const { public: { isDev } } = useRuntimeConfig();
-  const { contentBranch } = useAppConfig();
+const GITHUB_PREFIX = 'https://raw.githubusercontent.com/rotki/rotki/develop/frontend/app/public/assets/images/protocols/';
+const LOCAL_PREFIX = '/img/integrations/';
 
-  const getRemoteIntegrationData = async (): Promise<IntegrationData | null> => {
-    const branch = get(contentBranch);
-    try {
-      const response = await $fetch<IntegrationData>(
-        `https://raw.githubusercontent.com/rotki/rotki.com/${branch}/packages/website/public/integrations/all.json`,
-        {
-          parseResponse(responseText: string) {
-            return convertKeys(JSON.parse(responseText), true, false);
-          },
-        },
-      );
-      return IntegrationData.parse(response);
-    }
-    catch (error: any) {
-      logger.error(error);
+function localizeImageUrl(url: string): string {
+  return url.startsWith(GITHUB_PREFIX) ? url.replace(GITHUB_PREFIX, LOCAL_PREFIX) : url;
+}
 
-      return null;
-    }
+function localizeData(data: IntegrationData): IntegrationData {
+  function localize<T extends { image: string }>(items: T[]): T[] {
+    return items.map(item => ({ ...item, image: localizeImageUrl(item.image) }));
+  }
+
+  return {
+    blockchains: localize(data.blockchains),
+    exchanges: localize(data.exchanges),
+    protocols: localize(data.protocols),
   };
+}
+
+export function useIntegrationsData() {
+  const { public: { isDev } } = useRuntimeConfig();
 
   const filterDuplicateData = (data: IntegrationData): IntegrationData => {
     const uniqueProtocols: Record<string, IntegrationItem> = {};
 
     data.protocols.forEach((protocol) => {
-      const firstWord = protocol.label.split(' ')[0]; // Get the first word of label
+      const firstWord = protocol.label.split(' ')[0];
       if (!firstWord)
         return;
 
-      // Check if we already have an entry with this first word and same image
       const existing = uniqueProtocols[firstWord];
       if (!existing || existing.image !== protocol.image) {
-        // If not, add it to uniqueProtocols
         uniqueProtocols[firstWord] = { ...protocol };
       }
       else {
-        // If there's a duplicate, modify the label of the existing one
         existing.label = firstWord;
       }
     });
 
-    const uniqueProtocolList = Object.values(uniqueProtocols);
-
     return {
       ...data,
-      protocols: uniqueProtocolList,
+      protocols: Object.values(uniqueProtocols),
     };
   };
 
-  const data = asyncComputed<IntegrationData>(async () => {
-    let data: IntegrationData;
-    if (isDev) {
-      data = LocalIntegrationData;
-    }
-    else {
-      data = await getRemoteIntegrationData() ?? LocalIntegrationData;
-    }
-    return data;
-  }, LocalIntegrationData);
+  const data = computed<IntegrationData>(() => {
+    const parsed = IntegrationData.parse(LocalIntegrationData);
+    return isDev ? parsed : localizeData(parsed);
+  });
 
   return {
     data,
     filterDuplicateData,
   };
-});
+}

--- a/packages/website/modules/integration-images/module.ts
+++ b/packages/website/modules/integration-images/module.ts
@@ -1,0 +1,179 @@
+import { Buffer } from 'node:buffer';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { basename, resolve } from 'node:path';
+import { defineNuxtModule } from '@nuxt/kit';
+
+const CONCURRENCY = 20;
+const MANIFEST_FILE = '.manifest.json';
+
+interface ManifestEntry {
+  etag: string;
+  filename: string;
+}
+
+type Manifest = Record<string, ManifestEntry>;
+
+interface DownloadTask {
+  url: string;
+  dest: string;
+  etag?: string;
+}
+
+interface DownloadResult {
+  url: string;
+  filename: string;
+  etag?: string;
+  skipped: boolean;
+}
+
+async function readManifest(manifestPath: string): Promise<Manifest> {
+  if (!existsSync(manifestPath))
+    return {};
+
+  const raw = await readFile(manifestPath, 'utf-8');
+  return JSON.parse(raw) as Manifest;
+}
+
+async function writeManifest(manifestPath: string, manifest: Manifest): Promise<void> {
+  const sorted = Object.fromEntries(Object.entries(manifest).sort(([a], [b]) => a.localeCompare(b)));
+  await writeFile(manifestPath, `${JSON.stringify(sorted, undefined, 2)}\n`);
+}
+
+async function downloadBatch(tasks: DownloadTask[]): Promise<DownloadResult[]> {
+  const results: DownloadResult[] = [];
+
+  for (let i = 0; i < tasks.length; i += CONCURRENCY) {
+    const batch = tasks.slice(i, i + CONCURRENCY);
+    const settled = await Promise.allSettled(
+      batch.map(async ({ url, dest, etag }): Promise<DownloadResult> => {
+        const headers: Record<string, string> = {};
+        if (etag)
+          headers['if-none-match'] = etag;
+
+        const res = await fetch(url, { headers });
+
+        if (res.status === 304) {
+          return {
+            url,
+            filename: basename(dest),
+            etag,
+            skipped: true,
+          };
+        }
+
+        if (!res.ok)
+          throw new Error(`HTTP ${res.status} for ${url}`);
+
+        const buffer = Buffer.from(await res.arrayBuffer());
+        await writeFile(dest, buffer);
+
+        return {
+          url,
+          filename: basename(dest),
+          etag: res.headers.get('etag') ?? undefined,
+          skipped: false,
+        };
+      }),
+    );
+
+    for (const [idx, result] of settled.entries()) {
+      if (result.status === 'fulfilled') {
+        results.push(result.value);
+      }
+      else {
+        console.warn(`[integration-images] Failed to download ${batch[idx]?.url}: ${result.reason}`);
+      }
+    }
+  }
+
+  return results;
+}
+
+export default defineNuxtModule({
+  meta: { name: 'integration-images' },
+  async setup(_options, nuxt) {
+    if (nuxt.options.dev)
+      return;
+
+    const rootDir = nuxt.options.rootDir;
+    const jsonPath = resolve(rootDir, 'public/integrations/all.json');
+    const outputDir = resolve(rootDir, 'public/img/integrations');
+
+    if (!existsSync(jsonPath)) {
+      console.warn('[integration-images] public/integrations/all.json not found, skipping');
+      return;
+    }
+
+    const raw = await readFile(jsonPath, 'utf-8');
+    const data = JSON.parse(raw);
+
+    const urls = new Set<string>();
+    for (const category of ['blockchains', 'exchanges', 'protocols']) {
+      for (const item of data[category] ?? []) {
+        if (typeof item.image === 'string' && item.image.startsWith('http'))
+          urls.add(item.image);
+      }
+    }
+
+    if (urls.size === 0)
+      return;
+
+    await mkdir(outputDir, { recursive: true });
+
+    const manifestPath = resolve(outputDir, MANIFEST_FILE);
+    const manifest = await readManifest(manifestPath);
+
+    const expectedFiles = new Set<string>();
+    const tasks: DownloadTask[] = [...urls].map((url) => {
+      const filename = basename(new URL(url).pathname);
+      expectedFiles.add(filename);
+      return {
+        url,
+        dest: resolve(outputDir, filename),
+        etag: manifest[url]?.etag,
+      };
+    });
+
+    console.warn(`[integration-images] Checking ${urls.size} images...`);
+
+    const results = await downloadBatch(tasks);
+
+    const newManifest: Manifest = {};
+    let downloaded = 0;
+    let cached = 0;
+
+    for (const result of results) {
+      newManifest[result.url] = {
+        etag: result.etag ?? '',
+        filename: result.filename,
+      };
+
+      if (result.skipped) {
+        cached++;
+      }
+      else {
+        downloaded++;
+      }
+    }
+
+    await writeManifest(manifestPath, newManifest);
+
+    // Remove orphan files that are no longer in the URL set
+    const orphanManifestUrls = Object.keys(manifest).filter(url => !urls.has(url));
+    let removed = 0;
+    for (const url of orphanManifestUrls) {
+      const entry = manifest[url];
+      if (!entry)
+        continue;
+
+      const filePath = resolve(outputDir, entry.filename);
+      if (existsSync(filePath)) {
+        await unlink(filePath);
+        removed++;
+      }
+    }
+
+    console.warn(`[integration-images] Done: ${downloaded} downloaded, ${cached} cached (304), ${removed} removed`);
+  },
+});

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -156,6 +156,7 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     ['@pinia/nuxt', { disableVuex: true }],
     '@nuxt/test-utils/module',
+    './modules/integration-images/module.ts',
     './modules/ui-library/module.ts',
   ],
 


### PR DESCRIPTION
## Summary
- Add Nuxt module that downloads 149 integration images from GitHub at build time
- Serve images locally from `/img/integrations/` instead of `raw.githubusercontent.com`
- Simplify `use-integrations-data.ts`: remove `asyncComputed`, `createSharedComposable`, remote fetch fallback
- Cache integration images in CI via `actions/cache` (keyed on `all.json` hash)
- Images directory gitignored (generated at build time)

Depends on #584

Closes #554

## How it works
- **Build time**: Module reads `all.json`, downloads images to `public/img/integrations/`, skips if already cached
- **Dev mode**: Module skips entirely, images load from GitHub as before
- **Production**: Composable rewrites GitHub URLs to local `/img/integrations/` paths

## Test plan
- [x] Lint passes
- [x] Typecheck passes (module ran and downloaded 130 images)
- [x] Second run skips download (cache hit)
- [ ] CI build succeeds with image caching
- [ ] Integrations page loads images from local paths in production build