### PR TITLE
feat(account): restrict saved-card management to card customers

### DIFF
--- a/packages/website/app/layouts/account.vue
+++ b/packages/website/app/layouts/account.vue
@@ -25,7 +25,7 @@ useAutoLogout();
 const tabModelValue = ref<string>();
 const hydrated = ref<boolean>(false);
 
-const { account } = storeToRefs(useMainStore());
+const { account, hasCardPayment } = storeToRefs(useMainStore());
 
 const name = computed<string>(() => {
   const userAccount = get(account);
@@ -41,32 +41,38 @@ const name = computed<string>(() => {
   return `${firstName} ${lastName}`;
 });
 
-const tabs = computed<TabItem[]>(() => [{
-  label: t('account.tabs.subscription'),
-  icon: 'lu-crown',
-  to: '/home/subscription',
-}, {
-  label: t('account.tabs.payment_methods'),
-  icon: 'lu-credit-card',
-  to: '/home/saved-cards',
-  reload: true,
-}, {
-  label: t('account.tabs.devices'),
-  icon: 'lu-laptop-minimal',
-  to: '/home/devices',
-}, {
-  label: t('account.tabs.account_details'),
-  icon: 'lu-circle-user-round',
-  to: '/home/account-details',
-}, {
-  label: t('account.tabs.customer_information'),
-  icon: 'lu-info',
-  to: '/home/customer-information',
-}, {
-  label: t('account.tabs.address'),
-  icon: 'lu-map-pin',
-  to: '/home/address',
-}]);
+const tabs = computed<TabItem[]>(() => {
+  const all: TabItem[] = [{
+    label: t('account.tabs.subscription'),
+    icon: 'lu-crown',
+    to: '/home/subscription',
+  }, {
+    label: t('account.tabs.payment_methods'),
+    icon: 'lu-credit-card',
+    to: '/home/saved-cards',
+    reload: true,
+  }, {
+    label: t('account.tabs.devices'),
+    icon: 'lu-laptop-minimal',
+    to: '/home/devices',
+  }, {
+    label: t('account.tabs.account_details'),
+    icon: 'lu-circle-user-round',
+    to: '/home/account-details',
+  }, {
+    label: t('account.tabs.customer_information'),
+    icon: 'lu-info',
+    to: '/home/customer-information',
+  }, {
+    label: t('account.tabs.address'),
+    icon: 'lu-map-pin',
+    to: '/home/address',
+  }];
+
+  return get(hasCardPayment)
+    ? all
+    : all.filter(tab => tab.to !== '/home/saved-cards');
+});
 
 onMounted(() => {
   set(hydrated, true);

--- a/packages/website/app/middleware/02.auth.global.ts
+++ b/packages/website/app/middleware/02.auth.global.ts
@@ -8,6 +8,7 @@ import {
   type AuthState,
   ensureAuthenticated,
   ensureCanBuy,
+  ensureCardCustomer,
   ensureVerified,
   handleGuestOnly,
   type NavigationResult,
@@ -19,13 +20,13 @@ function applyResult(result: NavigationResult): ReturnType<typeof navigateTo> | 
 }
 
 export default defineNuxtRouteMiddleware(async (to) => {
-  const { auth, guestOnly, requiresSubscriber, requiresVerified } = to.meta;
+  const { auth, guestOnly, requiresCardCustomer, requiresSubscriber, requiresVerified } = to.meta;
 
   if (!auth && !guestOnly)
     return;
 
   const store = useMainStore();
-  const { account, authenticated, canBuy } = storeToRefs(store);
+  const { account, authenticated, canBuy, hasCardPayment } = storeToRefs(store);
   const authHint = useAuthHintCookie();
 
   function getState(): AuthState {
@@ -34,6 +35,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
       authHint: get(authHint) ?? undefined,
       canBuy: get(canBuy),
       emailConfirmed: get(account)?.emailConfirmed,
+      hasCardPayment: get(hasCardPayment),
     };
   }
 
@@ -61,6 +63,12 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (requiresSubscriber) {
     const upgradeSubId = typeof to.query.upgradeSubId === 'string' ? to.query.upgradeSubId : undefined;
     const result = await ensureCanBuy(getState, actions, upgradeSubId);
+    if ('redirect' in result)
+      return applyResult(result);
+  }
+
+  if (requiresCardCustomer) {
+    const result = ensureCardCustomer(getState);
     if ('redirect' in result)
       return applyResult(result);
   }

--- a/packages/website/app/pages/home/saved-cards.vue
+++ b/packages/website/app/pages/home/saved-cards.vue
@@ -25,6 +25,7 @@ interface CardOperation {
 definePageMeta({
   auth: true,
   layout: 'account',
+  requiresCardCustomer: true,
 });
 
 const { t } = useI18n({ useScope: 'global' });

--- a/packages/website/app/store/index.ts
+++ b/packages/website/app/store/index.ts
@@ -1,6 +1,8 @@
 import type { Account } from '@rotki/card-payment-common/schemas/account';
+import type { ApiResponse } from '@rotki/card-payment-common/schemas/api';
 import type { LoginCredentials } from '~/types/login';
 import { isSubPending, isSubRequestingUpgrade } from '@rotki/card-payment-common';
+import { PaymentMethod, PaymentProvider } from '@rotki/card-payment-common/schemas/subscription';
 import { isClient, useTimeoutFn } from '@vueuse/core';
 import { get, set } from '@vueuse/shared';
 import { acceptHMRUpdate, defineStore } from 'pinia';
@@ -10,6 +12,7 @@ import { useUserSubscriptions } from '~/composables/subscription/use-user-subscr
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { useAuthHintCookie, useEmailConfirmedCookie, useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { usePendingSubscriptionId } from '~/modules/checkout/composables/use-pending-subscription-id';
+import { UserPayments } from '~/types/account';
 import { isUnauthorizedError } from '~/utils/api-error-handling';
 import { useLogger } from '~/utils/use-logger';
 
@@ -19,9 +22,10 @@ export const useMainStore = defineStore('main', () => {
   const authenticated = ref<boolean>(false);
   const account = ref<Account>();
   const canBuy = ref<boolean>(true);
+  const hasCardPayment = ref<boolean>(false);
 
   const logger = useLogger('store');
-  const { setHooks } = useFetchWithCsrf();
+  const { fetchWithCsrf, setHooks } = useFetchWithCsrf();
   const authHintCookie = useAuthHintCookie();
   const emailConfirmedCookie = useEmailConfirmedCookie();
   const { pendingSubscriptionId, setPendingSubscriptionId, clearPendingSubscriptionId } = usePendingSubscriptionId();
@@ -78,6 +82,36 @@ export const useMainStore = defineStore('main', () => {
     }
   };
 
+  const fetchHasCardPayment = async (): Promise<void> => {
+    // Check already-loaded subscriptions first — refreshed immediately after a
+    // card purchase, so the flag flips without waiting on the payments-history
+    // endpoint (which may lag right after checkout).
+    const subs = get(userSubscriptions);
+    const cardSub = subs.some(s =>
+      s.paymentMethod === PaymentMethod.CARD
+      || s.paymentProvider === PaymentProvider.BRAINTREE,
+    );
+    if (cardSub) {
+      set(hasCardPayment, true);
+      return;
+    }
+
+    try {
+      const response = await fetchWithCsrf<ApiResponse<unknown>>(
+        '/webapi/2/history/payments/',
+        { method: 'GET' },
+      );
+      const payments = UserPayments.parse(response.result);
+      set(hasCardPayment, payments.some(p => p.paidUsing === 'card' && !p.isRefund));
+    }
+    catch (error) {
+      if (!isUnauthorizedError(error)) {
+        logger.error('Failed to fetch payment history:', error);
+      }
+      set(hasCardPayment, false);
+    }
+  };
+
   const getAccount = async (): Promise<void> => {
     const accountData = await accountApi.getAccount();
     if (accountData) {
@@ -87,6 +121,7 @@ export const useMainStore = defineStore('main', () => {
       set(emailConfirmedCookie, accountData.emailConfirmed);
       // Update canBuy after account is set
       await updateCanBuy();
+      await fetchHasCardPayment();
     }
   };
 
@@ -130,6 +165,7 @@ export const useMainStore = defineStore('main', () => {
     set(authHintCookie, undefined);
     set(emailConfirmedCookie, undefined);
     set(canBuy, true); // Reset to default
+    set(hasCardPayment, false);
     clearPendingSubscriptionId();
   }
 
@@ -151,6 +187,7 @@ export const useMainStore = defineStore('main', () => {
     authenticated,
     canBuy: computed<boolean>(() => get(canBuy)),
     getAccount,
+    hasCardPayment: computed<boolean>(() => get(hasCardPayment)),
     login,
     logout,
     pendingSubscriptionId: computed<string | null | undefined>(() => get(pendingSubscriptionId)),

--- a/packages/website/app/types/route-meta.d.ts
+++ b/packages/website/app/types/route-meta.d.ts
@@ -5,6 +5,7 @@ declare module '#app' {
     guestOnly?: boolean;
     requiresVerified?: boolean;
     requiresSubscriber?: boolean;
+    requiresCardCustomer?: boolean;
     backendRequired?: boolean;
   }
 }

--- a/packages/website/app/utils/auth-guards.ts
+++ b/packages/website/app/utils/auth-guards.ts
@@ -5,6 +5,7 @@ export interface AuthState {
   authHint: string | undefined;
   emailConfirmed: boolean | undefined;
   canBuy: boolean;
+  hasCardPayment: boolean;
 }
 
 export type StateGetter = () => AuthState;
@@ -109,6 +110,18 @@ export async function ensureCanBuy(
   }
 
   if (!getState().canBuy && !upgradeSubId)
+    return { redirect: SUBSCRIPTION_PATH };
+
+  return { allow: true };
+}
+
+/**
+ * Ensures the user has at least one historical card payment.
+ * Gates the saved-cards management UI so fresh accounts cannot abuse
+ * the add-card endpoint as a card-tester.
+ */
+export function ensureCardCustomer(getState: StateGetter): NavigationResult {
+  if (!getState().hasCardPayment)
     return { redirect: SUBSCRIPTION_PATH };
 
   return { allow: true };

--- a/packages/website/tests/unit/utils/auth-guards.spec.ts
+++ b/packages/website/tests/unit/utils/auth-guards.spec.ts
@@ -4,6 +4,7 @@ import {
   type AuthState,
   ensureAuthenticated,
   ensureCanBuy,
+  ensureCardCustomer,
   ensureVerified,
   handleGuestOnly,
   type StateGetter,
@@ -15,6 +16,7 @@ function createState(overrides: Partial<AuthState> = {}): AuthState {
     authHint: undefined,
     canBuy: true,
     emailConfirmed: undefined,
+    hasCardPayment: false,
     ...overrides,
   };
 }
@@ -233,6 +235,24 @@ describe('ensureCanBuy', () => {
     const getState = () => createState({ canBuy: false });
 
     const result = await ensureCanBuy(getState, actions, undefined);
+
+    expect(result).toEqual({ redirect: '/home/subscription' });
+  });
+});
+
+describe('ensureCardCustomer', () => {
+  it('should allow users with a prior card payment', () => {
+    const getState = () => createState({ hasCardPayment: true });
+
+    const result = ensureCardCustomer(getState);
+
+    expect(result).toEqual({ allow: true });
+  });
+
+  it('should redirect users without any card payment', () => {
+    const getState = () => createState({ hasCardPayment: false });
+
+    const result = ensureCardCustomer(getState);
 
     expect(result).toEqual({ redirect: '/home/subscription' });
   });


### PR DESCRIPTION
## Summary

- Gates `/home/saved-cards` (page + nav entry) behind a new `requiresCardCustomer` route meta.
- The flag is derived from already-loaded subscriptions (`paymentMethod === CARD` or `paymentProvider === BRAINTREE`) with `/webapi/2/history/payments/` as a fallback — so it flips immediately after a successful card purchase, no race with the payments endpoint.
- Fresh accounts (and accounts that only paid by crypto/paypal) are redirected to `/home/subscription`; the "Payment methods" tab is hidden in the account nav.

Motivation: someone has been creating throwaway accounts and using the add-card UI as a card-testing oracle. This raises the bar for that abuse. Backend enforcement on `/webapi/payment/btr/cards/` is still needed as a follow-up — the frontend block alone is bypassable by anyone hitting the endpoint directly.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (135/135, incl. 2 new `ensureCardCustomer` tests)
- [x] `pnpm lint`
- [ ] Manual: log in with a fresh account → "Payment methods" tab hidden, direct visit to `/home/saved-cards` redirects to `/home/subscription`.
- [ ] Manual: purchase a plan with a card → tab appears, page loads, can add/delete cards.
- [ ] Manual: account with only crypto/paypal payments → tab hidden, direct URL redirects.