### PR TITLE
fix(referral): persist ?ref code so navigation can't strip it

### DIFF
--- a/packages/website/app/composables/chronicling/use-referral-tracking.ts
+++ b/packages/website/app/composables/chronicling/use-referral-tracking.ts
@@ -1,0 +1,40 @@
+import { get, set } from '@vueuse/shared';
+
+const REFERRAL_COOKIE_NAME = 'referral_code';
+const REFERRAL_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+// Referral codes arrive as a `?ref=` query param on inbound links, but the param is
+// dropped by any in-app navigation that doesn't carry it forward (top nav, logo,
+// footer, the valid-plan-id redirect). Persisting it in a cookie keeps the attribution
+// sticky across lateral navigation and reloads until a purchase consumes it. Mirrors
+// the UTM capture pattern in `useUtmTracking`.
+export function useReferralTracking() {
+  const referralCookie = useCookie<string | undefined>(REFERRAL_COOKIE_NAME, {
+    maxAge: REFERRAL_COOKIE_MAX_AGE_SECONDS,
+    sameSite: 'lax',
+    path: '/',
+  });
+
+  // Capture the inbound `?ref=` from the landing route. Called once on app start
+  // (client-side) alongside UTM capture; last inbound code wins.
+  function captureReferralCode(): void {
+    if (import.meta.server)
+      return;
+
+    const { ref } = useRoute().query;
+    if (typeof ref === 'string' && ref && get(referralCookie) !== ref)
+      set(referralCookie, ref);
+  }
+
+  // Consume the attribution after a successful purchase so it isn't re-applied to
+  // the user's future purchases.
+  function clearReferralCode(): void {
+    set(referralCookie, undefined);
+  }
+
+  return {
+    captureReferralCode,
+    clearReferralCode,
+    referralCode: readonly(referralCookie),
+  };
+}

--- a/packages/website/app/modules/checkout/composables/use-checkout.ts
+++ b/packages/website/app/modules/checkout/composables/use-checkout.ts
@@ -7,6 +7,7 @@ import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useAvailablePlans } from '~/composables/tiers/use-available-plans';
 import { useTiersApi } from '~/composables/tiers/use-tiers-api';
 import { usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
+import { useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
 import { logger } from '~/utils/use-logger';
 
 export interface CheckoutError {
@@ -49,10 +50,9 @@ export function useCheckout() {
     return id && typeof id === 'string' ? id : undefined;
   });
 
-  const referralCode = computed<string | undefined>(() => {
-    const ref = getCurrentRoute().query.ref;
-    return ref && typeof ref === 'string' ? ref : undefined;
-  });
+  // Prefers the live ?ref query and falls back to the persisted cookie (see
+  // useReferralCodeParam) so the code survives navigation that stripped the param.
+  const { referralCode } = useReferralCodeParam();
 
   // ===================
   // Derived flags

--- a/packages/website/app/modules/checkout/composables/use-plan-params.ts
+++ b/packages/website/app/modules/checkout/composables/use-plan-params.ts
@@ -1,4 +1,5 @@
 import { get } from '@vueuse/shared';
+import { useReferralTracking } from '~/composables/chronicling/use-referral-tracking';
 
 type CurrencyParam = string | null;
 
@@ -53,12 +54,15 @@ type ReferralCodeParam = string | undefined;
 
 export function useReferralCodeParam() {
   const route = useRoute();
+  const { referralCode: storedReferralCode } = useReferralTracking();
   const referralCode = computed<ReferralCodeParam>(() => {
     const { ref } = route.query;
-    if (typeof ref !== 'string' || !ref)
-      return undefined;
+    if (typeof ref === 'string' && ref)
+      return ref;
 
-    return ref;
+    // Fall back to the persisted cookie when the query param was stripped by
+    // navigation (top nav, logo, footer, valid-plan-id redirect).
+    return get(storedReferralCode) || undefined;
   });
 
   return { referralCode };

--- a/packages/website/app/pages/checkout/success.vue
+++ b/packages/website/app/pages/checkout/success.vue
@@ -3,6 +3,7 @@ import { navigateTo } from '#app';
 import PageContainer from '~/components/common/PageContainer.vue';
 import PageContent from '~/components/common/PageContent.vue';
 import { useAutoLogout } from '~/composables/account/use-auto-logout';
+import { useReferralTracking } from '~/composables/chronicling/use-referral-tracking';
 import { usePageSeoNoIndex } from '~/composables/use-page-seo';
 import { useCheckout } from '~/modules/checkout/composables/use-checkout';
 
@@ -19,6 +20,11 @@ useAutoLogout();
 // Clear checkout state after successful payment
 const { reset } = useCheckout();
 reset();
+
+// Consume the referral attribution: a purchase reaching this page was sent to the
+// backend with the persisted ref, so clear the cookie to avoid re-applying it to
+// the user's future purchases.
+useReferralTracking().clearReferralCode();
 
 const route = useRoute();
 const crypto = computed<boolean>(() => !!route.query.crypto);

--- a/packages/website/app/plugins/startup.ts
+++ b/packages/website/app/plugins/startup.ts
@@ -1,5 +1,6 @@
 import { setSigilDebug } from '@rotki/sigil';
 import { get } from '@vueuse/shared';
+import { useReferralTracking } from '~/composables/chronicling/use-referral-tracking';
 import { useUtmTracking } from '~/composables/chronicling/use-utm-tracking';
 import { useAuthHintCookie } from '~/composables/use-fetch-with-csrf';
 import { useMainStore } from '~/store';
@@ -20,6 +21,9 @@ export default defineNuxtPlugin(async () => {
 
     const { captureUtmParams } = useUtmTracking();
     captureUtmParams();
+
+    const { captureReferralCode } = useReferralTracking();
+    captureReferralCode();
   }
 
   const authHint = useAuthHintCookie();

--- a/packages/website/tests/unit/composables/use-plan-params.nuxt.spec.ts
+++ b/packages/website/tests/unit/composables/use-plan-params.nuxt.spec.ts
@@ -1,0 +1,57 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { get } from '@vueuse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+import { useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
+
+// Controllable route query + persisted referral cookie. The mock factories only
+// reference these refs when invoked (at test time), so closing over them is safe.
+const query = ref<Record<string, unknown>>({});
+const cookie = ref<string | undefined>(undefined);
+
+mockNuxtImport('useRoute', () => () => ({ query: get(query) }));
+mockNuxtImport('useCookie', () => () => cookie);
+
+describe('useReferralCodeParam', () => {
+  beforeEach(() => {
+    query.value = {};
+    cookie.value = undefined;
+  });
+
+  it('returns the ref from the query when present', () => {
+    query.value = { ref: 'FROM_QUERY' };
+    const { referralCode } = useReferralCodeParam();
+    expect(get(referralCode)).toBe('FROM_QUERY');
+  });
+
+  it('falls back to the cookie when the query param was stripped', () => {
+    cookie.value = 'FROM_COOKIE';
+    const { referralCode } = useReferralCodeParam();
+    expect(get(referralCode)).toBe('FROM_COOKIE');
+  });
+
+  it('prefers the query param over the cookie', () => {
+    query.value = { ref: 'FROM_QUERY' };
+    cookie.value = 'FROM_COOKIE';
+    const { referralCode } = useReferralCodeParam();
+    expect(get(referralCode)).toBe('FROM_QUERY');
+  });
+
+  it('returns undefined when neither query nor cookie has a code', () => {
+    const { referralCode } = useReferralCodeParam();
+    expect(get(referralCode)).toBeUndefined();
+  });
+
+  it('ignores an empty-string query param and falls back to the cookie', () => {
+    query.value = { ref: '' };
+    cookie.value = 'FROM_COOKIE';
+    const { referralCode } = useReferralCodeParam();
+    expect(get(referralCode)).toBe('FROM_COOKIE');
+  });
+
+  it('ignores an array-valued query param', () => {
+    query.value = { ref: ['A', 'B'] };
+    const { referralCode } = useReferralCodeParam();
+    expect(get(referralCode)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Referral codes arrive as a `?ref=` query param, but the code was read live from `route.query.ref` with no persistence. Any navigation that didn't carry the query forward dropped it — the top nav, the logo, the footer, and the `valid-plan-id` redirect all use static link targets, so clicking e.g. **Pricing** from `/products?ref=CODE` lost the attribution before checkout.

## Fix

Persist the inbound `?ref` into a 30-day cookie, captured once on app start from the landing route (client-side), mirroring the existing UTM capture in `useUtmTracking` / `startup.ts`.

- New `useReferralTracking()` composable (capture / read / clear), colocated with `useUtmTracking`.
- `useReferralCodeParam` reads `route.query.ref` first and falls back to the cookie when the param is absent; `useCheckout` delegates to it so the fallback lives in one place.
- The success page calls `clearReferralCode()` — a purchase reaching that page was already sent to the backend with the ref, so the attribution is consumed and must not re-apply to the user's future purchases.

This fixes every strip point at once without touching the individual links, and survives reloads/new tabs.

## Tests

Adds `use-plan-params.nuxt.spec.ts` covering the query→cookie fallback (query present, cookie fallback, query-precedence, empty/array query, neither). Full suite: 141 passing. typecheck + lint clean.

## Notes

- Conflict-free against `develop` (referral-credit feature) — verified no file overlap.
- The bug exists on `main` today independent of the referral-credit work; the backend already records `ref` on checkout.