### PR TITLE
fix(sigil): avoid crypto.randomUUID throw in insecure contexts

### DIFF
--- a/packages/sigil/src/index.spec.ts
+++ b/packages/sigil/src/index.spec.ts
@@ -11,6 +11,7 @@ import {
   PaymentFailures,
   PaymentServerEvents,
   postPaymentLog,
+  randomSessionId,
   reasonForServerEvent,
   type SigilEventPayloadMap,
   SigilEvents,
@@ -164,6 +165,48 @@ describe('parseUtmFromQuery', () => {
   it('handles array-valued query parameters', () => {
     const result = parseUtmFromQuery({ utm_source: ['twitter', 'facebook'] });
     expect(result.utmSource).toBe('twitter');
+  });
+});
+
+describe('randomSessionId', () => {
+  const UUID_V4 = /^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i;
+  const realCrypto = globalThis.crypto;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: realCrypto });
+  });
+
+  it('uses crypto.randomUUID when available', () => {
+    const randomUUID = vi.fn(() => '11111111-1111-4111-8111-111111111111');
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: { randomUUID } });
+    expect(randomSessionId()).toBe('11111111-1111-4111-8111-111111111111');
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to getRandomValues in an insecure context (no randomUUID)', () => {
+    const getRandomValues = vi.fn((array: Uint8Array) => {
+      array.fill(0xAB);
+      return array;
+    });
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: { getRandomValues } });
+    const id = randomSessionId();
+    expect(getRandomValues).toHaveBeenCalledOnce();
+    // version (4) and variant (10xx) bits are forced regardless of input bytes
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('produces unique ids across the getRandomValues path', () => {
+    // Deterministic counter so different fills produce different ids without
+    // relying on a PRNG.
+    let counter = 0;
+    const getRandomValues = vi.fn((array: Uint8Array) => {
+      for (let i = 0; i < array.length; i++)
+        array[i] = (counter + i) & 0xFF;
+      counter += array.length;
+      return array;
+    });
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: { getRandomValues } });
+    expect(randomSessionId()).not.toBe(randomSessionId());
   });
 });
 

--- a/packages/sigil/src/tracking.ts
+++ b/packages/sigil/src/tracking.ts
@@ -111,6 +111,30 @@ export function parseUtmFromQuery(
   };
 }
 
+/**
+ * Generate a v4 UUID for use as an analytics session id, safe to call outside
+ * secure contexts.
+ *
+ * `crypto.randomUUID()` is only defined in secure contexts (HTTPS or
+ * `localhost`/`127.0.0.1`). When the app is reached over a plain-http,
+ * non-localhost origin (a LAN IP, container host name, `0.0.0.0`, a tunnel,
+ * etc.) the method is `undefined` and calling it throws, which would abort
+ * app initialization. `crypto.getRandomValues` carries no such restriction —
+ * it is available in insecure contexts too — so we use it to build a v4 UUID
+ * by hand when `randomUUID` is missing.
+ */
+export function randomSessionId(): string {
+  if (crypto.randomUUID)
+    return crypto.randomUUID();
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  // Per RFC 4122 §4.4: set version (4) and variant (10xx) bits.
+  bytes[6] = ((bytes[6] ?? 0) & 0x0F) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3F) | 0x80;
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
 interface CreateTrackingSessionInput {
   utm?: Pick<UtmParams, 'utmSource' | 'utmMedium' | 'utmCampaign' | 'utmContent' | 'utmTerm'>;
   referrer?: string;
@@ -125,7 +149,7 @@ interface CreateTrackingSessionInput {
  */
 export function createTrackingSession(input: CreateTrackingSessionInput): TrackingSession {
   return {
-    sessionId: crypto.randomUUID(),
+    sessionId: randomSessionId(),
     utm: {
       ...input.utm,
       referrer: input.referrer || undefined,


### PR DESCRIPTION
## Problem

Previews/builds intermittently crashed at app init with:

```
TypeError: crypto.randomUUID is not a function
    at createTrackingSession (tracking.ts:128)
    at captureUtmParams (use-utm-tracking.ts:21)
    at startup.ts:23
```

`crypto.randomUUID()` is only defined in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) — HTTPS, or `http://localhost`/`127.0.0.1`. When the same build is reached through an **insecure** http origin (a LAN IP like `http://192.168.x.x:3001`, `0.0.0.0`, a container host name, a tunnel), `crypto.randomUUID` is `undefined`. The unguarded call in `createTrackingSession` (`tracking.ts:128`) sits in the startup path, so the throw aborts Nuxt init and blocks the preview entirely. It's intermittent purely because it depends on which origin you open the build through.

## Fix

Add a `randomSessionId()` helper in `packages/sigil/src/tracking.ts`:

1. `crypto.randomUUID()` when available (secure contexts)
2. otherwise `crypto.getRandomValues()` — **not** secure-context-gated, so it works in insecure contexts too — to build a v4 UUID by hand

`createTrackingSession` now calls `randomSessionId()` instead of the bare `crypto.randomUUID()`.

Note: an earlier revision also had a `Math.random()` last-resort tier, but that path was unreachable in practice (`getRandomValues` is always present in browsers) and tripped the security scanner's "insecure randomness" check, so it was removed. The session id is analytics-only (UTM attribution), never a security token.

## Tests

New `randomSessionId` describe block covering both paths (each forced by stubbing `globalThis.crypto`) plus uniqueness on the `getRandomValues` path. Full suite: **49 passed**. `typecheck` and `lint` clean. No `Math.random()` anywhere in the package.

## Manual verification (real app, not just unit tests)

Ran the Nuxt dev server and loaded it over the LAN IP `http://192.168.188.41:3001` — a non-localhost http origin, i.e. the exact insecure context that triggered the crash.

Confirmed the crash *condition* was genuinely present:

- `isSecureContext: false`
- `typeof crypto.randomUUID === 'undefined'` (what threw before)
- `typeof crypto.getRandomValues === 'function'` (fallback available)

Confirmed the crash is gone:

- No `crypto.randomUUID is not a function` in the console; the app initialized past the startup plugin (only backend 404s remained, expected since the Go backend wasn't running).
- The fallback produced a valid v4 UUID, persisted to the `_utm` cookie: `b7893212-fe10-49e2-beb4-b03f7de7a2ec` (passes the strict v4 regex).