### PR TITLE
feat: add Reddit link to values contact section

### DIFF
--- a/packages/website/app/components/values/ValueContact.vue
+++ b/packages/website/app/components/values/ValueContact.vue
@@ -6,7 +6,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const {
   public: {
-    contact: { emailMailto, email, twitter, discord, github },
+    contact: { emailMailto, email, twitter, discord, github, reddit },
   },
 } = useRuntimeConfig();
 
@@ -30,6 +30,12 @@ const contacts: { title: string; description: string; href: string; icon: RuiIco
     description: t('values.contact_section.discord.description'),
     href: discord,
     icon: 'lu-discord',
+  },
+  {
+    title: 'Reddit',
+    description: t('values.contact_section.reddit.description'),
+    href: reddit,
+    icon: 'lu-reddit',
   },
   {
     title: 'Github',

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -1221,6 +1221,9 @@
         "description": "Contribute code/issues."
       },
       "header": "Get in touch",
+      "reddit": {
+        "description": "Join the discussion."
+      },
       "subtitle": "For media inquiries or additional information about rotki, please reach out to:",
       "title": "Contact us",
       "twitter": {

--- a/packages/website/tests/setup.ts
+++ b/packages/website/tests/setup.ts
@@ -18,6 +18,7 @@ mockNuxtImport('useRuntimeConfig', () => () => {
         email: 'info@rotki.com',
         emailMailto: 'mailto:info@rotki.com',
         github: 'https://github.com/rotki',
+        reddit: 'https://www.reddit.com/r/rotki',
         twitter: 'https://twitter.com/rotkiapp',
       },
       i18n: {


### PR DESCRIPTION
## Summary

The footer socials and schema.org `sameAs` already linked our subreddit (https://www.reddit.com/r/rotki). This extends the Reddit link to the **values-page contact section**, which previously listed only Email, Twitter, Discord, and GitHub.

## Changes

- `ValueContact.vue` — add a Reddit entry (`lu-reddit` icon) to the contact list
- `en.json` — add `values.contact_section.reddit.description` ("Join the discussion.")
- `tests/setup.ts` — add `reddit` to the mocked runtime-config `contact` block for parity

## Notes

- `lu-reddit` is a valid icon in `@rotki/ui-library@2.21.0` (confirmed in the icon registry and `RuiIcons` type union).
- No test renders these components today, so the mock key is added purely for config parity.