### PR TITLE
fix(backend): accept Reporting API CSP violation reports

### DIFF
--- a/backend/internal/api/csp/handler.go
+++ b/backend/internal/api/csp/handler.go
@@ -2,9 +2,11 @@
 package csp
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -76,6 +78,33 @@ type cspReportWrapper struct {
 	CSPReport cspReport `json:"csp-report"`
 }
 
+// reportingAPIReport mirrors a single entry of the Reporting API payload sent
+// via the `report-to` directive / `Reporting-Endpoints` header. The body is
+// posted as a JSON array with Content-Type "application/reports+json" and uses
+// camelCase field names, unlike the legacy hyphenated `report-uri` format.
+// Modern Firefox/Chrome/Edge prefer this mechanism when both are advertised.
+type reportingAPIReport struct {
+	Type string        `json:"type"`
+	URL  string        `json:"url"`
+	Body cspReportBody `json:"body"`
+}
+
+// cspReportBody is the CSP Level 3 `csp-violation` report body (camelCase).
+type cspReportBody struct {
+	BlockedURL         string `json:"blockedURL"`
+	ColumnNumber       int    `json:"columnNumber"`
+	Disposition        string `json:"disposition"`
+	DocumentURL        string `json:"documentURL"`
+	EffectiveDirective string `json:"effectiveDirective"`
+	LineNumber         int    `json:"lineNumber"`
+	OriginalPolicy     string `json:"originalPolicy"`
+	Referrer           string `json:"referrer"`
+	Sample             string `json:"sample"`
+	SourceFile         string `json:"sourceFile"`
+	StatusCode         int    `json:"statusCode"`
+	ViolatedDirective  string `json:"violatedDirective"`
+}
+
 type cspResponse struct {
 	Message string `json:"message"`
 	Success bool   `json:"success,omitempty"`
@@ -95,8 +124,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var wrapper cspReportWrapper
-	if err := readCSPReport(r, &wrapper); err != nil {
+	reports, err := readCSPReports(r)
+	if err != nil {
 		h.logger.Error("invalid CSP report format", "error", err)
 		validate.WriteJSON(w, http.StatusBadRequest, cspResponse{
 			Message: "Invalid CSP violation report format",
@@ -104,20 +133,59 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	report := wrapper.CSPReport
+	// A Reporting API batch can legitimately contain zero csp-violation entries
+	// (e.g. only deprecation/intervention reports) — accept it as a no-op.
+	if len(reports) == 0 {
+		validate.WriteJSON(w, http.StatusOK, cspResponse{
+			Message: "No CSP violations to process",
+			Success: true,
+		})
+		return
+	}
 
+	clientIP := validate.ClientIP(r)
+	userAgent := r.UserAgent()
+
+	// Single report (the common legacy report-uri case): preserve the original
+	// per-report response semantics so callers see the precise filter reason.
+	if len(reports) == 1 {
+		status, resp, errs := h.evaluateReport(reports[0], clientIP, userAgent)
+		if len(errs) > 0 {
+			h.logger.Error("CSP report missing required fields", "errors", errs.Error())
+			errs.WriteJSON(w)
+			return
+		}
+		validate.WriteJSON(w, status, resp)
+		return
+	}
+
+	// Reporting API batch: process every report for its side effects (filtering
+	// and structured logging) and return a single aggregate acknowledgement.
+	for _, report := range reports {
+		if _, _, errs := h.evaluateReport(report, clientIP, userAgent); len(errs) > 0 {
+			h.logger.Error("CSP report missing required fields", "errors", errs.Error())
+		}
+	}
+	validate.WriteJSON(w, http.StatusOK, cspResponse{
+		Message: "CSP violation reports received and logged",
+		Success: true,
+	})
+}
+
+// evaluateReport runs validation, security/false-positive/bot filtering and
+// structured logging for a single normalized report. It returns the HTTP status
+// and response body the handler should emit for a single-report request, plus
+// any validation errors (empty when the report is valid). All logging happens
+// as a side effect so batch callers can discard the returned response.
+func (h *Handler) evaluateReport(report cspReport, clientIP, userAgent string) (int, cspResponse, validate.Errors) {
 	// Validate required fields
 	if errs := validate.Collect(
 		validate.RequiredString("document-uri", report.DocumentURI),
 		validate.RequiredString("violated-directive", report.ViolatedDirective),
 		validate.RequiredString("original-policy", report.OriginalPolicy),
 	); len(errs) > 0 {
-		h.logger.Error("CSP report missing required fields", "errors", errs.Error())
-		errs.WriteJSON(w)
-		return
+		return 0, cspResponse{}, errs
 	}
-
-	clientIP := validate.ClientIP(r)
 
 	// Check for suspicious patterns across all report field values.
 	// We check the raw field values rather than JSON-encoded strings
@@ -131,24 +199,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, pattern := range suspiciousPatterns {
 		if pattern.MatchString(reportStr) {
 			h.logger.Warn("suspicious CSP report pattern detected", "ip", clientIP)
-			validate.WriteJSON(w, http.StatusOK, cspResponse{
+			return http.StatusOK, cspResponse{
 				Message: "Report filtered due to suspicious content",
 				Status:  "filtered",
 				Reason:  "suspicious-pattern",
-			})
-			return
+			}, nil
 		}
 	}
 
 	// Filter browser extension violations
 	if extensionPattern.MatchString(report.SourceFile) || extensionPattern.MatchString(report.BlockedURI) {
 		h.logger.Debug("CSP violation from browser extension filtered")
-		validate.WriteJSON(w, http.StatusOK, cspResponse{
+		return http.StatusOK, cspResponse{
 			Message: "Browser extension violation filtered out",
 			Status:  "ignored",
 			Reason:  "browser-extension",
-		})
-		return
+		}, nil
 	}
 
 	// Filter known false positives
@@ -156,12 +222,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, pattern := range knownFalsePositives {
 			if pattern.MatchString(report.BlockedURI) {
 				h.logger.Debug("known false positive filtered", "blocked_uri", report.BlockedURI)
-				validate.WriteJSON(w, http.StatusOK, cspResponse{
+				return http.StatusOK, cspResponse{
 					Message: "Known false positive filtered",
 					Status:  "ignored",
 					Reason:  "false-positive",
-				})
-				return
+				}, nil
 			}
 		}
 	}
@@ -170,24 +235,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(report.DocumentURI, "localhost") &&
 		(report.BlockedURI == "inline" || report.BlockedURI == "eval") {
 		h.logger.Debug("localhost inline/eval violation filtered")
-		validate.WriteJSON(w, http.StatusOK, cspResponse{
+		return http.StatusOK, cspResponse{
 			Message: "Localhost development violation filtered",
 			Status:  "ignored",
 			Reason:  "localhost-development",
-		})
-		return
+		}, nil
 	}
 
 	// Filter bot traffic
-	userAgent := r.UserAgent()
 	if botPattern.MatchString(userAgent) {
 		h.logger.Debug("CSP violation from bot/crawler filtered")
-		validate.WriteJSON(w, http.StatusOK, cspResponse{
+		return http.StatusOK, cspResponse{
 			Message: "Bot/crawler violation filtered",
 			Status:  "ignored",
 			Reason:  "bot-traffic",
-		})
-		return
+		}, nil
 	}
 
 	// Log the violation with sanitized fields
@@ -229,34 +291,103 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"document", documentURI,
 	)
 
-	validate.WriteJSON(w, http.StatusOK, cspResponse{
+	return http.StatusOK, cspResponse{
 		Message: "CSP violation report received and logged",
 		Success: true,
+	}, nil
+}
+
+// readCSPReports decodes one or more CSP violation reports from the request
+// body, transparently handling both wire formats a browser may send:
+//
+//   - Legacy `report-uri` (Content-Type application/csp-report): a single
+//     JSON object {"csp-report": {...}} with hyphenated field names.
+//   - Reporting API `report-to` / `Reporting-Endpoints` (Content-Type
+//     application/reports+json): a JSON array of reports with camelCase fields
+//     nested under "body". Modern Firefox/Chrome/Edge use this.
+//
+// The format is detected by sniffing the first non-whitespace byte rather than
+// trusting Content-Type, since intermediaries occasionally rewrite it. Unknown
+// fields are silently ignored so browser-specific extras never cause a 400.
+func readCSPReports(r *http.Request) ([]cspReport, error) {
+	r.Body = http.MaxBytesReader(nil, r.Body, maxReportSize)
+
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return nil, fmt.Errorf("request body too large (max %d bytes)", maxReportSize)
+		}
+		return nil, errors.New("invalid request body")
+	}
+
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	if len(trimmed) == 0 {
+		return nil, errors.New("empty request body")
+	}
+
+	// Reporting API batch: a JSON array of report objects.
+	if trimmed[0] == '[' {
+		var batch []reportingAPIReport
+		if err := json.Unmarshal(data, &batch); err != nil {
+			return nil, errors.New("invalid request body")
+		}
+		reports := make([]cspReport, 0, len(batch))
+		for i := range batch {
+			// Reporting endpoints are shared across report types; keep only CSP
+			// violations and drop deprecation/intervention/other entries.
+			if batch[i].Type != "" && batch[i].Type != "csp-violation" {
+				continue
+			}
+			reports = append(reports, normalizeReportingAPIReport(&batch[i]))
+		}
+		return reports, nil
+	}
+
+	// Legacy report-uri format: a single {"csp-report": {...}} object.
+	var wrapper cspReportWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, errors.New("invalid request body")
+	}
+	return []cspReport{fillDirectives(wrapper.CSPReport)}, nil
+}
+
+// normalizeReportingAPIReport maps a Reporting API report onto the internal
+// cspReport shape used by the rest of the pipeline.
+func normalizeReportingAPIReport(rep *reportingAPIReport) cspReport {
+	b := rep.Body
+	documentURI := b.DocumentURL
+	if documentURI == "" {
+		documentURI = rep.URL // top-level url is the document URL in this format
+	}
+	return fillDirectives(cspReport{
+		BlockedURI:         b.BlockedURL,
+		ColumnNumber:       b.ColumnNumber,
+		Disposition:        b.Disposition,
+		DocumentURI:        documentURI,
+		EffectiveDirective: b.EffectiveDirective,
+		LineNumber:         b.LineNumber,
+		OriginalPolicy:     b.OriginalPolicy,
+		Referrer:           b.Referrer,
+		ScriptSample:       b.Sample,
+		SourceFile:         b.SourceFile,
+		StatusCode:         b.StatusCode,
+		ViolatedDirective:  b.ViolatedDirective,
 	})
 }
 
-// readCSPReport decodes a CSP violation report from the request body.
-// Unlike validate.ReadJSONBody, it does NOT reject unknown fields because
-// browsers may send non-standard or newer spec fields (e.g. "disposition",
-// "document-url") that are not in our struct. Rejecting them would cause
-// legitimate reports to fail with 400.
-func readCSPReport(r *http.Request, dst *cspReportWrapper) error {
-	r.Body = http.MaxBytesReader(nil, r.Body, maxReportSize)
-
-	dec := json.NewDecoder(r.Body)
-	if err := dec.Decode(dst); err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
-			return fmt.Errorf("request body too large (max %d bytes)", maxReportSize)
-		}
-		return errors.New("invalid request body")
+// fillDirectives cross-populates the violated/effective directive fields. The
+// legacy format favors `violated-directive` while the Reporting API favors
+// `effectiveDirective` (and often omits the deprecated `violatedDirective`);
+// downstream validation and logging expect both to be present.
+func fillDirectives(rep cspReport) cspReport {
+	if rep.ViolatedDirective == "" {
+		rep.ViolatedDirective = rep.EffectiveDirective
 	}
-
-	if dec.More() {
-		return errors.New("request body must contain a single JSON object")
+	if rep.EffectiveDirective == "" {
+		rep.EffectiveDirective = rep.ViolatedDirective
 	}
-
-	return nil
+	return rep
 }
 
 // sanitize removes control characters and truncates to maxLen (rune-safe).

--- a/backend/internal/api/csp/handler_test.go
+++ b/backend/internal/api/csp/handler_test.go
@@ -210,6 +210,196 @@ func TestCSPHandler_AcceptsUnknownFields(t *testing.T) {
 	}
 }
 
+// makeReportingAPIBatch builds a Reporting API (report-to) payload: a JSON
+// array of report objects with camelCase body fields, as sent by modern
+// Firefox/Chrome/Edge via the Reporting-Endpoints header.
+func makeReportingAPIBatch(reports ...map[string]any) string {
+	b, _ := json.Marshal(reports)
+	return string(b)
+}
+
+func cspViolationReport(blockedURL, effectiveDirective string) map[string]any {
+	const documentURL = "https://rotki.com/"
+	return map[string]any{
+		"age":  0,
+		"type": "csp-violation",
+		"url":  documentURL,
+		"body": map[string]any{
+			"blockedURL":         blockedURL,
+			"documentURL":        documentURL,
+			"effectiveDirective": effectiveDirective,
+			"originalPolicy":     testOriginalPolicy,
+			"disposition":        "enforce",
+			"statusCode":         200,
+		},
+	}
+}
+
+func TestCSPHandler_ReportingAPIValidReport(t *testing.T) {
+	h := newTestHandler()
+	body := makeReportingAPIBatch(cspViolationReport("https://evil.com/script.js", "script-src-elem"))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/reports+json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp cspResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success=true, got %+v", resp)
+	}
+}
+
+// TestCSPHandler_ReportingAPIFirefoxPayload reproduces the real-world Firefox
+// 151 wire payload that previously 400'd: a reports+json array whose body uses
+// `effectiveDirective` with no `violatedDirective`.
+func TestCSPHandler_ReportingAPIFirefoxPayload(t *testing.T) {
+	h := newTestHandler()
+	body := `[{"age":0,"body":{"blockedURL":"https://evil.com/x.js","columnNumber":12,"disposition":"enforce","documentURL":"https://rotki.com/","effectiveDirective":"script-src-elem","lineNumber":1,"originalPolicy":"default-src 'self'","referrer":"","sample":"","sourceFile":"https://rotki.com/","statusCode":200},"type":"csp-violation","url":"https://rotki.com/","user_agent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:151.0) Gecko/20100101 Firefox/151.0"}]`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/reports+json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp cspResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success=true, got %+v", resp)
+	}
+}
+
+func TestCSPHandler_ReportingAPIBatchMultiple(t *testing.T) {
+	h := newTestHandler()
+	body := makeReportingAPIBatch(
+		cspViolationReport("https://evil.com/a.js", "script-src-elem"),
+		cspViolationReport("https://evil.com/b.css", "style-src-elem"),
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/reports+json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp cspResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success=true, got %+v", resp)
+	}
+}
+
+// Single-report batches preserve the precise per-report filter reason, just
+// like the legacy path.
+func TestCSPHandler_ReportingAPIFiltersBrowserExtension(t *testing.T) {
+	h := newTestHandler()
+	body := makeReportingAPIBatch(cspViolationReport("moz-extension://abc123/inject.js", "script-src-elem"))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/reports+json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	var resp cspResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Reason != "browser-extension" {
+		t.Fatalf("expected reason=browser-extension, got %q", resp.Reason)
+	}
+}
+
+// Non-csp-violation report types (deprecation/intervention) are dropped; a
+// batch containing only those is accepted as a valid no-op.
+func TestCSPHandler_ReportingAPIIgnoresNonCSPTypes(t *testing.T) {
+	h := newTestHandler()
+	body := makeReportingAPIBatch(map[string]any{
+		"age":  0,
+		"type": "deprecation",
+		"url":  "https://rotki.com/",
+		"body": map[string]any{"id": "WebSQL", "message": "WebSQL is deprecated"},
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/reports+json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp cspResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success=true for no-op batch, got %+v", resp)
+	}
+}
+
+// A reports+json batch mixing a valid CSP violation with an unrelated report
+// type still succeeds and processes the violation.
+func TestCSPHandler_ReportingAPIMixedTypes(t *testing.T) {
+	h := newTestHandler()
+	body := makeReportingAPIBatch(
+		map[string]any{"type": "intervention", "url": "https://rotki.com/", "body": map[string]any{"id": "x"}},
+		cspViolationReport("https://evil.com/script.js", "script-src-elem"),
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/reports+json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCSPHandler_ReportingAPIInvalidJSON(t *testing.T) {
+	h := newTestHandler()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader("[not json"))
+	req.Header.Set("Content-Type", "application/reports+json")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// Format detection sniffs the body, not Content-Type: an array body is parsed
+// as a Reporting API batch even when the header is missing/wrong.
+func TestCSPHandler_ReportingAPIDetectedWithoutContentType(t *testing.T) {
+	h := newTestHandler()
+	body := makeReportingAPIBatch(cspViolationReport("https://evil.com/script.js", "script-src-elem"))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/csp/violation", strings.NewReader(body))
+	// no Content-Type set
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestCSPHandler_FiltersBotTraffic(t *testing.T) {
 	h := newTestHandler()
 	body := makeReport("https://evil.com/script.js", "https://rotki.com/", "script-src")


### PR DESCRIPTION
## Problem

The CSP middleware advertises **both** report mechanisms — the legacy `report-uri` directive and the modern `report-to` / `Reporting-Endpoints` header (`backend/internal/csp/policies.go`, `middleware.go:79`). When both are present, modern browsers prefer the Reporting API and POST a JSON **array** of reports with `Content-Type: application/reports+json` and camelCase body fields:

```json
[{"age":0,"type":"csp-violation","url":"https://rotki.com/","body":{"blockedURL":"...","documentURL":"...","effectiveDirective":"script-src-elem","originalPolicy":"...","disposition":"enforce","statusCode":200}}]
```

…rather than the legacy `{"csp-report": { "blocked-uri": ... }}` object with hyphenated keys.

The handler only parsed the legacy shape, so every Reporting API report failed to decode and returned **400** — meaning we were silently dropping CSP violations from essentially all up-to-date browsers (Firefox 151, current Chrome/Edge). Observed in logs:

```
POST /api/csp/violation ... status 400 ... Firefox/151.0 referer https://rotki.com/
```

## Fix

- `readCSPReports` now parses **both** wire formats, detected by sniffing the first non-whitespace byte (`[` → Reporting API array, `{` → legacy). Sniffing rather than trusting `Content-Type` is robust to intermediaries rewriting the header.
- New `reportingAPIReport` / `cspReportBody` structs + `normalizeReportingAPIReport` map the camelCase body onto the existing internal `cspReport`.
- `fillDirectives` cross-populates `violated`/`effective` directive — the Reporting API favors `effectiveDirective` and usually omits the deprecated `violatedDirective`, which the existing required-field validation and logging both depend on.
- Reporting endpoints are shared across report types, so non-`csp-violation` entries (deprecation/intervention) are dropped; a batch containing only those is accepted as a valid **no-op**.
- Per-report logic extracted into `evaluateReport`. The **single / legacy path keeps its exact per-report filter-reason responses** (suspicious-pattern, browser-extension, false-positive, localhost-development, bot-traffic); batches are processed per report with a single aggregate acknowledgement.

## Tests

9 new tests alongside the 10 existing (all still pass):
- real Firefox 151 reports+json payload
- multi-report batch
- ignored non-CSP report types + mixed-type batch
- browser-extension filtering via the new format
- body-sniffed detection without a `Content-Type` header
- invalid array JSON → 400

`go build`, full `go test ./...`, and `golangci-lint` (0 issues) all clean.