### PR TITLE
fix(referral): auto-apply referral code as discount in crypto/paypal checkout

### DIFF
--- a/packages/website/app/modules/checkout/composables/use-checkout.ts
+++ b/packages/website/app/modules/checkout/composables/use-checkout.ts
@@ -86,11 +86,27 @@ export function useCheckout() {
   // ===================
   // Discount code handling
   // ===================
-  // Input value (for text field binding)
-  const discountCodeInput = ref<string>(String(getCurrentRoute().query.discountCode || getCurrentRoute().query.ref || ''));
+  // Tracks whether the user dismissed the auto-applied referral discount. Persisted via
+  // useState so it survives client-side navigation through the checkout (the URL cannot
+  // carry it - buildQueryParams strips empty values), and resets on a full reload.
+  const referralDismissed = useState<boolean>('checkout-referral-dismissed', () => false);
 
-  // Applied value (from URL - source of truth)
-  const appliedDiscountCode = computed<string>(() => String(getCurrentRoute().query.discountCode || ''));
+  // Applied value (source of truth). An explicit discountCode in the URL wins; otherwise
+  // the referral code is auto-applied as a discount (mirroring the card flow) unless the
+  // user dismissed it.
+  const appliedDiscountCode = computed<string>(() => {
+    const code = getCurrentRoute().query.discountCode;
+    if (typeof code === 'string' && code)
+      return code;
+
+    if (get(referralDismissed))
+      return '';
+
+    return get(referralCode) ?? '';
+  });
+
+  // Input value (for text field binding), seeded from the applied value.
+  const discountCodeInput = ref<string>(get(appliedDiscountCode));
 
   // ===================
   // Breakdown data (persists across navigations via useState)
@@ -135,6 +151,9 @@ export function useCheckout() {
 
   async function applyDiscount(): Promise<void> {
     const code = get(discountCodeInput);
+    // An empty input clears the discount; remember the dismissal so an auto-applied
+    // referral code is not immediately re-applied (see appliedDiscountCode).
+    set(referralDismissed, !code);
     const currentRoute = getCurrentRoute();
     await navigateTo({
       path: currentRoute.path,
@@ -211,6 +230,7 @@ export function useCheckout() {
     set(planSwitchLoading, false);
     set(loading, false);
     set(error, undefined);
+    set(referralDismissed, false);
   }
 
   // ===================


### PR DESCRIPTION
## Problem

Referral codes share the discount-code slot (the breakdown returns an `isReferral` flag). The **card** flow prefills the discount from `?ref` and auto-applies it; the **crypto/paypal** flow only seeded the discount text input from `?ref` — `appliedDiscountCode` (source of truth for the breakdown + payment payload) read `query.discountCode` alone, so the referral was never applied until the user clicked **Apply**, where it showed as a plain "discount".

## Fix

`appliedDiscountCode` falls back to the referral code when no explicit `discountCode` is in the URL, so crypto/paypal auto-apply it on load like card. The applied UI already distinguishes referral from discount via `isReferral`, so it shows **"Referral code applied"** automatically — no relabel work needed.

Removal is tracked with a `useState` flag (`checkout-referral-dismissed`), not a URL sentinel: clearing the field marks the referral dismissed so it isn't auto-re-applied, surviving client-side navigation while resetting on a full page load (the pay routes hard-reload via `navigateToWithCSPSupport`, so this matches the card flow's session-scoped behavior). The text input is seeded from `appliedDiscountCode` so the field and applied state never disagree.

## Safety

Payload is unchanged from the existing **manual-apply** path, which already sent `discountCode == referralCode` alongside the separate `referralCode`. Also falls back to the persisted referral cookie (#603), so it works even if `?ref` was stripped by navigation.

## Review

A `/code-review` pass flagged a first-cut approach (empty-string URL sentinel) that didn't survive `buildQueryParams` (strips empties); reworked to the `useState` flag above.

## Verification

Built + served via the Go static stack proxying to Django; confirmed in-browser: crypto **and** paypal auto-apply on load; removal sticks within a page view and across client-side nav; re-applies on full reload (session-scoped). typecheck + lint clean, 141 unit tests pass.