### PR TITLE
feat(checkout): friendly errors for add-card 429s and declines

### DIFF
--- a/packages/card-payment/src/utils/card-api.ts
+++ b/packages/card-payment/src/utils/card-api.ts
@@ -93,7 +93,8 @@ export async function addCard(payload: AddCardPayload): Promise<string> {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`HTTP ${response.status}: ${extractErrorMessage(errorText)}`);
+      const message = extractErrorMessage(errorText);
+      throw new Error(response.status === 429 ? message : `HTTP ${response.status}: ${message}`);
     }
 
     const data = await response.json();

--- a/packages/website/app/components/account/home/payment-methods/AddCardDialog.vue
+++ b/packages/website/app/components/account/home/payment-methods/AddCardDialog.vue
@@ -54,11 +54,11 @@ async function handleAddCard() {
     // Reset form state
     set(error, undefined);
   }
-  catch (error: any) {
-    logger.error('Failed to add card:', error);
+  catch (caughtError: any) {
+    logger.error('Failed to add card:', caughtError);
     set(error, {
       title: t('common.error'),
-      message: error.message || t('common.error_occurred'),
+      message: caughtError.message || t('common.error_occurred'),
     });
   }
   finally {
@@ -114,7 +114,7 @@ onUnmounted(async () => {
         type="error"
         class="mb-4"
         :title="error.title"
-        :text="error.message"
+        :description="error.message"
         closeable
         @close="error = undefined"
       />

--- a/packages/website/app/composables/use-fetch-with-csrf.ts
+++ b/packages/website/app/composables/use-fetch-with-csrf.ts
@@ -150,6 +150,10 @@ export const useFetchWithCsrf = createSharedComposable(() => {
     },
     retry: FETCH_CONFIG.RETRIES,
     retryDelay: FETCH_CONFIG.RETRY_DELAY_MS,
+    // ofetch's default retryStatusCodes includes 429, but retrying a rate-limited
+    // request just burns the user's budget and (because Django rotates the CSRF
+    // cookie between requests) often comes back as a confusing 403 HTML page.
+    retryStatusCodes: [408, 409, 425, 500, 502, 503, 504],
     timeout: FETCH_CONFIG.TIMEOUT_MS,
   });
 

--- a/packages/website/app/modules/checkout/composables/use-payment-cards.ts
+++ b/packages/website/app/modules/checkout/composables/use-payment-cards.ts
@@ -27,6 +27,24 @@ export function usePaymentCards(): UsePaymentCardsReturn {
   const logger = useLogger('card-payment');
   const { fetchWithCsrf } = useFetchWithCsrf();
   const emailConfirmed = useEmailConfirmedCookie();
+  const { t } = useI18n();
+
+  function buildAddCardError(error: any): Error {
+    if (error?.statusCode === 429) {
+      const backendMessage: string = error?.data?.message ?? '';
+      const message = backendMessage.toLowerCase().includes('failed')
+        ? t('home.account.payment_methods.errors.rate_limited_failures')
+        : t('home.account.payment_methods.errors.rate_limited');
+      return new Error(message);
+    }
+    // 400s on this endpoint are either schema/JSON-decode errors (frontend bugs the user
+    // can't act on) or Braintree gateway errors (raw "Do Not Honor"-style dumps that read
+    // like a stack trace). Substitute a friendly message; raw cause is kept in the logs.
+    if (error?.statusCode === 400) {
+      return new Error(t('home.account.payment_methods.errors.card_declined'));
+    }
+    return new Error(error?.data?.message || error?.message || t('common.error_occurred'));
+  }
 
   const { data, pending, refresh } = useAsyncData<SavedCard[]>(
     'payment-cards',
@@ -75,7 +93,7 @@ export function usePaymentCards(): UsePaymentCardsReturn {
     }
     catch (error: any) {
       logger.error(error);
-      throw new Error(error.message);
+      throw buildAddCardError(error);
     }
   };
 

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -444,6 +444,11 @@
         "add_card": "Add card",
         "cannot_delete_linked_card": "This card is used for subscription auto-renewal and cannot be deleted",
         "crypto_subscription_no_card_operations": "Card operations are not available for cryptocurrency subscriptions",
+        "errors": {
+          "card_declined": "We couldn't add this card. Please double-check the details or try a different card.",
+          "rate_limited": "Too many add-card attempts. Please wait a while before trying again.",
+          "rate_limited_failures": "Too many failed card attempts. For your security, please wait a while before trying again."
+        },
         "link_card": "Set for auto-renewal",
         "linked_card": "Auto-renewal card",
         "no_active_subscription": "No active subscription found",

--- a/packages/website/tests/unit/composables/use-payment-cards.spec.ts
+++ b/packages/website/tests/unit/composables/use-payment-cards.spec.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+
+import { createFetchError } from '../../utils';
+
+const { mockFetchWithCsrf } = vi.hoisted(() => ({ mockFetchWithCsrf: vi.fn() }));
+
+vi.mock('~/composables/use-fetch-with-csrf', () => ({
+  // ref(false) → useAsyncData('payment-cards', …) short-circuits to [] without calling
+  // fetchWithCsrf, so the mocked rejection in each test is consumed by addCard, not the
+  // auto-refresh. Must be a real Vue ref (a plain { value: false } is truthy under VueUse `get`).
+  useEmailConfirmedCookie: () => ref(false),
+  useFetchWithCsrf: () => ({
+    fetchWithCsrf: mockFetchWithCsrf,
+    setHooks: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/use-logger', () => ({
+  useLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>();
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string): string => key,
+    }),
+  };
+});
+
+describe('usePaymentCards', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('addCard 429 handling', () => {
+    it('uses the failures-specific i18n key when the backend body mentions a failure', async () => {
+      mockFetchWithCsrf.mockRejectedValueOnce(
+        createFetchError(429, { message: 'Too many failed attempts. Please try again later.' }),
+      );
+
+      const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
+      const { addCard } = usePaymentCards();
+
+      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+        .rejects
+        .toThrow('home.account.payment_methods.errors.rate_limited_failures');
+    });
+
+    it('uses the generic rate-limit i18n key for the total-attempts gate', async () => {
+      mockFetchWithCsrf.mockRejectedValueOnce(
+        createFetchError(429, { message: 'Too many attempts. Please try again later.' }),
+      );
+
+      const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
+      const { addCard } = usePaymentCards();
+
+      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+        .rejects
+        .toThrow('home.account.payment_methods.errors.rate_limited');
+    });
+
+    it('falls back to the generic rate-limit i18n key for upstream 429s without a JSON body (e.g. Traefik)', async () => {
+      // Traefik / reverse-proxy 429s typically have no parsed JSON body.
+      mockFetchWithCsrf.mockRejectedValueOnce(createFetchError(429, undefined));
+
+      const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
+      const { addCard } = usePaymentCards();
+
+      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+        .rejects
+        .toThrow('home.account.payment_methods.errors.rate_limited');
+    });
+  });
+
+  describe('addCard 400 handling', () => {
+    it('replaces the raw Braintree gateway dump with the friendly card-declined string', async () => {
+      mockFetchWithCsrf.mockRejectedValueOnce(
+        createFetchError(400, {
+          message: 'Error during payment token generation. Either try again later or get in '
+            + 'contact with your payment provider. Error returned by payment provider was Do Not Honor',
+        }),
+      );
+
+      const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
+      const { addCard } = usePaymentCards();
+
+      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+        .rejects
+        .toThrow('home.account.payment_methods.errors.card_declined');
+    });
+
+    it('uses the friendly card-declined string for schema/validation 400s too', async () => {
+      mockFetchWithCsrf.mockRejectedValueOnce(
+        createFetchError(400, { message: { payment_method_nonce: ['Missing data for required field.'] } }),
+      );
+
+      const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
+      const { addCard } = usePaymentCards();
+
+      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+        .rejects
+        .toThrow('home.account.payment_methods.errors.card_declined');
+    });
+  });
+
+  describe('addCard other errors', () => {
+    it('surfaces the backend message for non-400/429 statuses when present', async () => {
+      mockFetchWithCsrf.mockRejectedValueOnce(
+        createFetchError(500, { message: 'Internal failure' }),
+      );
+
+      const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
+      const { addCard } = usePaymentCards();
+
+      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+        .rejects
+        .toThrow('Internal failure');
+    });
+
+    it('falls back to common.error_occurred when no message is available', async () => {
+      const error = createFetchError(500, undefined);
+      // simulate a totally opaque error object
+      delete (error as any).message;
+      mockFetchWithCsrf.mockRejectedValueOnce(error);
+
+      const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
+      const { addCard } = usePaymentCards();
+
+      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+        .rejects
+        .toThrow('common.error_occurred');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Map `POST /webapi/payment/btr/cards/` 429s and 400s to i18n strings so users no longer see raw Braintree gateway dumps (e.g. *"Do Not Honor"*).
- Stop ofetch from auto-retrying 429s — the retry burned the user's rate budget and (due to Django CSRF cookie rotation between requests) surfaced as a confusing 403 HTML page that broke JSON parsing.
- Fix `AddCardDialog` so error messages actually render: `RuiAlert`'s prop is `description`, not `text` (silently dropped); and the catch block shadowed the outer `error` ref so updates were no-ops.
- Drop the `HTTP 429:` prefix in the standalone `card-payment` package so the backend rate-limit message stands alone.

Pairs with the backend gate in https://github.com/rotki/rotki-web/pull/230.

## Test plan
- [ ] Add a card with a Braintree decline test card (e.g. `4000111111111115`) → dialog shows the friendly *"We couldn't add this card…"* message instead of the raw gateway dump.
- [ ] Trigger the failure-gate (5 declines on the same account in <1h) → next attempt shows *"Too many failed card attempts…"*.
- [ ] Trigger the total gate (>10 add-card attempts/h) → shows *"Too many add-card attempts…"*.
- [ ] Confirm no auto-retry on 429 (network tab shows a single POST per click).
- [ ] `pnpm test` / `pnpm typecheck` / `pnpm lint` all green.