### PR TITLE
fix(card-payment): keep card decline errors inline, not full-screen

### DIFF
--- a/packages/card-payment/src/App.vue
+++ b/packages/card-payment/src/App.vue
@@ -221,7 +221,6 @@ onMounted(async () => {
       :current-step="3"
     >
       <CardPayment
-        v-model:error="errorMessage"
         v-model:selected-card="selectedCard"
         :cards="cards"
         :plan-data="planData"
@@ -232,6 +231,7 @@ onMounted(async () => {
         @payment-success="navigation.goTo3DSecure(upgradeSubId)"
         @go-back="back()"
         @refresh-card="refreshCard()"
+        @fatal-error="errorMessage = $event"
       />
     </CheckoutLayout>
   </DefaultLayout>

--- a/packages/card-payment/src/components/AddCardDialog.vue
+++ b/packages/card-payment/src/components/AddCardDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Client } from 'braintree-web/client';
 import { get, set } from '@vueuse/core';
-import { ref, useTemplateRef } from 'vue';
+import { ref, useTemplateRef, watch } from 'vue';
 import { addCard } from '@/utils/card-api';
 import BaseButton from './BaseButton.vue';
 import BaseDialog from './BaseDialog.vue';
@@ -15,11 +15,11 @@ const { client } = defineProps<{
 
 const emit = defineEmits<{
   'card-added': [token: string];
-  'error': [message: string];
 }>();
 
 const addCardFormValid = ref<boolean>(false);
 const isAddingCard = ref<boolean>(false);
+const addCardError = ref<string>();
 const addCardForm = useTemplateRef<InstanceType<typeof NewCardForm>>('addCardForm');
 
 async function handleAddCard(): Promise<void> {
@@ -28,11 +28,12 @@ async function handleAddCard(): Promise<void> {
   }
 
   set(isAddingCard, true);
+  set(addCardError, undefined);
 
   try {
     const form = get(addCardForm);
     if (!form) {
-      emit('error', 'Add card form not available');
+      set(addCardError, 'Add card form not available');
       set(isAddingCard, false);
       return;
     }
@@ -45,13 +46,21 @@ async function handleAddCard(): Promise<void> {
     emit('card-added', newCardToken);
     set(open, false);
   }
-  catch (error: any) {
-    emit('error', error.message || 'Failed to add card');
+  catch (caughtError: any) {
+    set(addCardError, caughtError.message || 'Failed to add card');
   }
   finally {
     set(isAddingCard, false);
   }
 }
+
+// Reset the inline error each time the dialog is reopened so a stale alert
+// from a prior attempt doesn't persist across sessions.
+watch(open, (isOpen) => {
+  if (isOpen) {
+    set(addCardError, undefined);
+  }
+});
 </script>
 
 <template>
@@ -65,8 +74,29 @@ async function handleAddCard(): Promise<void> {
       :client="client"
       :disabled="isAddingCard"
       @validation-change="addCardFormValid = $event"
-      @error="emit('error', $event)"
+      @error="addCardError = $event"
     />
+
+    <div
+      v-if="addCardError"
+      class="mt-4 flex items-start gap-3 rounded-md border border-rui-error/30 bg-rui-error/10 p-3 text-sm text-rui-error"
+      role="alert"
+    >
+      <svg
+        class="h-5 w-5 shrink-0 mt-0.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+        />
+      </svg>
+      <span class="flex-1">{{ addCardError }}</span>
+    </div>
 
     <template #actions>
       <BaseButton

--- a/packages/card-payment/src/components/CardPayment.vue
+++ b/packages/card-payment/src/components/CardPayment.vue
@@ -28,7 +28,6 @@ interface VatBreakdown {
   fullAmount: string;
 }
 
-const error = defineModel<string>('error', { required: true });
 const selectedCard = defineModel<SavedCard | undefined>('selectedCard', { required: true });
 
 const { planData, selectedPlan, upgradeSubId, cards, vatIdStatus, country } = defineProps<{
@@ -44,7 +43,16 @@ const emit = defineEmits<{
   'go-back': [];
   'payment-success': [];
   'refresh-card': [];
+  // Fatal errors that make the whole payment view unusable (e.g. Braintree client
+  // failed to initialize). The parent should show a full-screen ErrorState. Per-
+  // transaction errors (card decline, payment failure) stay inline.
+  'fatal-error': [message: string];
 }>();
+
+// Per-transaction error (card decline, tokenization failure, payment failure). Kept
+// local so a recoverable problem doesn't escalate to App.vue's full-screen ErrorState,
+// which is reserved for genuinely fatal init failures (e.g. plan/Braintree client load).
+const transactionError = ref<string>();
 
 const client = shallowRef<Client>();
 const isProcessing = ref<boolean>(false);
@@ -122,7 +130,7 @@ async function initializeBraintreeClient(): Promise<void> {
     set(client, clientInstance);
   }
   catch (error_: any) {
-    set(error, `Failed to initialize payment client: ${error_.message}`);
+    emit('fatal-error', `Failed to initialize payment client: ${error_.message}`);
     console.error(error_);
     trackCardPaymentFailure({
       failure: 'BRAINTREE_INIT_FAILED',
@@ -195,7 +203,7 @@ async function processPayment(): Promise<void> {
   }
 
   set(isProcessing, true);
-  set(error, '');
+  set(transactionError, '');
 
   const card = get(selectedCard);
   const cardType = card ? 'saved' as const : 'new' as const;
@@ -226,7 +234,7 @@ async function processPayment(): Promise<void> {
     else {
       const form = get(newCardForm);
       if (!form) {
-        set(error, 'New card form not available');
+        set(transactionError, 'New card form not available');
         set(isProcessing, false);
         return;
       }
@@ -266,7 +274,7 @@ async function processPayment(): Promise<void> {
     emit('payment-success');
   }
   catch (error_: any) {
-    set(error, error_.message || 'Payment failed. Please try again.');
+    set(transactionError, error_.message || 'Payment failed. Please try again.');
     set(isProcessing, false);
     trackCardPaymentFailure({
       failure: 'CARD_PAYMENT_API_ERROR',
@@ -349,6 +357,48 @@ onUnmounted(async () => {
     <div class="grid grid-cols-1 gap-6 xl:grid-cols-[1.5fr_1fr] xl:gap-8 xl:items-start">
       <!-- Left Column: Payment Form -->
       <div class="flex flex-col gap-6 min-w-0">
+        <!-- Inline transaction error (card decline, payment failure, etc.) -->
+        <div
+          v-if="transactionError"
+          class="flex items-start gap-3 rounded-md border border-rui-error/30 bg-rui-error/10 p-4 text-sm text-rui-error"
+          role="alert"
+        >
+          <svg
+            class="h-5 w-5 shrink-0 mt-0.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          <span class="flex-1">{{ transactionError }}</span>
+          <button
+            type="button"
+            class="shrink-0 text-rui-error hover:opacity-70"
+            aria-label="Dismiss"
+            @click="transactionError = undefined"
+          >
+            <svg
+              class="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
         <!-- Card Input Section -->
         <div class="bg-white rounded-lg border border-rui-grey-300 p-6">
           <!-- Saved Card Display -->
@@ -357,7 +407,7 @@ onUnmounted(async () => {
               :card="selectedCard"
               :disabled="isProcessing"
               @card-deleted="handleCardDeleted()"
-              @error="error = $event"
+              @error="transactionError = $event"
             />
 
             <!-- Button to change card -->
@@ -380,7 +430,7 @@ onUnmounted(async () => {
             :client="client"
             :disabled="isProcessing"
             @validation-change="newCardFormValid = $event"
-            @error="error = $event"
+            @error="transactionError = $event"
           />
         </div>
       </div>
@@ -495,7 +545,6 @@ onUnmounted(async () => {
       v-model:open="showAddCardDialog"
       :client="client"
       @card-added="handleCardAdded($event)"
-      @error="error = $event"
     />
   </div>
 </template>

--- a/packages/card-payment/src/utils/card-api.ts
+++ b/packages/card-payment/src/utils/card-api.ts
@@ -93,8 +93,22 @@ export async function addCard(payload: AddCardPayload): Promise<string> {
 
     if (!response.ok) {
       const errorText = await response.text();
-      const message = extractErrorMessage(errorText);
-      throw new Error(response.status === 429 ? message : `HTTP ${response.status}: ${message}`);
+      const backendMessage = extractErrorMessage(errorText);
+      // 400s on this endpoint are either schema/JSON-decode errors (programmer-side) or
+      // raw Braintree gateway dumps ("Do Not Honor" etc.) — replace with a friendly
+      // message; raw cause is kept in the console.error below for debugging.
+      // 429 surfaces the backend's already-user-friendly rate-limit message verbatim.
+      let message: string;
+      if (response.status === 400) {
+        message = 'We couldn\'t add this card. Please double-check the details or try a different card.';
+      }
+      else if (response.status === 429) {
+        message = backendMessage;
+      }
+      else {
+        message = `HTTP ${response.status}: ${backendMessage}`;
+      }
+      throw new Error(message);
     }
 
     const data = await response.json();


### PR DESCRIPTION
## Summary
- A Braintree card decline (e.g. *Do Not Honor*) on the standalone card-payment SPA was escalating to App.vue's full-screen \`<ErrorState>\` (\"Payment Initialization Failed\"), wiping out the whole payment view for a recoverable error.
- Keep per-transaction errors (card decline, tokenize failure, payment failure, child component errors) inline as a dismissable alert at the top of the payment form column.
- Reserve the full-screen escalation for genuine init failures (e.g. Braintree client init) via a new \`fatal-error\` emit.
- Map 400s in this package's \`addCard\` to a friendly message so users don't see the raw \"HTTP 400: Error during payment token generation… Do Not Honor\" dump (raw cause stays in console.error for debugging).

Follow-up to #586.

## Test plan
- [ ] On the card-payment screen with no saved card, enter a Braintree decline test card (e.g. \`4000111111111115\`) → see the friendly inline alert instead of the full-screen \"Payment Initialization Failed\" page.
- [ ] Open the \"Add New Card\" dialog and add a decline test card → friendly alert shows inside the dialog (was previously the full-screen page).
- [ ] Force a Braintree client init failure (e.g. invalid client token) → full-screen ErrorState still shows (this path is intentionally preserved).
- [ ] \`pnpm typecheck\` / \`pnpm lint\` green.