### PR TITLE
fix(backend): accept is_upgrade/card_type/discount_applied in payment log

### DIFF
--- a/backend/internal/api/paymentlog/handler.go
+++ b/backend/internal/api/paymentlog/handler.go
@@ -44,15 +44,24 @@ var allowedSteps = map[string]bool{
 	"callback": true,
 }
 
+// Allowed card types.
+var allowedCardTypes = map[string]bool{
+	"saved": true,
+	"new":   true,
+}
+
 // event is the request body for a payment error event.
 type event struct {
-	PaymentMethod string `json:"payment_method"`
-	Event         string `json:"event"`
-	ErrorMessage  string `json:"error_message"`
-	ErrorCode     string `json:"error_code,omitempty"`
-	PlanID        *int   `json:"plan_id,omitempty"`
-	Step          string `json:"step,omitempty"`
-	Timestamp     int64  `json:"timestamp"`
+	PaymentMethod   string `json:"payment_method"`
+	Event           string `json:"event"`
+	ErrorMessage    string `json:"error_message"`
+	ErrorCode       string `json:"error_code,omitempty"`
+	PlanID          *int   `json:"plan_id,omitempty"`
+	Step            string `json:"step,omitempty"`
+	IsUpgrade       *bool  `json:"is_upgrade,omitempty"`
+	CardType        string `json:"card_type,omitempty"`
+	DiscountApplied *bool  `json:"discount_applied,omitempty"`
+	Timestamp       int64  `json:"timestamp"`
 }
 
 // Handler logs frontend payment error events.
@@ -109,6 +118,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if ev.Step != "" {
 		attrs = append(attrs, "step", ev.Step)
 	}
+	if ev.IsUpgrade != nil {
+		attrs = append(attrs, "is_upgrade", *ev.IsUpgrade)
+	}
+	if ev.CardType != "" {
+		attrs = append(attrs, "card_type", ev.CardType)
+	}
+	if ev.DiscountApplied != nil {
+		attrs = append(attrs, "discount_applied", *ev.DiscountApplied)
+	}
 
 	h.logger.Info("payment_event", attrs...)
 
@@ -127,6 +145,9 @@ func (h *Handler) isValid(ev *event) bool {
 		return false
 	}
 	if ev.Step != "" && !allowedSteps[ev.Step] {
+		return false
+	}
+	if ev.CardType != "" && !allowedCardTypes[ev.CardType] {
 		return false
 	}
 	if ev.Timestamp == 0 {

--- a/backend/internal/api/paymentlog/handler_test.go
+++ b/backend/internal/api/paymentlog/handler_test.go
@@ -282,6 +282,89 @@ func TestHandler_UnknownFieldsRejected(t *testing.T) {
 	}
 }
 
+// TestHandler_CryptoCheckoutErrorWithIsUpgrade reproduces the exact frontend
+// wire payload that previously 400'd: the crypto checkout_error log carries an
+// `is_upgrade` field, which the handler must accept (regression for the
+// DisallowUnknownFields contract drift).
+func TestHandler_CryptoCheckoutErrorWithIsUpgrade(t *testing.T) {
+	h := NewHandler(testLogger())
+
+	ev := map[string]any{
+		"payment_method": "crypto",
+		"event":          "checkout_error",
+		"error_message":  "('In crypto subscription flow: Querying cryptocompare returned 401 return code', True)",
+		"plan_id":        3,
+		"is_upgrade":     false,
+		"timestamp":      time.Now().UnixMilli(),
+	}
+	data, _ := json.Marshal(ev)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/logging/payment", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_AllOptionalFields(t *testing.T) {
+	h := NewHandler(testLogger())
+	planID := 3
+	isUpgrade := true
+	discountApplied := true
+	ev := validEvent()
+	ev.ErrorCode = "401"
+	ev.PlanID = &planID
+	ev.Step = "submit"
+	ev.IsUpgrade = &isUpgrade
+	ev.CardType = "saved"
+	ev.DiscountApplied = &discountApplied
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_AllCardTypes(t *testing.T) {
+	h := NewHandler(testLogger())
+
+	for cardType := range allowedCardTypes {
+		t.Run(cardType, func(t *testing.T) {
+			ev := validEvent()
+			ev.CardType = cardType
+
+			req := makeRequest(t, ev)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusNoContent {
+				t.Errorf("expected 204 for card type %s, got %d", cardType, w.Code)
+			}
+		})
+	}
+}
+
+func TestHandler_UnknownCardType(t *testing.T) {
+	h := NewHandler(testLogger())
+	ev := validEvent()
+	ev.CardType = "amex"
+
+	req := makeRequest(t, ev)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestHandler_ErrorMessageSanitized(t *testing.T) {
 	// This test verifies the handler doesn't crash with control characters.
 	// Actual sanitization is tested in validate package.


### PR DESCRIPTION
## Problem

The frontend `PaymentLogPayload` (`@rotki/sigil`) sends `is_upgrade`, `card_type`, and `discount_applied`, but the Go payment-log handler's `event` struct lacked these fields. Since `validate.ReadJSONBody` uses `DisallowUnknownFields()`, any log POST carrying them was rejected with a generic **400** before validation ran.

This broke virtually every payment-failure log, since both call sites always set `is_upgrade`. Example payload observed in production:

```json
{"payment_method":"crypto","event":"checkout_error","error_message":"...cryptocompare returned 401...","plan_id":3,"is_upgrade":false,"timestamp":1780993735939}
```

The `is_upgrade` field has no matching struct field → JSON decode error → 400.

## Fix

- Add `IsUpgrade *bool`, `CardType string`, `DiscountApplied *bool` to the `event` struct (pointers for booleans so absent ≠ false).
- Validate `card_type` against a `saved`/`new` allowlist, matching the existing `step`/`method`/`event` validation pattern.
- Thread all three into the structured Loki log attrs (nil/empty-guarded).

## Tests

- Regression test mirroring the exact crypto `checkout_error` wire payload (with `is_upgrade`) → now 204.
- Coverage for all three optional fields together, all valid card types, and rejection of unknown card types.

`go build`, `go vet`, and the `paymentlog` package tests all pass.

> Note: the underlying cryptocompare 401 in the sample is an unrelated Python-backend issue; this PR only restores correct *logging* of such errors.