### PR TITLE
chore(deps): bump @rotki/ui-library to 2.21.0 (+ public-asset patch fix, toggle height)

### DIFF
--- a/packages/card-payment/src/components/DiscountCodeInput.vue
+++ b/packages/card-payment/src/components/DiscountCodeInput.vue
@@ -102,14 +102,18 @@ watch(value, (newValue) => {
             @blur="focused = false"
           />
           <label
-            class="left-0 text-base leading-[3.5] text-rui-text-secondary pointer-events-none absolute flex h-full w-full select-none transition-all border-0 border-transparent pl-12"
+            class="left-0 text-base text-rui-text-secondary pointer-events-none absolute flex items-center h-full w-full origin-left select-none transition-all border-0 border-transparent"
             :class="{
-              'leading-tight text-xs -top-5': value || focused,
-              'top-0': !value && !focused,
+              // Float by transform only (translate up to the notch + scale down).
+              // height and font-size stay constant across states so transition-all
+              // animates smoothly with no jump. Resting/floated are mutually
+              // exclusive so they never compete in the cascade (the conflict was
+              // order-dependent and broke when the ui-library stylesheet reordered).
+              'pl-4 -translate-y-7 scale-75': value || focused,
+              'pl-12': !value && !focused,
               'text-rui-error': hasError,
               'text-rui-primary': focused && !hasError,
               'text-rui-success': !hasError && value && !focused,
-              '!pl-4': value || focused,
             }"
           >
             Discount/Referral Code

--- a/packages/card-payment/src/components/NewCardForm.vue
+++ b/packages/card-payment/src/components/NewCardForm.vue
@@ -228,13 +228,12 @@ defineExpose({
           class="leading-6 text-rui-text w-full bg-transparent outline-0 outline-none transition-all h-14 border-b-0 px-3"
         />
         <label
-          class="left-0 text-base leading-[3.5] text-rui-text-secondary pointer-events-none absolute flex h-full w-full select-none transition-all border-0 border-transparent pl-12"
+          class="left-0 text-base text-rui-text-secondary pointer-events-none absolute flex items-center h-full w-full origin-left select-none transition-all border-0 border-transparent"
           :class="{
-            'leading-tight text-xs -top-5': focusedField === 'number' || fieldContent.number,
-            'top-0': focusedField !== 'number' && !fieldContent.number,
+            'pl-4 -translate-y-7 scale-75': focusedField === 'number' || fieldContent.number,
+            'pl-12': focusedField !== 'number' && !fieldContent.number,
             'text-rui-error': fieldErrors.number,
             'text-rui-success': focusedField === 'number' && !fieldErrors.number,
-            '!pl-4': focusedField === 'number' || fieldContent.number,
           }"
         >
           Card Number
@@ -265,10 +264,10 @@ defineExpose({
           class="leading-6 text-rui-text w-full bg-transparent outline-0 outline-none transition-all h-14 border-b-0 px-3"
         />
         <label
-          class="left-0 text-base leading-[3.5] text-rui-text-secondary pointer-events-none absolute flex h-full w-full select-none transition-all border-0 border-transparent pl-3"
+          class="left-0 text-base text-rui-text-secondary pointer-events-none absolute flex items-center h-full w-full origin-left select-none transition-all border-0 border-transparent"
           :class="{
-            'leading-tight text-xs -top-5 pl-4': focusedField === 'expirationDate' || fieldContent.expirationDate,
-            'top-0': focusedField !== 'expirationDate' && !fieldContent.expirationDate,
+            'pl-4 -translate-y-7 scale-75': focusedField === 'expirationDate' || fieldContent.expirationDate,
+            'pl-3': focusedField !== 'expirationDate' && !fieldContent.expirationDate,
             'text-rui-error': fieldErrors.expirationDate,
             'text-rui-success': focusedField === 'expirationDate' && !fieldErrors.expirationDate,
           }"
@@ -301,10 +300,10 @@ defineExpose({
           class="leading-6 text-rui-text w-full bg-transparent outline-0 outline-none transition-all h-14 border-b-0 px-3"
         />
         <label
-          class="left-0 text-base leading-[3.5] text-rui-text-secondary pointer-events-none absolute flex h-full w-full select-none transition-all border-0 border-transparent pl-3"
+          class="left-0 text-base text-rui-text-secondary pointer-events-none absolute flex items-center h-full w-full origin-left select-none transition-all border-0 border-transparent"
           :class="{
-            'leading-tight text-xs -top-5 pl-4': focusedField === 'cvv' || fieldContent.cvv,
-            'top-0': focusedField !== 'cvv' && !fieldContent.cvv,
+            'pl-4 -translate-y-7 scale-75': focusedField === 'cvv' || fieldContent.cvv,
+            'pl-3': focusedField !== 'cvv' && !fieldContent.cvv,
             'text-rui-error': fieldErrors.cvv,
             'text-rui-success': focusedField === 'cvv' && !fieldErrors.cvv,
           }"

--- a/packages/website/app/components/pricings/PricingPeriodTab.vue
+++ b/packages/website/app/components/pricings/PricingPeriodTab.vue
@@ -43,7 +43,7 @@ const tabs = [
   <div class="flex relative">
     <RuiTabs
       v-model="model"
-      class="border border-rui-gray-200 bg-rui-grey-200 rounded-md [&>div]:p-1"
+      class="border border-rui-gray-200 bg-rui-grey-200 rounded-md [&>div]:p-1 [&>div]:!h-auto"
     >
       <RuiTab
         v-for="tab in tabs"

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -161,6 +161,41 @@ export default defineNuxtConfig({
   ],
 
   vite: {
+    // Pre-bundle deps Vite's startup scan misses (subpath/deep imports), so the
+    // dev server doesn't discover them mid-session and trigger a full reload.
+    // Dev-only: has no effect on the production build. Covers heavy
+    // route-specific libs (web3/payments) too, at the cost of a slower dev
+    // cold-start.
+    optimizeDeps: {
+      include: [
+        '@rotki/ui-library',
+        '@rotki/ui-library/components',
+        '@rotki/ui-library/composables',
+        '@vue/devtools-core',
+        '@vue/devtools-kit',
+        '@vuelidate/core',
+        '@vuelidate/validators',
+        'zod',
+        'swiper/vue',
+        'swiper/modules',
+        'qrcode',
+        'ethers',
+        'ethers/address',
+        'ethers/constants',
+        'ethers/contract',
+        'ethers/providers',
+        'ethers/utils',
+        '@reown/appkit',
+        '@reown/appkit/vue',
+        '@reown/appkit/networks',
+        '@reown/appkit-adapter-ethers',
+        '@reown/appkit-controllers',
+        'braintree-web',
+        'braintree-web/client',
+        'braintree-web/hosted-fields',
+        'braintree-web/three-d-secure',
+      ],
+    },
     build: {
       // Disable Vite's automatic modulepreload link injection
       // Dynamic imports will still work, but won't preload dependencies

--- a/packages/website/tests/e2e/specs/pages/index.spec.ts
+++ b/packages/website/tests/e2e/specs/pages/index.spec.ts
@@ -212,7 +212,9 @@ test.describe('download page', () => {
     await expect(linuxButton).toBeVisible();
     await linuxButton.click();
 
-    const linuxMenu = page.locator('[role=menu-content]');
+    // scope to this menu's content: closed menus stay in the DOM, so a bare
+    // [role=menu] matches multiple elements
+    const linuxMenu = page.locator('[role=menu]').filter({ hasText: 'LINUX' });
     await expect(linuxMenu).toBeVisible();
 
     const linuxAppImageLink = page.getByRole('link', { name: 'LINUX AppImage' });
@@ -253,7 +255,7 @@ test.describe('download page', () => {
     await expect(appleButton).toBeVisible();
     await appleButton.click();
 
-    const appleMenu = page.locator('[role=menu-content]');
+    const appleMenu = page.locator('[role=menu]').filter({ hasText: 'MAC' });
     await expect(appleMenu).toBeVisible();
 
     const appleSiliconLink = page.getByRole('link', { name: 'MAC Apple Silicon' });

--- a/patches/@nuxt__vite-builder@4.4.6.patch
+++ b/patches/@nuxt__vite-builder@4.4.6.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.mjs b/dist/index.mjs
-index cba32bb19d053c847fe180477cf16984130d24fd..e73da76b8db78993d0a62d4f4476b167cdb71165 100644
+index cba32bb19d053c847fe180477cf16984130d24fd..106a1e35fcb57e11a1f714703d6ca2dff03aa8db 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
 @@ -522,8 +522,15 @@ function sendError(socket, id, error) {
@@ -20,3 +20,14 @@ index cba32bb19d053c847fe180477cf16984130d24fd..e73da76b8db78993d0a62d4f4476b167
  const CSS_URL_RE = /url\((\/[^)]+)\)/g;
  const CSS_URL_SINGLE_RE = /url\(\/[^)]+\)/;
  const RENDER_CHUNK_RE = /(?<= = )['"`]/;
+@@ -553,7 +560,9 @@ const PublicDirsPlugin = (options) => {
+ 			order: "pre",
+ 			filter: { id: PREFIX_RE },
+ 			handler(id) {
+-				return `import { publicAssetsURL } from '#internal/nuxt/paths';export default publicAssetsURL(${JSON.stringify(decodeURIComponent(id.slice(15)))})`;
++				// slice(16) (not 15): the added null byte makes the prefix one char
++				// longer, so the old hardcoded offset left a stray "?" on the path.
++				return `import { publicAssetsURL } from '#internal/nuxt/paths';export default publicAssetsURL(${JSON.stringify(decodeURIComponent(id.slice(16)))})`;
+ 			}
+ 		},
+ 		resolveId: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 5.2.10
       version: 5.2.10
     '@rotki/ui-library':
-      specifier: 2.15.0
-      version: 2.15.0
+      specifier: 2.21.0
+      version: 2.21.0
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -149,7 +149,7 @@ importers:
     devDependencies:
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.15.0(dayjs@1.11.13)(vue@3.5.34(typescript@5.9.3))
+        version: 2.21.0(dayjs@1.11.13)(tailwindcss@3.4.19(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@tsconfig/node24':
         specifier: 'catalog:'
         version: 24.0.4
@@ -325,7 +325,7 @@ importers:
         version: 1.60.0
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.15.0(dayjs@1.11.13)(vue@3.5.34(typescript@5.9.3))
+        version: 2.21.0(dayjs@1.11.13)(tailwindcss@3.4.19(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       '@types/braintree-web':
         specifier: 'catalog:'
         version: 3.96.17
@@ -1455,6 +1455,15 @@ packages:
 
   '@fingerprintjs/botd@2.0.0':
     resolution: {integrity: sha512-yhuz23NKEcBDTHmGz/ULrXlGnbHenO+xZmVwuBkuqHUkqvaZ5TAA0kAgcRy4Wyo5dIBdkIf57UXX8/c9UlMLJg==}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@fontsource/roboto@5.2.10':
     resolution: {integrity: sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==}
@@ -2767,9 +2776,6 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@popperjs/core@2.11.8':
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -3165,12 +3171,16 @@ packages:
     peerDependencies:
       eslint: ^9.20.0
 
-  '@rotki/ui-library@2.15.0':
-    resolution: {integrity: sha512-pRuTCsIB6hT4jiU3AZgZ8+VI8Z8C0WrpuAji8ESe6hT/X51CNdM4TpZtOG+lFKLFTi4/DL/w9qzAH35GWypCPw==}
+  '@rotki/ui-library@2.21.0':
+    resolution: {integrity: sha512-wd5UcCh0yuu/gtAPSFaTyS4CP4NOtvTwOLFg9EKz2rez+bHBiSq7S/5Alm7ao3LqOWLZ2T/a9ACnPfOqnfZYwQ==}
     engines: {node: '>=24 <25', pnpm: '>=10 <11'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
       vue: '>=3.5.0'
+      vue-router: '>=5.0.0'
+    peerDependenciesMeta:
+      vue-router:
+        optional: true
 
   '@safe-global/safe-apps-provider@0.18.6':
     resolution: {integrity: sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==}
@@ -8705,6 +8715,19 @@ packages:
     peerDependencies:
       tailwindcss: 1 || 2 || 2.0.1-compat || 3
 
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+
+  tailwind-variants@3.2.2:
+    resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
+
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
@@ -10843,6 +10866,17 @@ snapshots:
 
   '@fingerprintjs/botd@2.0.0': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@fontsource/roboto@5.2.10': {}
 
   '@humanfs/core@0.19.1': {}
@@ -12365,8 +12399,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@popperjs/core@2.11.8': {}
-
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -12975,15 +13007,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.15.0(dayjs@1.11.13)(vue@3.5.34(typescript@5.9.3))':
+  '@rotki/ui-library@2.21.0(dayjs@1.11.13)(tailwindcss@3.4.19(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
-      '@popperjs/core': 2.11.8
+      '@floating-ui/dom': 1.7.6
       '@vueuse/core': 14.2.1(vue@3.5.34(typescript@5.9.3))
       '@vueuse/shared': 14.2.1(vue@3.5.34(typescript@5.9.3))
       dayjs: 1.11.13
       scule: 1.3.0
+      tailwind-merge: 2.6.1
+      tailwind-variants: 3.2.2(tailwind-merge@2.6.1)(tailwindcss@3.4.19(yaml@2.9.0))
       tinycolor2: 1.6.0
       vue: 3.5.34(typescript@5.9.3)
+    optionalDependencies:
+      vue-router: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+    transitivePeerDependencies:
+      - tailwindcss
 
   '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
@@ -20147,6 +20185,14 @@ snapshots:
       tailwindcss: 3.4.19(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  tailwind-merge@2.6.1: {}
+
+  tailwind-variants@3.2.2(tailwind-merge@2.6.1)(tailwindcss@3.4.19(yaml@2.9.0)):
+    dependencies:
+      tailwindcss: 3.4.19(yaml@2.9.0)
+    optionalDependencies:
+      tailwind-merge: 2.6.1
 
   tailwindcss@3.4.19(yaml@2.9.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ overrides:
   chokidar: 5.0.0
 
 patchedDependencies:
-  '@nuxt/vite-builder@4.4.6': 350f482b22d8e5e03bfdfd79ed88cb961c950cda2c2d93a9d66ce5b33ee580e0
+  '@nuxt/vite-builder@4.4.6': b60bc93bc57e827f2abb6a1345d2a46fddba4150e7e283e3bc55250a721f7f8b
 
 importers:
 
@@ -11725,7 +11725,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/vite-builder@4.4.6(patch_hash=350f482b22d8e5e03bfdfd79ed88cb961c950cda2c2d93a9d66ce5b33ee580e0)(267f9276b852f2f39cdc35cfd8d4b371)':
+  '@nuxt/vite-builder@4.4.6(patch_hash=b60bc93bc57e827f2abb6a1345d2a46fddba4150e7e283e3bc55250a721f7f8b)(267f9276b852f2f39cdc35cfd8d4b371)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -18420,7 +18420,7 @@ snapshots:
       '@nuxt/nitro-server': 4.4.6(a89497934179389563b9cf698aeb2c7d)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.6(patch_hash=350f482b22d8e5e03bfdfd79ed88cb961c950cda2c2d93a9d66ce5b33ee580e0)(267f9276b852f2f39cdc35cfd8d4b371)
+      '@nuxt/vite-builder': 4.4.6(patch_hash=b60bc93bc57e827f2abb6a1345d2a46fddba4150e7e283e3bc55250a721f7f8b)(267f9276b852f2f39cdc35cfd8d4b371)
       '@unhead/vue': 2.1.15(vue@3.5.34(typescript@5.9.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ trustPolicyExclude:
   - '@noble/hashes@1.7.0'
   - slow-redact@0.3.2
   - synckit@0.9.3
+  - tailwind-merge@2.6.1
 
 overrides:
   chokidar: 5.0.0
@@ -37,7 +38,7 @@ packages:
 
 catalog:
   '@fontsource/roboto': 5.2.10
-  '@rotki/ui-library': 2.15.0
+  '@rotki/ui-library': 2.21.0
   '@types/braintree-web': 3.96.17
   '@types/node': 24.12.4
   '@tsconfig/node24': 24.0.4


### PR DESCRIPTION
## Summary

Bumps `@rotki/ui-library` 2.15.0 → 2.21.0, plus the fixes that surfaced while validating the bump against the running app. Commits:

1. **`chore(deps)`** — ui-library 2.15.0 → 2.21.0. Allows `tailwind-merge@2.6.1` via `trustPolicyExclude` (new transitive dep for `tv()`; no provenance but same maintainer as the provenance-bearing 3.x line).
2. **`fix(deps)`** — corrects the `@nuxt/vite-builder` patch (`slice(16)`); the prior `slice(15)` left a stray `?` → broken `/?/img/*` URLs (404) for `/public` assets. **This regression was live on `main`.**
3. **`fix(pricing)`** — billing toggle height (RuiTabs now forces `h-[3rem]`) + `vite.optimizeDeps.include` (dev-only).
4. **`test(e2e)`** — ui-library 2.21 changed RuiMenu: content role `menu-content` → valid `menu`, and closed menus persist in the DOM. Updated the download-page test to `[role=menu]` scoped per OS.
5. **`fix(card-payment)`** — discount + card (number/expiry/cvv) floating labels. The hand-rolled labels mixed resting/floated utilities on one element, so cascade order decided the winner; 2.21's CSS reorder broke them. Reworked to be order-independent and to float via **transform only** (translate+scale, constant height/font) so the transition no longer jumps.

## Verification

- typecheck / lint / unit tests (189) green
- card-payment + website production builds green
- browser (chrome-devtools): `/img/*` load 200 (no `/?/img/`); toggle 40px; floating labels center on the notch with smooth transitions
- e2e download menu assertions updated to the corrected ARIA role