### PR TITLE
fix(csrf): prevent duplicated CSRF header on retried requests

### DIFF
--- a/packages/website/app/composables/use-fetch-with-csrf.ts
+++ b/packages/website/app/composables/use-fetch-with-csrf.ts
@@ -71,17 +71,27 @@ export const useFetchWithCsrf = createSharedComposable(() => {
       // Check if the body is FormData
       const isFormData = options.body instanceof FormData;
 
-      let headers: any = {
-        accept: 'application/json',
-        // Only set content-type for non-FormData requests
-        // FormData will set its own boundary parameter for multipart/form-data
-        ...(!isFormData && { 'content-type': 'application/json' }),
-        ...(token && { [CSRF_HEADER]: token }),
-      };
+      // Build the outgoing headers via the Headers API so names are normalised
+      // and set() overwrites (instead of appends). ofetch reuses the same
+      // `options` object across retries and re-runs this hook over the previous
+      // attempt's headers; a plain-object merge would mix `X-CSRFToken` with the
+      // lowercased `x-csrftoken` and the Headers constructor would then collapse
+      // them into a duplicated "abcd, abcd" value.
+      const headers = new Headers();
+      headers.set('accept', 'application/json');
+      // Only set content-type for non-FormData requests; FormData sets its own
+      // boundary parameter for multipart/form-data.
+      if (!isFormData)
+        headers.set('content-type', 'application/json');
 
-      for (const [key, value] of options.headers) {
-        headers[key] = value;
-      }
+      // Merge any caller-provided headers, normalising case via the Headers API.
+      for (const [key, value] of new Headers(options.headers))
+        headers.set(key, value);
+
+      // Set the CSRF token last so the freshly resolved token always wins, even
+      // when this hook re-runs over a retried request's existing headers.
+      if (token)
+        headers.set(CSRF_HEADER, token);
 
       if (import.meta.server || import.meta.env.NODE_ENV === 'test') {
         let cookieString = event?.headers.get('cookie');
@@ -106,14 +116,12 @@ export const useFetchWithCsrf = createSharedComposable(() => {
           }
         }
 
-        headers = {
-          ...headers,
-          ...(cookieString && { cookie: cookieString }),
-          referer: baseUrl,
-        };
+        if (cookieString)
+          headers.set('cookie', cookieString);
+        headers.set('referer', baseUrl);
       }
 
-      options.headers = new Headers(headers);
+      options.headers = headers;
       options.baseURL = baseUrl;
       // Only convert keys for non-FormData bodies
       if (!isFormData) {

--- a/packages/website/tests/mocks/handlers.ts
+++ b/packages/website/tests/mocks/handlers.ts
@@ -2,6 +2,10 @@ import { http, HttpResponse } from 'msw';
 
 const { BACKEND_URL } = import.meta.env;
 
+// Counts attempts against `/webapi/retry/` so the handler can fail the first one
+// and succeed on the retry. Reset it from the test before use.
+export const retryAttempts = { count: 0 };
+
 export const handlers = [
   // Mock app manifest requests to prevent errors during test initialization
   http.get('*/_nuxt/builds/meta/*.json', () =>
@@ -34,6 +38,12 @@ export const handlers = [
       'Access-Control-Allow-Origin': '*',
     },
   })),
+  http.options(`${BACKEND_URL}/webapi/retry/`, () => HttpResponse.json({}, {
+    headers: {
+      'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+      'Access-Control-Allow-Origin': '*',
+    },
+  })),
   http.get(`${BACKEND_URL}/webapi/csrf/`, () =>
     HttpResponse.json(
       {
@@ -47,6 +57,14 @@ export const handlers = [
     )),
   http.post(`${BACKEND_URL}/webapi/login/`, () =>
     HttpResponse.json({ message: 'success' })),
+  // Fails the first attempt with a retryable status so ofetch retries, letting a
+  // test assert the CSRF header isn't duplicated (e.g. "abcd, abcd") on retry.
+  http.post(`${BACKEND_URL}/webapi/retry/`, () => {
+    retryAttempts.count += 1;
+    if (retryAttempts.count === 1)
+      return HttpResponse.json({ message: 'retry' }, { status: 503 });
+    return HttpResponse.json({ message: 'success' });
+  }),
   http.get(`${BACKEND_URL}/webapi/countries/`, () =>
     HttpResponse.json({
       message: 'it works!',

--- a/packages/website/tests/unit/composables/use-fetch-with-csrf.nuxt.spec.ts
+++ b/packages/website/tests/unit/composables/use-fetch-with-csrf.nuxt.spec.ts
@@ -4,6 +4,18 @@ import type { Country } from '~/composables/use-countries';
 import type { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { retryAttempts } from '../../mocks/handlers';
+
+// Provide a stable CSRF token cookie so outgoing requests carry a token, which
+// is required to exercise the retry header-dedup path.
+mockNuxtImport('useCookie', () => (name: string) =>
+  ref(name === 'csrftoken' ? '1234' : undefined));
+
+// In the server/test code path the token is read from the request event's
+// cookies (a runtime global, not an auto-import); return the token here so
+// request headers carry it.
+vi.stubGlobal('parseCookies', () => ({ csrftoken: '1234' }));
 
 const logout = vi.fn();
 const refresh = vi.fn();
@@ -57,4 +69,37 @@ describe('useFetchWithCsrf composable', () => {
       }),
     ).resolves.toMatchObject({ message: 'success' });
   }, 2000);
+
+  it('fetchWithCsrf: does not duplicate the CSRF header across retries', async () => {
+    retryAttempts.count = 0;
+
+    // MSW + undici drops headers when reading them off the intercepted request
+    // (mswjs/headers-polyfill#72), so assert against the headers the composable
+    // builds. The per-call response hooks run after the instance onRequest (which
+    // sets the CSRF header): the failed first attempt hits onResponseError, the
+    // retried success hits onResponse — both see the fully-built options.headers.
+    const csrfHeaders: (string | null)[] = [];
+    const capture = ({ options }: { options: { headers?: HeadersInit } }): void => {
+      csrfHeaders.push(new Headers(options.headers).get('X-CSRFToken'));
+    };
+
+    await expect(
+      fetchWithCsrf<ApiResponse<undefined>>(`/webapi/retry/`, {
+        body: { foo: 'bar' },
+        method: 'POST',
+        onResponse: capture,
+        onResponseError: capture,
+      }),
+    ).resolves.toMatchObject({ message: 'success' });
+
+    // The first attempt fails with 503 and is retried, so the request is sent
+    // twice over the same (reused) options object.
+    expect(retryAttempts.count).toBe(2);
+    expect(csrfHeaders.length).toBeGreaterThanOrEqual(2);
+    // Every attempt must carry a single, un-duplicated CSRF token — not
+    // "1234, 1234" caused by appending the header on retry.
+    for (const header of csrfHeaders) {
+      expect(header).toBe('1234');
+    }
+  }, 5000);
 });


### PR DESCRIPTION
## Problem

`useFetchWithCsrf` could send the CSRF token header as `X-CSRFToken: abcd, abcd` instead of `abcd` whenever a request was **retried**.

ofetch reuses the same `options` object across retry attempts and re-runs the `onRequest` hook over the *previous* attempt's headers. The old code built a plain object seeded with `X-CSRFToken` (capital case), then merged the prior attempt's headers by iterating `options.headers` — a `Headers` object, which yields the **lowercased** `x-csrftoken`. The plain object then held *both* keys, and `new Headers(...)` collapsed them case-insensitively by **appending** → `abcd, abcd`.

It only triggered on an actual retry (a 5xx/408/409/425 first response), which is why it looked intermittent.

## Fix

Build the outgoing headers with the `Headers` API throughout, using `set()` (case-insensitive overwrite) instead of round-tripping through a plain object. The CSRF token is set **last** so the freshly resolved token always wins, even when the hook re-runs over a retried request's existing headers. This also mirrors the existing pattern in `packages/card-payment/src/utils/api.ts`.

## Test

Adds a regression test that forces a `503` → retry via an MSW handler and asserts the CSRF header stays a single, un-duplicated value across attempts.

> Note: the test asserts against the headers the composable builds (via ofetch's per-call response hooks) rather than the MSW-intercepted request, because MSW + undici drops headers read off the intercepted request ([mswjs/headers-polyfill#72](https://github.com/mswjs/headers-polyfill/issues/72)). Verified the test fails with `"1234, 1234"` against the old code and passes with the fix.

## Verification

- Target spec: 4/4 pass
- Full website unit suite: 149/149 pass
- `pnpm typecheck`: 0 errors · ESLint: clean