### PR TITLE
feat(login): label login field as "Email or username"

### DIFF
--- a/packages/website/app/components/account/login/LoginForm.vue
+++ b/packages/website/app/components/account/login/LoginForm.vue
@@ -84,7 +84,7 @@ async function performLogin() {
           dense
           variant="outlined"
           :disabled="loading"
-          :label="t('auth.common.username')"
+          :label="t('auth.login.email_or_username')"
           autocomplete="username"
           hide-details
           color="primary"

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -283,6 +283,7 @@
     },
     "login": {
       "alert_error": "If you are writing your username and password from the app, we remind you that they are independent accounts.",
+      "email_or_username": "Email or username",
       "first_time_premium": "First time premium?",
       "forgot_password": "Forgot password?",
       "message": " Premium users unlock the full potential of rotki by removing all limits and unlocking all features.",


### PR DESCRIPTION
## Summary
- Update the login form's username field label to "Email or username" to reflect that the backend accepts either.
- Added a dedicated `auth.login.email_or_username` i18n key (scoped to login since other forms use single-purpose username/email fields).
- Field id, autocomplete attribute, validation rule, and API payload key remain `username` (the `username` autocomplete token is the HTML spec value for either-or fields).
- `auth.login.alert_error` intentionally left untouched — it references the desktop app login, which is username-only.

## Test plan
- [ ] Visit `/login`, confirm field label reads "Email or username".
- [ ] Log in with an email — succeeds.
- [ ] Log in with a username — succeeds.
- [ ] Password manager autofill still populates the field.