### PR TITLE
feat: add comparison pages for competing products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ planning/
 .tmp/
 
 
+.lighthouseci/

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -5,7 +5,8 @@
       "url": [
         "http://localhost/index.html",
         "http://localhost/products/index.html",
-        "http://localhost/integrations/aave/index.html"
+        "http://localhost/integrations/aave/index.html",
+        "http://localhost/compare/koinly/index.html"
       ],
       "numberOfRuns": 5,
       "settings": { "chromeFlags": "--no-sandbox" }

--- a/packages/website/app/components/comparison/ComparisonTable.vue
+++ b/packages/website/app/components/comparison/ComparisonTable.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+export interface ComparisonRow {
+  label: string;
+  rotki: string;
+  competitor: string;
+  highlight?: boolean;
+}
+
+const { competitor, rows } = defineProps<{
+  competitor: string;
+  rows: ComparisonRow[];
+}>();
+</script>
+
+<template>
+  <div class="overflow-x-auto border border-rui-grey-200 rounded-xl bg-white shadow-sm">
+    <table class="w-full border-collapse text-left">
+      <thead>
+        <tr class="border-b border-rui-grey-200">
+          <th class="p-4 text-body-2 font-bold text-rui-text-secondary w-1/3">
+            &nbsp;
+          </th>
+          <th class="p-4 text-body-1 font-bold text-rui-primary bg-rui-primary/10 border-x border-rui-primary/20">
+            rotki
+          </th>
+          <th class="p-4 text-body-1 font-medium text-rui-text-secondary">
+            {{ competitor }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="row in rows"
+          :key="row.label"
+          class="border-b border-rui-grey-100 last:border-b-0"
+        >
+          <th
+            scope="row"
+            class="p-4 align-top text-body-2 font-medium text-rui-text-secondary border-l-4"
+            :class="row.highlight ? 'border-rui-primary' : 'border-transparent'"
+          >
+            {{ row.label }}
+          </th>
+          <td
+            class="p-4 align-top text-body-2 border-x border-rui-primary/20"
+            :class="row.highlight ? 'bg-rui-primary/[.07]' : 'bg-rui-primary/[.03]'"
+          >
+            <div class="flex items-start gap-2">
+              <RuiIcon
+                v-if="row.highlight"
+                name="lu-circle-check"
+                size="18"
+                color="success"
+                class="shrink-0 mt-0.5"
+              />
+              <span :class="row.highlight ? 'font-medium text-rui-text' : 'text-rui-text'">{{ row.rotki }}</span>
+            </div>
+          </td>
+          <td class="p-4 align-top text-body-2 text-rui-text-secondary">
+            {{ row.competitor }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/packages/website/app/components/footer/FooterNavigation.vue
+++ b/packages/website/app/components/footer/FooterNavigation.vue
@@ -35,6 +35,11 @@ const menus: MenuGroup[] = [
         to: '/integrations',
         highlightActive: true,
       },
+      {
+        label: t('navigation_menu.compare.title'),
+        to: '/compare',
+        highlightActive: true,
+      },
     ],
   },
   {

--- a/packages/website/app/pages/compare/[slug].vue
+++ b/packages/website/app/pages/compare/[slug].vue
@@ -1,0 +1,388 @@
+<script setup lang="ts">
+import { isDefined } from '@vueuse/core';
+import { get } from '@vueuse/shared';
+import ButtonLink from '~/components/common/ButtonLink.vue';
+import ComparisonTable from '~/components/comparison/ComparisonTable.vue';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+const { path } = useRoute();
+const { t } = useI18n({ useScope: 'global' });
+const { public: { baseUrl } } = useRuntimeConfig();
+
+const { data: comparison } = await useAsyncData(
+  path,
+  () => queryCollection('comparisons').path(path).first(),
+  { dedupe: 'defer' },
+);
+
+if (!isDefined(comparison)) {
+  showError({ message: `Page not found: ${path}`, status: 404 });
+}
+else {
+  const item = get(comparison);
+  const slug = path.replace(/\/+$/, '').split('/').pop() ?? '';
+  // Keep the SERP title short (<60 chars); titleTemplate appends " | rotki".
+  // The full positioning still lives in the <h1>, tagline, and meta description.
+  const title = `rotki vs ${item.competitor}`;
+  // OG image is generated per-slug at build time by the comparison-seo module
+  // (with a share.png fallback written to the same path), so this URL always resolves.
+  usePageSeo(title, item.metaDescription, path, { keywords: item.keywords, ogImage: `compare/${slug}.png` });
+
+  const url = `${baseUrl}${path}`;
+
+  const ldBlocks: string[] = [];
+
+  ldBlocks.push(JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': [
+      { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': baseUrl },
+      { '@type': 'ListItem', 'position': 2, 'name': 'Compare', 'item': `${baseUrl}/compare` },
+      { '@type': 'ListItem', 'position': 3, 'name': `rotki vs ${item.competitor}`, 'item': url },
+    ],
+  }));
+
+  ldBlocks.push(JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    'name': 'rotki',
+    'description': item.intro,
+    'url': url,
+    'applicationCategory': 'FinanceApplication',
+    'operatingSystem': 'Windows, macOS, Linux',
+    'offers': { '@type': 'Offer', 'price': '0', 'priceCurrency': 'USD' },
+  }));
+
+  if ((item.faq?.length ?? 0) > 0) {
+    ldBlocks.push(JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      'mainEntity': item.faq!.map(({ q, a }) => ({
+        '@type': 'Question',
+        'name': q,
+        'acceptedAnswer': { '@type': 'Answer', 'text': a },
+      })),
+    }));
+  }
+
+  useHead({
+    // Escape the angle bracket so a closing-script sequence inside the JSON-LD
+    // (e.g. from FAQ content) cannot break out of the server-rendered script tag.
+    script: ldBlocks.map(block => ({
+      type: 'application/ld+json',
+      innerHTML: block.replaceAll('<', '\\u003c'),
+    })),
+  });
+}
+
+definePageMeta({
+  landing: true,
+});
+</script>
+
+<template>
+  <div v-if="comparison">
+    <section class="py-10 md:py-16 bg-rui-primary/[.04]">
+      <div class="container">
+        <nav class="text-sm text-rui-text-secondary mb-4">
+          <NuxtLink
+            to="/compare"
+            class="hover:text-rui-primary"
+          >
+            {{ t('compare.header') }}
+          </NuxtLink>
+          <span class="mx-2">/</span>
+          <span>rotki vs {{ comparison.competitor }}</span>
+        </nav>
+        <div class="flex items-center gap-4 md:gap-5">
+          <div class="w-16 h-16 md:w-20 md:h-20 border border-rui-grey-200 rounded-xl p-3 bg-white shadow-sm shrink-0 flex items-center justify-center">
+            <img
+              :src="comparison.image"
+              :alt="comparison.competitor"
+              class="w-full h-full object-contain"
+              width="80"
+              height="80"
+              loading="eager"
+            />
+          </div>
+          <span class="text-h6 md:text-h5 font-bold text-rui-text-secondary uppercase tracking-wide">vs</span>
+          <div class="w-16 h-16 md:w-20 md:h-20 border-2 border-rui-primary rounded-xl p-3 bg-white shadow-sm shrink-0 flex items-center justify-center">
+            <img
+              src="/img/logo-small.svg"
+              alt="rotki"
+              class="w-full h-full object-contain"
+              width="80"
+              height="80"
+              loading="eager"
+            />
+          </div>
+        </div>
+        <div class="w-16 h-1 bg-rui-primary rounded-full mt-8" />
+        <h1 class="text-h4 md:text-h3 font-bold mt-4">
+          {{ comparison.tagline }}
+        </h1>
+        <p class="text-body-1 text-rui-text-secondary mt-4 max-w-3xl">
+          {{ comparison.intro }}
+        </p>
+        <span class="block text-body-2 text-rui-text-secondary mt-5">
+          {{ t('compare.detail.updated', { date: comparison.updatedAt }) }}
+        </span>
+      </div>
+    </section>
+
+    <section
+      v-if="(comparison.keyTakeaways?.length ?? 0) > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <div class="max-w-3xl border border-rui-primary/20 border-l-4 border-l-rui-primary bg-rui-primary/[.04] rounded-r-xl p-6 md:p-8">
+          <h2 class="text-h6 font-bold mb-4 uppercase tracking-wide text-rui-primary">
+            {{ t('compare.detail.takeaways_title') }}
+          </h2>
+          <ul class="space-y-3">
+            <li
+              v-for="takeaway in comparison.keyTakeaways"
+              :key="takeaway"
+              class="flex items-start gap-3 text-body-1"
+            >
+              <RuiIcon
+                name="lu-circle-check"
+                size="20"
+                color="primary"
+                class="shrink-0 mt-0.5"
+              />
+              <span>{{ takeaway }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-10 md:py-14">
+      <div class="container">
+        <div class="border-l-4 border-rui-primary bg-rui-primary/[.04] rounded-r-xl p-6 max-w-3xl">
+          <h2 class="text-h6 font-bold mb-2">
+            {{ t('compare.detail.verdict') }}
+          </h2>
+          <p class="text-body-1 text-rui-text-secondary">
+            {{ comparison.verdict }}
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(comparison.dimensions?.length ?? 0) > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.detail.table_title', { competitor: comparison.competitor }) }}
+        </h2>
+        <ComparisonTable
+          :competitor="comparison.competitor"
+          :rows="comparison.dimensions ?? []"
+        />
+      </div>
+    </section>
+
+    <section
+      v-if="(comparison.rotkiAdvantages?.length ?? 0) > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-4">
+          {{ t('compare.detail.advantages_title') }}
+        </h2>
+        <ul class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+          <li
+            v-for="advantage in comparison.rotkiAdvantages"
+            :key="advantage"
+            class="flex items-start gap-3 text-body-1"
+          >
+            <RuiIcon
+              name="lu-circle-check"
+              size="20"
+              color="primary"
+              class="shrink-0 mt-0.5"
+            />
+            <span>{{ advantage }}</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section
+      v-if="(comparison.tradeoffs?.length ?? 0) > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-1">
+          {{ t('compare.detail.tradeoffs_title') }}
+        </h2>
+        <p class="text-body-2 text-rui-text-secondary mb-4 max-w-3xl">
+          {{ t('compare.detail.tradeoffs_subtitle', { competitor: comparison.competitor }) }}
+        </p>
+        <ul class="space-y-3 max-w-3xl">
+          <li
+            v-for="tradeoff in comparison.tradeoffs"
+            :key="tradeoff"
+            class="flex items-start gap-3 text-body-1"
+          >
+            <RuiIcon
+              name="lu-circle-alert"
+              size="20"
+              color="warning"
+              class="shrink-0 mt-0.5"
+            />
+            <span>{{ tradeoff }}</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section
+      v-if="(comparison.whoShouldRotki?.length ?? 0) > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.detail.who_title') }}
+        </h2>
+        <div class="border border-rui-primary/30 bg-rui-primary/[.04] rounded-xl p-6 md:p-8 max-w-3xl">
+          <h3 class="text-h6 font-semibold mb-4 text-rui-primary">
+            {{ t('compare.detail.who_rotki') }}
+          </h3>
+          <ul class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+            <li
+              v-for="who in comparison.whoShouldRotki"
+              :key="who"
+              class="flex items-start gap-3 text-body-1"
+            >
+              <RuiIcon
+                name="lu-circle-check"
+                size="20"
+                color="primary"
+                class="shrink-0 mt-0.5"
+              />
+              <span>{{ who }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-10 md:py-14 bg-rui-primary/[.04]">
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.detail.deepdive_title', { competitor: comparison.competitor }) }}
+        </h2>
+        <div class="max-w-[820px]">
+          <ContentRenderer :value="comparison" />
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(comparison.relatedIntegrations?.length ?? 0) > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-2">
+          {{ t('compare.detail.related_title') }}
+        </h2>
+        <p class="text-body-2 text-rui-text-secondary mb-5 max-w-3xl">
+          {{ t('compare.detail.related_subtitle') }}
+        </p>
+        <div class="flex flex-wrap gap-3">
+          <NuxtLink
+            v-for="related in comparison.relatedIntegrations"
+            :key="related.slug"
+            :to="`/integrations/${related.slug}`"
+            class="inline-flex items-center gap-2 border border-rui-grey-200 rounded-full px-4 py-2 text-body-2 bg-white hover:border-rui-primary hover:text-rui-primary transition-colors"
+          >
+            {{ related.label }}
+          </NuxtLink>
+          <NuxtLink
+            to="/integrations"
+            class="inline-flex items-center gap-2 border border-rui-primary rounded-full px-4 py-2 text-body-2 text-rui-primary bg-white hover:bg-rui-primary/[.04] transition-colors"
+          >
+            {{ t('integration.detail.cta.all') }}
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(comparison.faq?.length ?? 0) > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.detail.faq_title') }}
+        </h2>
+        <div class="space-y-4 max-w-3xl">
+          <div
+            v-for="entry in comparison.faq"
+            :key="entry.q"
+            class="flex items-start gap-4 border border-rui-grey-200 rounded-xl p-5 bg-white"
+          >
+            <div class="flex items-center justify-center w-9 h-9 rounded-full bg-rui-primary/10 shrink-0">
+              <RuiIcon
+                name="lu-message-circle"
+                size="20"
+                color="primary"
+              />
+            </div>
+            <div>
+              <h3 class="text-h6 font-semibold mb-1">
+                {{ entry.q }}
+              </h3>
+              <p class="text-body-1 text-rui-text-secondary">
+                {{ entry.a }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-12 md:py-16 bg-rui-primary/[.04]">
+      <div class="container flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
+        <div class="max-w-2xl">
+          <h2 class="text-h5 font-bold mb-2">
+            {{ t('compare.detail.cta.title') }}
+          </h2>
+          <p class="text-body-1 text-rui-text-secondary">
+            {{ t('compare.detail.cta.description') }}
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <ButtonLink
+            to="/download"
+            color="primary"
+            variant="default"
+          >
+            {{ t('compare.detail.cta.download') }}
+          </ButtonLink>
+          <ButtonLink
+            to="/compare"
+            variant="outlined"
+          >
+            {{ t('compare.detail.cta.all') }}
+          </ButtonLink>
+          <NuxtLink
+            v-if="comparison.competitorUrl"
+            :to="comparison.competitorUrl"
+            external
+            target="_blank"
+            rel="nofollow noopener"
+            class="text-body-2 text-rui-text-secondary self-center underline hover:text-rui-primary"
+          >
+            {{ t('compare.detail.visit_competitor', { competitor: comparison.competitor }) }}
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/packages/website/app/pages/compare/index.vue
+++ b/packages/website/app/pages/compare/index.vue
@@ -1,0 +1,350 @@
+<script setup lang="ts">
+import type { ComparisonHubCollectionItem, ComparisonsCollectionItem } from '@nuxt/content';
+import { get } from '@vueuse/shared';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+const { t } = useI18n({ useScope: 'global' });
+const { public: { baseUrl } } = useRuntimeConfig();
+
+usePageSeo(
+  t('compare.title'),
+  t('compare.description'),
+  '/compare',
+);
+
+const { data: hub } = await useAsyncData(
+  'comparison-hub',
+  () => queryCollection('comparisonHub').first(),
+  { dedupe: 'defer' },
+);
+
+const { data: comparisons } = await useAsyncData(
+  'comparisons-hub',
+  () => queryCollection('comparisons').order('competitor', 'ASC').all(),
+  { dedupe: 'defer' },
+);
+
+const items = computed<ComparisonsCollectionItem[]>(() => get(comparisons) ?? []);
+const hubData = computed<ComparisonHubCollectionItem | undefined>(() => get(hub) ?? undefined);
+const keyTakeaways = computed<string[]>(() => get(hubData)?.keyTakeaways ?? []);
+const rotkiHighlights = computed<string[]>(() => get(hubData)?.rotkiHighlights ?? []);
+const faq = computed<{ q: string; a: string }[]>(() => get(hubData)?.faq ?? []);
+
+const jsonLd = computed<string[]>(() => {
+  const list = get(items);
+  const blocks: string[] = [];
+
+  blocks.push(JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    'name': 'rotki crypto tax software comparisons',
+    'description': t('compare.description'),
+    'url': `${baseUrl}/compare`,
+    'numberOfItems': list.length,
+    'itemListElement': list.map((item, index) => ({
+      '@type': 'ListItem',
+      'position': index + 1,
+      'name': `rotki vs ${item.competitor}`,
+      'item': `${baseUrl}${item.path}`,
+    })),
+  }));
+
+  const faqItems = get(faq);
+  if (faqItems.length > 0) {
+    blocks.push(JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      'mainEntity': faqItems.map(({ q, a }) => ({
+        '@type': 'Question',
+        'name': q,
+        'acceptedAnswer': { '@type': 'Answer', 'text': a },
+      })),
+    }));
+  }
+
+  return blocks;
+});
+
+useHead({
+  script: jsonLd.value.map(block => ({
+    type: 'application/ld+json',
+    innerHTML: block.replaceAll('<', '\\u003c'),
+  })),
+});
+
+definePageMeta({
+  landing: true,
+});
+</script>
+
+<template>
+  <div>
+    <section class="py-10 md:py-20 bg-rui-primary/[.04]">
+      <div class="container">
+        <div class="max-w-[820px]">
+          <span class="text-h6 text-rui-primary uppercase tracking-wide font-bold">
+            {{ t('compare.header') }}
+          </span>
+          <div class="w-16 h-1 bg-rui-primary rounded-full mt-4" />
+          <h1 class="text-h4 md:text-h3 font-bold mt-4">
+            {{ t('compare.title') }}
+          </h1>
+          <p
+            v-if="hubData"
+            class="text-body-1 mt-4"
+          >
+            {{ hubData.intro }}
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="keyTakeaways.length > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.hub.takeaways_title') }}
+        </h2>
+        <div class="max-w-3xl border border-rui-primary/20 border-l-4 border-l-rui-primary bg-rui-primary/[.04] rounded-r-xl p-6 md:p-8">
+          <ul class="space-y-3">
+            <li
+              v-for="takeaway in keyTakeaways"
+              :key="takeaway"
+              class="flex items-start gap-3 text-body-1"
+            >
+              <RuiIcon
+                name="lu-circle-check"
+                size="20"
+                color="primary"
+                class="shrink-0 mt-0.5"
+              />
+              <span>{{ takeaway }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-10 md:py-14 bg-rui-primary/[.04]">
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.hub.summary_title') }}
+        </h2>
+        <div class="overflow-x-auto border border-rui-grey-200 rounded-xl bg-white">
+          <table class="w-full border-collapse text-left">
+            <thead>
+              <tr class="border-b border-rui-grey-200 bg-rui-primary/[.04]">
+                <th class="p-4 text-body-2 font-bold text-rui-text-secondary">
+                  {{ t('compare.hub.col_tool') }}
+                </th>
+                <th class="p-4 text-body-2 font-bold text-rui-text-secondary">
+                  {{ t('compare.hub.col_storage') }}
+                </th>
+                <th class="p-4 text-body-2 font-bold text-rui-text-secondary">
+                  {{ t('compare.hub.col_open_source') }}
+                </th>
+                <th class="p-4 text-body-2 font-bold text-rui-text-secondary">
+                  {{ t('compare.hub.col_custody') }}
+                </th>
+                <th class="p-4 text-body-2 font-bold text-rui-text-secondary">
+                  {{ t('compare.hub.col_deployment') }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b border-rui-grey-100 bg-rui-primary/[.07]">
+                <th
+                  scope="row"
+                  class="p-4 text-body-1 font-bold text-rui-primary border-l-4 border-rui-primary"
+                >
+                  rotki
+                </th>
+                <td class="p-4 text-body-2 font-medium text-rui-text">
+                  {{ t('compare.hub.rotki_storage') }}
+                </td>
+                <td class="p-4 text-body-2 font-medium text-rui-text">
+                  <span class="inline-flex items-center gap-2">
+                    <RuiIcon
+                      name="lu-circle-check"
+                      size="18"
+                      color="success"
+                      class="shrink-0"
+                    />
+                    {{ t('compare.hub.rotki_open_source') }}
+                  </span>
+                </td>
+                <td class="p-4 text-body-2 font-medium text-rui-text">
+                  <span class="inline-flex items-center gap-2">
+                    <RuiIcon
+                      name="lu-circle-check"
+                      size="18"
+                      color="success"
+                      class="shrink-0"
+                    />
+                    {{ t('compare.hub.rotki_custody') }}
+                  </span>
+                </td>
+                <td class="p-4 text-body-2 font-medium text-rui-text">
+                  {{ t('compare.hub.rotki_deployment') }}
+                </td>
+              </tr>
+              <tr
+                v-for="item in items"
+                :key="item.path"
+                class="border-b border-rui-grey-100 last:border-b-0"
+              >
+                <th
+                  scope="row"
+                  class="p-4 text-body-2 font-medium border-l-4 border-transparent"
+                >
+                  <NuxtLink
+                    :to="item.path"
+                    class="text-rui-text hover:text-rui-primary"
+                  >
+                    {{ item.competitor }}
+                  </NuxtLink>
+                </th>
+                <td class="p-4 text-body-2 text-rui-text-secondary">
+                  {{ t('compare.hub.competitor_storage') }}
+                </td>
+                <td class="p-4 text-body-2 text-rui-text-secondary">
+                  <span class="inline-flex items-center gap-2">
+                    <RuiIcon
+                      name="lu-circle-x"
+                      size="18"
+                      color="error"
+                      class="shrink-0 opacity-70"
+                    />
+                    {{ t('compare.hub.competitor_open_source') }}
+                  </span>
+                </td>
+                <td class="p-4 text-body-2 text-rui-text-secondary">
+                  <span class="inline-flex items-center gap-2">
+                    <RuiIcon
+                      name="lu-circle-x"
+                      size="18"
+                      color="error"
+                      class="shrink-0 opacity-70"
+                    />
+                    {{ t('compare.hub.competitor_custody') }}
+                  </span>
+                </td>
+                <td class="p-4 text-body-2 text-rui-text-secondary">
+                  {{ t('compare.hub.competitor_deployment') }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-10 md:py-14">
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.hub.list_title') }}
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <NuxtLink
+            v-for="item in items"
+            :key="item.path"
+            :to="item.path"
+            class="flex items-start gap-4 border border-rui-grey-200 rounded-xl p-5 bg-white hover:border-rui-primary transition-colors"
+          >
+            <div class="w-12 h-12 border border-rui-grey-200 rounded-lg p-2 bg-white shrink-0">
+              <img
+                :src="item.image"
+                :alt="item.competitor"
+                class="w-full h-full object-contain"
+                width="48"
+                height="48"
+                loading="lazy"
+              />
+            </div>
+            <div>
+              <h3 class="text-h6 font-semibold">
+                rotki vs {{ item.competitor }}
+              </h3>
+              <p class="text-body-2 text-rui-text-secondary mt-1 line-clamp-2">
+                {{ item.tagline }}
+              </p>
+            </div>
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="rotkiHighlights.length > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-4">
+          {{ t('compare.hub.why_title') }}
+        </h2>
+        <ul class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+          <li
+            v-for="highlight in rotkiHighlights"
+            :key="highlight"
+            class="flex items-start gap-3 text-body-1"
+          >
+            <RuiIcon
+              name="lu-circle-check"
+              size="20"
+              color="primary"
+              class="shrink-0 mt-0.5"
+            />
+            <span>{{ highlight }}</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section
+      v-if="hubData"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <div class="max-w-[820px]">
+          <ContentRenderer :value="hubData" />
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="faq.length > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('compare.hub.faq_title') }}
+        </h2>
+        <div class="space-y-4 max-w-3xl">
+          <div
+            v-for="entry in faq"
+            :key="entry.q"
+            class="flex items-start gap-4 border border-rui-grey-200 rounded-xl p-5 bg-white"
+          >
+            <div class="flex items-center justify-center w-9 h-9 rounded-full bg-rui-primary/10 shrink-0">
+              <RuiIcon
+                name="lu-message-circle"
+                size="20"
+                color="primary"
+              />
+            </div>
+            <div>
+              <h3 class="text-h6 font-semibold mb-1">
+                {{ entry.q }}
+              </h3>
+              <p class="text-body-1 text-rui-text-secondary">
+                {{ entry.a }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/packages/website/app/plugins/startup.ts
+++ b/packages/website/app/plugins/startup.ts
@@ -26,12 +26,19 @@ export default defineNuxtPlugin(async () => {
     captureReferralCode();
   }
 
-  const authHint = useAuthHintCookie();
-  const hint = get(authHint);
-
-  if (hint) {
-    logger.debug('auth hint found, fetching account');
-    const { getAccount } = useMainStore();
-    return getAccount();
+  // Account recovery is a client-only concern. Landing pages are statically
+  // prerendered with no user context and every auth-gated route is `ssr: false`,
+  // so fetching the account during SSR gains us nothing. It is also unsafe: in a
+  // Nuxt-only dev server (`make dev-web`) `/webapi` has no proxy, so a server-side
+  // request to `/webapi/account/` falls through to the SPA renderer, which re-runs
+  // this plugin and recurses until the render worker runs out of memory. Guarding
+  // to the client both avoids that loop and matches where auth state actually lives.
+  if (import.meta.client) {
+    const authHint = useAuthHintCookie();
+    if (get(authHint)) {
+      logger.debug('auth hint found, fetching account');
+      const { getAccount } = useMainStore();
+      await getAccount();
+    }
   }
 });

--- a/packages/website/app/utils/comparison-prerender.ts
+++ b/packages/website/app/utils/comparison-prerender.ts
@@ -1,0 +1,15 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Build-time helper: resolves the list of `/compare/<slug>` routes to prerender
+ * from the markdown files in `content/comparisons`. Mirrors the integrations
+ * prerender helper so every comparison page is statically generated (and its OG
+ * card rendered) even if it is not reachable via crawled links.
+ */
+export function comparisonPrerenderRoutes(): string[] {
+  const dir = path.resolve(import.meta.dirname, '../../content/comparisons');
+  return readdirSync(dir)
+    .filter(file => file.endsWith('.md') && !file.startsWith('_'))
+    .map(file => `/compare/${file.replace(/\.md$/, '')}`);
+}

--- a/packages/website/app/utils/llms-config.ts
+++ b/packages/website/app/utils/llms-config.ts
@@ -33,8 +33,16 @@ export const llms: ContentLlmsOptions = {
   sections: [
     {
       title: 'Integrations',
-      description: 'Exchanges, blockchains, and DeFi protocols supported by rotki. rotki runs locally and queries each source directly using your own API keys and RPC endpoints — nothing passes through rotki-operated servers.',
+      description: 'Exchanges, blockchains, and DeFi protocols supported by rotki. rotki runs locally and queries each source directly using your own API keys and RPC endpoints, so nothing passes through rotki-operated servers.',
       contentCollection: 'integrations',
+      contentFilters: [
+        { field: 'extension', operator: '=', value: 'md' },
+      ],
+    },
+    {
+      title: 'Comparisons',
+      description: 'Side-by-side comparisons of rotki against popular cloud crypto tax tools. rotki is the open-source, local-first alternative: your data stays encrypted on your own machine instead of being uploaded to a vendor cloud.',
+      contentCollection: 'comparisons',
       contentFilters: [
         { field: 'extension', operator: '=', value: 'md' },
       ],

--- a/packages/website/content.config.ts
+++ b/packages/website/content.config.ts
@@ -7,6 +7,8 @@ const JOBS = 'content/jobs/*.md';
 const TESTIMONIALS = 'content/testimonials/*.md';
 const SPONSORSHIP_TIERS = 'content/sponsorship-tiers/*.md';
 const INTEGRATIONS = 'content/integrations/*.md';
+const COMPARISONS = 'content/comparisons/*.md';
+const COMPARISON_HUB = 'content/comparison-hub/*.md';
 
 const documentSchema = z.object({
   address: z.string().optional(),
@@ -61,6 +63,60 @@ const integrationSchema = z.object({
   isExchangeWithKey: z.boolean().optional(),
 });
 
+const comparisonSchema = z.object({
+  slug: z.string(),
+  competitor: z.string(),
+  competitorUrl: z.string().optional(),
+  image: z.string(),
+  tagline: z.string(),
+  intro: z.string(),
+  // SERP/meta description (<160 chars). Kept separate from `intro` so the
+  // visible intro paragraph can stay longer than the meta description allows.
+  metaDescription: z.string(),
+  keywords: z.string().optional(),
+  // Short, scannable summary bullets shown near the top of the page.
+  keyTakeaways: z.array(z.string()).default([]),
+  // One-paragraph summary shown near the top and reused for the verdict block.
+  verdict: z.string(),
+  // Side-by-side table rows. rotki is always the left column. `highlight` emphasises
+  // the rows that are most relevant to rotki's positioning (privacy, open source, self-custody).
+  dimensions: z.array(z.object({
+    label: z.string(),
+    rotki: z.string(),
+    competitor: z.string(),
+    highlight: z.boolean().optional(),
+  })).default([]),
+  rotkiAdvantages: z.array(z.string()).default([]),
+  // Cases where the competitor may be a better fit. Shown openly so the comparison stays balanced.
+  tradeoffs: z.array(z.string()).default([]),
+  // "Who rotki is for" bullets, to address switcher intent.
+  whoShouldRotki: z.array(z.string()).default([]),
+  // Links to relevant /integrations/<slug> pages.
+  relatedIntegrations: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  faq: z.array(z.object({
+    q: z.string(),
+    a: z.string(),
+  })).default([]),
+  // Freshness stamp shown on the page (e.g. "Updated June 2026").
+  updatedAt: z.string(),
+  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
+});
+
+// Hub content (intro, takeaways, shared rotki highlights, FAQ) lives in markdown so it
+// is editable alongside the comparison pages rather than in i18n. Only UI labels stay in en.json.
+const comparisonHubSchema = z.object({
+  intro: z.string(),
+  keyTakeaways: z.array(z.string()).default([]),
+  rotkiHighlights: z.array(z.string()).default([]),
+  faq: z.array(z.object({
+    q: z.string(),
+    a: z.string(),
+  })).default([]),
+});
+
 export default defineContentConfig({
   collections: {
     documents: defineCollection({
@@ -105,6 +161,26 @@ export default defineContentConfig({
         cwd: '~~/',
         include: INTEGRATIONS,
         prefix: 'integrations',
+      },
+      type: 'page',
+    }),
+    comparisons: defineCollection({
+      schema: comparisonSchema.extend({ sitemap: defineSitemapSchema() }),
+      source: {
+        cwd: '~~/',
+        include: COMPARISONS,
+        // Prefix must match the page route (`/compare/<slug>`) so `queryCollection('comparisons').path(...)`
+        // in compare/[slug].vue resolves; the collection name stays `comparisons`.
+        prefix: 'compare',
+      },
+      type: 'page',
+    }),
+    comparisonHub: defineCollection({
+      schema: comparisonHubSchema,
+      source: {
+        cwd: '~~/',
+        include: COMPARISON_HUB,
+        prefix: 'comparison-hub',
       },
       type: 'page',
     }),

--- a/packages/website/content/comparison-hub/index.md
+++ b/packages/website/content/comparison-hub/index.md
@@ -1,0 +1,30 @@
+---
+intro: "rotki is the open-source, privacy-first crypto portfolio tracker and tax tool. Unlike the hosted services below, rotki runs locally on your computer, stores your data encrypted on your own machine, and is fully auditable. Pick a tool to see a detailed side-by-side comparison."
+keyTakeaways:
+  - "rotki is local-first and open source: your transaction history stays on your own machine, and the code can be audited on GitHub."
+  - "The cloud tools below are convenient and feature-rich, but they require uploading your full transaction history to their servers."
+  - "rotki has a free local tier and integrates with 180+ exchanges, blockchains, and DeFi protocols."
+  - "Choose rotki if privacy, self-custody, and open source matter to you and you want your financial data to stay on your own machine."
+rotkiHighlights:
+  - "Local-first: your transaction history is read and stored on your own machine, not uploaded to a vendor cloud."
+  - "Open source: the entire application is auditable on GitHub, so you can verify exactly what it does with your data."
+  - "Self-custodied data: you connect exchanges with read-only API keys and query chains via your own endpoints; you never hand over your full history."
+  - "Free local tier: the core tracking, accounting, and reporting work locally for free, with premium features available by subscription."
+faq:
+  - q: "What is the best open-source crypto tax software?"
+    a: "rotki is an open-source, local-first crypto portfolio tracker and tax tool. Its source code is public and auditable, and it runs on your own computer instead of a hosted cloud, which is why it is a strong fit for privacy-conscious users."
+  - q: "Is there a private alternative to cloud crypto tax tools like Koinly or CoinTracker?"
+    a: "Yes. rotki is designed as a local-first alternative: it keeps your data encrypted on your own device and queries exchanges and blockchains directly using your own API keys and RPC endpoints, so your full transaction history is not uploaded to a third-party server."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core portfolio tracking, accounting, and tax reporting (with some limits). A premium subscription unlocks higher limits and additional features."
+---
+
+## How we compare
+
+Every tool on this page does the same core job: it pulls together your exchange and on-chain activity, tracks your portfolio, and produces accounting and tax reports. The meaningful difference is **where your data lives and who controls it**.
+
+The hosted services (Koinly, CoinTracker, CoinTracking, CoinLedger, ZenLedger, Awaken) run in the cloud. You create an account, connect your exchanges and wallets, and your transaction history is uploaded to and stored on the vendor's servers. That model is convenient: it works in a browser, often on mobile, and your data is reachable from any device.
+
+rotki takes the opposite approach. It is a desktop application you run on your own computer. It reads your exchange data through read-only API keys and your on-chain activity through RPC endpoints you choose, and it stores everything in a local database encrypted with SQLCipher using 256-bit AES. By default nothing passes through rotki-operated servers. The one exception is rotki's optional premium backup and multi-device sync, and even that is zero-knowledge: your database is encrypted on your device with a key derived from your password before it is uploaded, and rotki's servers never receive that password, so only you can decrypt the backup, never rotki. Because rotki is open source, you can verify exactly how it handles your data.
+
+Each comparison below leads with that distinction, then lays out the practical trade-offs of running locally, and why we think it is the better foundation for managing your crypto finances.

--- a/packages/website/content/comparisons/awaken.md
+++ b/packages/website/content/comparisons/awaken.md
@@ -1,0 +1,107 @@
+---
+slug: awaken
+competitor: "Awaken"
+competitorUrl: "https://awaken.tax"
+image: "/img/compare/awaken.svg"
+tagline: "rotki vs Awaken: open-source DeFi accounting that stays local"
+intro: "Awaken is a hosted crypto tax tool with a focus on DeFi and NFT activity. rotki is the open-source, local-first alternative that decodes your on-chain activity directly on your own computer, with your data kept local."
+metaDescription: "rotki is the open-source, local-first alternative to Awaken. It decodes your DeFi and NFT activity on your own computer, keeping your data local."
+keywords: "rotki vs awaken, awaken tax alternative, open source awaken alternative, private defi tax software, local crypto tax software"
+keyTakeaways:
+  - "Both Awaken and rotki focus on getting DeFi and on-chain activity right."
+  - "Awaken does this in the cloud; rotki decodes your on-chain activity locally on your own machine."
+  - "rotki is open source and self-custodied; Awaken is a closed-source hosted service."
+  - "rotki has a free local tier and integrates with 180+ exchanges, blockchains, and DeFi protocols."
+verdict: "Awaken offers a hosted experience focused on DeFi and NFTs, but it uploads your on-chain history to its servers to do it. rotki decodes that same activity locally, keeps your data on your own machine, and is fully open source. If privacy and self-custody matter to you, rotki is the one to choose."
+updatedAt: "June 2026"
+ctaPlan: free
+dimensions:
+  - label: "Data storage"
+    rotki: "Local and encrypted on your own machine"
+    competitor: "Uploaded to and stored on the vendor cloud"
+    highlight: true
+  - label: "Open source"
+    rotki: "Yes, fully auditable on GitHub"
+    competitor: "Closed-source"
+    highlight: true
+  - label: "Data custody"
+    rotki: "Self-custodied; you keep your data"
+    competitor: "You hand your full history to the vendor"
+    highlight: true
+  - label: "Breach blast radius"
+    rotki: "Your device only"
+    competitor: "Centralized; one vendor breach can affect many users"
+    highlight: true
+  - label: "API keys and RPC"
+    rotki: "Your own read-only keys and endpoints, used locally"
+    competitor: "Keys and data processed on the vendor servers"
+    highlight: true
+  - label: "Deployment"
+    rotki: "Desktop app for Windows, macOS, and Linux, or self-hosted via Docker"
+    competitor: "Hosted web app, with a mobile app where offered"
+  - label: "Free tier"
+    rotki: "Free local tier covers core tracking, accounting, and reporting (with limits)"
+    competitor: "Free tier with limits; a paid plan is needed for full tax reports"
+  - label: "Pricing model"
+    rotki: "Free, plus an optional subscription (Basic, Advanced, Custom)"
+    competitor: "Tiered plans, typically priced by transaction volume"
+  - label: "DeFi and NFT decoding"
+    rotki: "Decodes DeFi and NFT activity into readable events with full PnL accounting"
+    competitor: "Cloud-based DeFi and NFT categorization"
+  - label: "Migration importer"
+    rotki: "Import via exchange API keys, addresses, and standard files"
+    competitor: "Hosted importer for moving from other tools"
+rotkiAdvantages:
+  - "Your transaction history never leaves your computer; rotki reads exchanges and chains directly with your own keys and endpoints."
+  - "The entire application is open source and auditable, so you can verify exactly how your data is handled."
+  - "Self-custodied data: there is no vendor account holding your full financial history."
+  - "A free local tier covers core portfolio tracking, accounting, and tax reporting."
+  - "DeFi and NFT activity is decoded into readable events with full PnL accounting, processed locally."
+tradeoffs:
+  - "rotki is a desktop app you run yourself rather than a hosted service in a browser. That is what keeps your on-chain history on your own machine instead of in a vendor's cloud, and it is worth running an app for."
+  - "Your data lives on the device where you run rotki, so you handle your own backups. Premium adds optional zero-knowledge sync, and either way your history stays encrypted and under your control."
+  - "rotki does not offer a one-click hosted importer; you connect your accounts and addresses and it decodes everything locally. Keeping that decoding on your own machine, where you can verify it, is the deliberate trade and the reason to choose it."
+whoShouldRotki:
+  - "You have significant DeFi or NFT activity and want it decoded transparently and locally."
+  - "You value open-source software you can audit and self-host."
+  - "You want your on-chain history to stay on your own computer."
+  - "You would rather own your data than trade it for cloud convenience."
+relatedIntegrations:
+  - slug: ethereum
+    label: "Ethereum"
+  - slug: uniswap
+    label: "Uniswap"
+  - slug: aave
+    label: "Aave"
+  - slug: arbitrum-one
+    label: "Arbitrum One"
+faq:
+  - q: "Is Awaken open source?"
+    a: "No. Awaken is a closed-source, hosted service. rotki is open source and its code can be audited on GitHub."
+  - q: "Does Awaken store my data in the cloud?"
+    a: "Yes. Awaken imports and stores your transaction data on its servers. rotki keeps your data encrypted on your own machine."
+  - q: "Is rotki a good alternative to Awaken for DeFi?"
+    a: "Yes. rotki decodes on-chain activity, including DeFi and NFT events, into readable events with full profit and loss accounting, all processed locally on your machine."
+  - q: "Can I move my data from another tool into rotki?"
+    a: "rotki imports through exchange API keys, your public addresses, and standard files. It does not offer a one-click hosted migration like Awaken's importer, because the work happens locally on your machine."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core functionality with some limits. A premium subscription unlocks higher limits and additional features."
+---
+
+Awaken and rotki both put on-chain activity at the center: DeFi positions, swaps, NFTs, and the messy reality of wallet history. Awaken does this as a hosted service, while rotki does it as a local-first, open-source desktop application that decodes your activity on your own machine.
+
+## How Awaken works
+
+Awaken is a cloud tool with a strong focus on DeFi and NFT tax handling, and it offers importers to help people move over from other hosted services. You connect your wallets and accounts, and Awaken processes that history on its servers. The trade-off is that your on-chain history is uploaded to the vendor.
+
+## How rotki works
+
+rotki reads your on-chain activity through RPC endpoints you choose and decodes it locally into readable events, with full profit and loss accounting. Everything is stored in an encrypted database on your own computer, and because rotki is open source, you can verify exactly how each protocol is decoded rather than trusting a closed cloud pipeline.
+
+## Privacy and ownership
+
+For on-chain-heavy users this matters a lot: your wallet history is sensitive, and a hosted tool concentrates it on its servers. rotki keeps that history local and self-custodied, so there is no central store to breach and no dependence on a vendor's handling of your data.
+
+## The trade-off
+
+rotki does not offer a one-click hosted importer, and it asks you to connect your accounts, run a desktop app, and keep your own backups. In return it decodes your DeFi and NFT activity locally, with open-source transparency and your on-chain history kept on your own machine. For anyone who wants that history private and auditable rather than uploaded to a vendor, that is the trade worth making, and the reason to choose rotki.

--- a/packages/website/content/comparisons/coinledger.md
+++ b/packages/website/content/comparisons/coinledger.md
@@ -1,0 +1,107 @@
+---
+slug: coinledger
+competitor: "CoinLedger"
+competitorUrl: "https://coinledger.io"
+image: "/img/compare/coinledger.svg"
+tagline: "rotki vs CoinLedger: a private, open-source alternative"
+intro: "CoinLedger is a hosted crypto tax service focused on quick report generation and exports to tax software. rotki is the open-source, local-first alternative that keeps your data on your own computer while still producing portfolio, accounting, and tax reports."
+metaDescription: "rotki is the open-source, local-first alternative to CoinLedger. Generate portfolio, accounting, and tax reports while your data stays on your machine."
+keywords: "rotki vs coinledger, coinledger alternative, open source coinledger alternative, private crypto tax software, local crypto tax software"
+keyTakeaways:
+  - "CoinLedger is built around fast, hosted tax-report generation and exports to filing software."
+  - "rotki keeps your data on your own machine and is fully open source; CoinLedger is a closed-source cloud service."
+  - "Choose CoinLedger for a quick managed path to a filing-ready report; choose rotki for privacy and self-custody."
+  - "rotki has a free local tier and integrates with 180+ exchanges, blockchains, and DeFi protocols."
+verdict: "CoinLedger is geared toward fast, hosted report generation and tax-software exports, but it does that by uploading your data to its cloud. rotki keeps your transaction history on your own machine, is fully open source, and covers portfolio tracking, accounting, and tax reporting. If privacy and self-custody matter to you, rotki is the one to choose."
+updatedAt: "June 2026"
+ctaPlan: free
+dimensions:
+  - label: "Data storage"
+    rotki: "Local and encrypted on your own machine"
+    competitor: "Uploaded to and stored on the vendor cloud"
+    highlight: true
+  - label: "Open source"
+    rotki: "Yes, fully auditable on GitHub"
+    competitor: "Closed-source"
+    highlight: true
+  - label: "Data custody"
+    rotki: "Self-custodied; you keep your data"
+    competitor: "You hand your full history to the vendor"
+    highlight: true
+  - label: "Breach blast radius"
+    rotki: "Your device only"
+    competitor: "Centralized; one vendor breach can affect many users"
+    highlight: true
+  - label: "API keys and RPC"
+    rotki: "Your own read-only keys and endpoints, used locally"
+    competitor: "Keys and data processed on the vendor servers"
+    highlight: true
+  - label: "Deployment"
+    rotki: "Desktop app for Windows, macOS, and Linux, or self-hosted via Docker"
+    competitor: "Hosted web app, with a mobile app where offered"
+  - label: "Free tier"
+    rotki: "Free local tier covers core tracking, accounting, and reporting (with limits)"
+    competitor: "Free to import and preview; a paid plan is needed to download full tax reports"
+  - label: "Pricing model"
+    rotki: "Free, plus an optional subscription (Basic, Advanced, Custom)"
+    competitor: "Tiered plans, typically priced by transaction volume"
+  - label: "Tax-software exports"
+    rotki: "Standard reports and exports you generate locally"
+    competitor: "Exports to popular tax-filing software"
+  - label: "On-chain decoding"
+    rotki: "Decodes on-chain activity into readable events with full PnL accounting"
+    competitor: "Cloud import and categorization; coverage varies"
+rotkiAdvantages:
+  - "Your transaction history never leaves your computer; rotki reads exchanges and chains directly with your own keys and endpoints."
+  - "The entire application is open source and auditable, so you can verify exactly how your data is handled."
+  - "Self-custodied data: there is no vendor account holding your full financial history."
+  - "A free local tier covers core portfolio tracking, accounting, and tax reporting."
+  - "On-chain activity is decoded into readable events, so your DeFi and wallet history is accounted for transparently."
+tradeoffs:
+  - "rotki is a desktop app you run yourself rather than a hosted service in a browser. That is what keeps your data on your own machine instead of in a vendor's cloud, and it is worth running an app for."
+  - "Your data lives on the device where you run rotki, so you handle your own backups. Premium adds optional zero-knowledge sync, and either way your history stays encrypted and under your control."
+  - "rotki does not wire directly into consumer filing software; it generates standard reports and exports locally. Doing the work on your own machine, where you can verify it, is the deliberate trade and the reason to choose it."
+whoShouldRotki:
+  - "You want your transaction history to stay on your own computer."
+  - "You value open-source software you can audit and self-host."
+  - "You want transparent on-chain decoding behind your tax numbers."
+  - "You would rather own your data than trade it for cloud convenience."
+relatedIntegrations:
+  - slug: coinbase
+    label: "Coinbase"
+  - slug: kraken
+    label: "Kraken"
+  - slug: ethereum
+    label: "Ethereum"
+  - slug: uniswap
+    label: "Uniswap"
+faq:
+  - q: "Is CoinLedger open source?"
+    a: "No. CoinLedger is a closed-source, hosted service. rotki is open source and its code can be audited on GitHub."
+  - q: "Does CoinLedger store my data in the cloud?"
+    a: "Yes. CoinLedger imports and stores your transaction data on its servers. rotki keeps your data encrypted on your own machine."
+  - q: "Is rotki a good alternative to CoinLedger?"
+    a: "If privacy, self-custody, and open source matter to you, yes. rotki covers portfolio tracking, accounting, and tax reporting locally, with a free tier and an optional subscription for more."
+  - q: "Can rotki export reports for tax filing?"
+    a: "Yes. rotki generates accounting and tax reports and standard exports locally on your machine. CoinLedger emphasizes direct integrations with consumer filing software, which rotki does not aim to replicate."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core functionality with some limits. A premium subscription unlocks higher limits and additional features."
+---
+
+CoinLedger is built around getting you to a finished tax report quickly, with exports into consumer filing software. rotki is a local-first, open-source desktop application that produces the same kind of reports while keeping your data on your own machine. The tools overlap on output but differ on where your data lives.
+
+## How CoinLedger works
+
+CoinLedger is a hosted service. You connect exchanges and wallets, it imports your history into its cloud, and it focuses on turning that into a filing-ready tax report with direct exports to popular tax software. The cost is the usual one: your full history sits on the vendor's servers.
+
+## How rotki works
+
+rotki runs locally and stores your data in an encrypted database on your computer. It connects to exchanges with read-only API keys and reads chains through your own RPC endpoints, and it is open source so you can audit it. It produces accounting and tax reports and standard exports without uploading your data anywhere.
+
+## Privacy and ownership
+
+If you would rather not hand your complete transaction history to a tax vendor, rotki is the answer. Your data stays self-custodied and local, there is no cloud account to be breached, and you are not trusting a closed pipeline to handle your records.
+
+## The trade-off
+
+rotki does not wire directly into consumer filing software, and it asks you to run a desktop app and keep your own backups. In return you get privacy, self-custody, and open-source transparency, with your records processed on your own machine instead of a vendor's cloud. For anyone who would rather own their data than hand it over for a faster filing flow, that is the trade worth making, and the reason to choose rotki.

--- a/packages/website/content/comparisons/cointracker.md
+++ b/packages/website/content/comparisons/cointracker.md
@@ -1,0 +1,106 @@
+---
+slug: cointracker
+competitor: "CoinTracker"
+competitorUrl: "https://www.cointracker.io"
+image: "/img/compare/cointracker.svg"
+tagline: "rotki vs CoinTracker: keep your portfolio data on your own machine"
+intro: "CoinTracker is a hosted portfolio tracker and crypto tax tool with web and mobile apps that sync your data to its cloud. rotki is the open-source, local-first alternative that keeps your portfolio and transaction history encrypted on your own computer, querying exchanges and chains with your own keys and endpoints."
+metaDescription: "rotki is the open-source, local-first alternative to CoinTracker. Your portfolio and transactions stay encrypted on your own computer, never in the cloud."
+keywords: "rotki vs cointracker, cointracker alternative, open source cointracker alternative, private crypto portfolio tracker, local crypto tax software"
+keyTakeaways:
+  - "CoinTracker is a cloud portfolio tracker with web and mobile apps; rotki keeps your portfolio on your own machine."
+  - "rotki is open source and self-custodied; CoinTracker is a closed-source hosted service."
+  - "CoinTracker shines at mobile, always-synced tracking; rotki shines at privacy and auditability."
+  - "rotki has a free local tier and integrates with 180+ exchanges, blockchains, and DeFi protocols."
+verdict: "CoinTracker gives you a convenient cloud dashboard with mobile access, but only by storing your data on its servers. rotki delivers portfolio tracking, accounting, and tax reporting on your own machine, as open-source software you can audit. If privacy and self-custody matter to you, rotki is the one to choose."
+updatedAt: "June 2026"
+ctaPlan: free
+dimensions:
+  - label: "Data storage"
+    rotki: "Local and encrypted on your own machine"
+    competitor: "Uploaded to and stored on the vendor cloud"
+    highlight: true
+  - label: "Open source"
+    rotki: "Yes, fully auditable on GitHub"
+    competitor: "Closed-source"
+    highlight: true
+  - label: "Data custody"
+    rotki: "Self-custodied; you keep your data"
+    competitor: "You hand your full history to the vendor"
+    highlight: true
+  - label: "Breach blast radius"
+    rotki: "Your device only"
+    competitor: "Centralized; one vendor breach can affect many users"
+    highlight: true
+  - label: "API keys and RPC"
+    rotki: "Your own read-only keys and endpoints, used locally"
+    competitor: "Keys and data processed on the vendor servers"
+    highlight: true
+  - label: "Deployment"
+    rotki: "Desktop app for Windows, macOS, and Linux, or self-hosted via Docker"
+    competitor: "Hosted web app with a mobile app"
+  - label: "Mobile access"
+    rotki: "Desktop-focused; no first-party mobile app"
+    competitor: "Native mobile apps with cloud sync"
+  - label: "Free tier"
+    rotki: "Free local tier covers core tracking, accounting, and reporting (with limits)"
+    competitor: "Free portfolio tracking (transaction-capped); a paid plan is needed for tax reports"
+  - label: "Pricing model"
+    rotki: "Free, plus an optional subscription (Basic, Advanced, Custom)"
+    competitor: "Tiered plans, typically priced by transaction volume"
+  - label: "On-chain decoding"
+    rotki: "Decodes on-chain activity into readable events with full PnL accounting"
+    competitor: "Cloud import and categorization; coverage varies"
+rotkiAdvantages:
+  - "Your transaction history never leaves your computer; rotki reads exchanges and chains directly with your own keys and endpoints."
+  - "The entire application is open source and auditable, so you can verify exactly how your data is handled."
+  - "Self-custodied data: there is no vendor account holding your full financial history."
+  - "A free local tier covers core portfolio tracking, accounting, and tax reporting."
+  - "On-chain activity is decoded into readable events, so your DeFi and wallet history is accounted for transparently."
+tradeoffs:
+  - "rotki is a desktop app you run yourself rather than a hosted service you reach from any browser. That is what keeps your data on your own machine instead of in a vendor's cloud, and it is worth running an app for."
+  - "Your data lives on the device where you run rotki, so you handle your own backups. Premium adds optional zero-knowledge sync, and either way your history stays encrypted and under your control."
+  - "rotki is desktop-first, without a mobile-first cloud dashboard. That is the deliberate cost of keeping your full history local and private rather than syncing it through someone else's servers."
+whoShouldRotki:
+  - "You want your portfolio and transaction history to stay on your own computer."
+  - "You value open-source software you can audit and self-host."
+  - "You would rather own your data than trade it for cloud convenience."
+relatedIntegrations:
+  - slug: coinbase
+    label: "Coinbase"
+  - slug: kraken
+    label: "Kraken"
+  - slug: ethereum
+    label: "Ethereum"
+  - slug: uniswap
+    label: "Uniswap"
+faq:
+  - q: "Is CoinTracker open source?"
+    a: "No. CoinTracker is a closed-source, hosted service. rotki is open source and its code can be audited on GitHub."
+  - q: "Does CoinTracker store my data in the cloud?"
+    a: "Yes. CoinTracker syncs and stores your portfolio and transaction data on its servers. rotki keeps your data encrypted on your own machine."
+  - q: "Does rotki have a mobile app like CoinTracker?"
+    a: "No. rotki is a desktop application for Windows, macOS, and Linux. This is a deliberate trade-off: your data stays on your own machine rather than syncing through a cloud account."
+  - q: "Is rotki a good alternative to CoinTracker?"
+    a: "If privacy, self-custody, and open source matter to you, yes. rotki covers portfolio tracking, accounting, and tax reporting locally, with a free tier and an optional subscription for more."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core functionality with some limits. A premium subscription unlocks higher limits and additional features."
+---
+
+CoinTracker and rotki both track your crypto portfolio and prepare tax reports, but they make a very different promise about where your data lives. CoinTracker is a cloud service built around convenience and mobile access. rotki is a local-first desktop application built around privacy and ownership.
+
+## How CoinTracker works
+
+CoinTracker is designed to be always on and always synced. You connect your exchanges and wallets, and your data is stored in CoinTracker's cloud so you can open the web or mobile app from any device and see an up-to-date view. The trade-off is that your full transaction history is held on the vendor's servers.
+
+## How rotki works
+
+rotki runs on your computer and stores your data in an encrypted local database. It connects to exchanges with read-only API keys and reads on-chain activity through RPC endpoints you choose. Nothing is uploaded to rotki-operated servers, and the code is open source so you can verify how it behaves. The result is a portfolio tracker and tax tool where you, not a vendor, hold the data.
+
+## Privacy and ownership
+
+If you would rather not place your entire financial history in a third-party cloud, this is the deciding factor. rotki keeps that history local and self-custodied. There is no vendor account that could be breached, sold, or mined, and you are not relying on someone else's retention policy.
+
+## The trade-off
+
+rotki is desktop-first and does not chase the mobile, always-synced cloud experience. It asks you to run a desktop app and keep your own backups. In exchange you get privacy, self-custody, and open-source software you can audit, with your data on your machine rather than a vendor's. For anyone who values owning their financial data, that is a trade worth making, and the reason to choose rotki.

--- a/packages/website/content/comparisons/cointracking.md
+++ b/packages/website/content/comparisons/cointracking.md
@@ -1,0 +1,107 @@
+---
+slug: cointracking
+competitor: "CoinTracking"
+competitorUrl: "https://cointracking.info"
+image: "/img/compare/cointracking.svg"
+tagline: "rotki vs CoinTracking: open-source accounting without the cloud"
+intro: "CoinTracking is a long-running hosted crypto tax and reporting service with an extensive set of reports. rotki is the open-source, local-first alternative: comparable portfolio tracking, accounting, and tax reporting, but running on your own machine with your data kept local."
+metaDescription: "rotki is the open-source, local-first alternative to CoinTracking. Portfolio tracking, accounting, and tax reports run on your own machine, data kept local."
+keywords: "rotki vs cointracking, cointracking alternative, open source cointracking alternative, private crypto tax software, local crypto accounting"
+keyTakeaways:
+  - "CoinTracking is a mature, report-heavy hosted service; rotki is the local-first, open-source alternative."
+  - "rotki keeps your data on your own machine; CoinTracking stores it in its cloud."
+  - "CoinTracking offers a very wide range of pre-built reports; rotki does the core accounting locally and transparently."
+  - "rotki has a free local tier and integrates with 180+ exchanges, blockchains, and DeFi protocols."
+verdict: "CoinTracking has a deep, mature reporting set, but it runs as a hosted account that holds your full history on its servers. rotki keeps your data on your own computer, is fully open source, and still covers portfolio tracking, accounting, and tax reporting. If privacy and self-custody matter to you, rotki is the one to choose."
+updatedAt: "June 2026"
+ctaPlan: free
+dimensions:
+  - label: "Data storage"
+    rotki: "Local and encrypted on your own machine"
+    competitor: "Uploaded to and stored on the vendor cloud"
+    highlight: true
+  - label: "Open source"
+    rotki: "Yes, fully auditable on GitHub"
+    competitor: "Closed-source"
+    highlight: true
+  - label: "Data custody"
+    rotki: "Self-custodied; you keep your data"
+    competitor: "You hand your full history to the vendor"
+    highlight: true
+  - label: "Breach blast radius"
+    rotki: "Your device only"
+    competitor: "Centralized; one vendor breach can affect many users"
+    highlight: true
+  - label: "API keys and RPC"
+    rotki: "Your own read-only keys and endpoints, used locally"
+    competitor: "Keys and data processed on the vendor servers"
+    highlight: true
+  - label: "Deployment"
+    rotki: "Desktop app for Windows, macOS, and Linux, or self-hosted via Docker"
+    competitor: "Hosted web app, with a mobile app where offered"
+  - label: "Free tier"
+    rotki: "Free local tier covers core tracking, accounting, and reporting (with limits)"
+    competitor: "Free tier is transaction-capped and largely view-only after a short trial; paid plans to import and report"
+  - label: "Pricing model"
+    rotki: "Free, plus an optional subscription (Basic, Advanced, Custom)"
+    competitor: "Tiered plans, including longer-term and lifetime options"
+  - label: "Reporting breadth"
+    rotki: "Core accounting and tax reports generated locally"
+    competitor: "Very wide range of pre-built reports and charts"
+  - label: "On-chain decoding"
+    rotki: "Decodes on-chain activity into readable events with full PnL accounting"
+    competitor: "Cloud import and categorization; coverage varies"
+rotkiAdvantages:
+  - "Your transaction history never leaves your computer; rotki reads exchanges and chains directly with your own keys and endpoints."
+  - "The entire application is open source and auditable, so you can verify exactly how your data is handled."
+  - "Self-custodied data: there is no vendor account holding your full financial history."
+  - "A free local tier covers core portfolio tracking, accounting, and tax reporting."
+  - "On-chain activity is decoded into readable events, so your DeFi and wallet history is accounted for transparently."
+tradeoffs:
+  - "rotki is a desktop app you run yourself rather than a hosted account in a browser. That is what keeps your data on your own machine instead of in a vendor's cloud, and it is worth running an app for."
+  - "Your data lives on the device where you run rotki, so you handle your own backups. Premium adds optional zero-knowledge sync, and either way your history stays encrypted and under your control."
+  - "rotki focuses on accurate core accounting and transparent on-chain decoding rather than the widest possible catalog of reports. Keeping that work local and auditable is the point, and the reason to choose it."
+whoShouldRotki:
+  - "You want your transaction history to stay on your own computer."
+  - "You value open-source software you can audit and self-host."
+  - "You prefer transparent on-chain decoding over a closed cloud pipeline."
+  - "You would rather own your data than trade it for cloud convenience."
+relatedIntegrations:
+  - slug: binance
+    label: "Binance"
+  - slug: kraken
+    label: "Kraken"
+  - slug: bitstamp
+    label: "Bitstamp"
+  - slug: ethereum
+    label: "Ethereum"
+faq:
+  - q: "Is CoinTracking open source?"
+    a: "No. CoinTracking is a closed-source, hosted service. rotki is open source and its code can be audited on GitHub."
+  - q: "Does CoinTracking store my data in the cloud?"
+    a: "Yes. CoinTracking imports and stores your transaction data on its servers. rotki keeps your data encrypted on your own machine."
+  - q: "Is rotki a good alternative to CoinTracking?"
+    a: "If privacy, self-custody, and open source matter to you, yes. rotki covers portfolio tracking, accounting, and tax reporting locally, with a free tier and an optional subscription for more."
+  - q: "Does rotki have as many reports as CoinTracking?"
+    a: "CoinTracking is known for a very broad catalog of reports and charts. rotki focuses on accurate core accounting and tax reports generated locally, with transparent on-chain decoding, rather than matching that breadth."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core functionality with some limits. A premium subscription unlocks higher limits and additional features."
+---
+
+CoinTracking is one of the oldest names in crypto tax software, known for a deep and report-heavy hosted platform. rotki approaches the same job as a local-first, open-source desktop application. Both will track your portfolio and produce tax reports; the question is whether you want that work done in the cloud or on your own machine.
+
+## How CoinTracking works
+
+CoinTracking is a hosted account. You import your trades and transfers through API connections or files, and CoinTracking stores that history on its servers and turns it into a large range of reports, charts, and tax outputs. Breadth of reporting is its reputation. As with any hosted tool, the cost is that your full history is held by the vendor.
+
+## How rotki works
+
+rotki runs on your computer and stores everything in an encrypted local database. It pulls exchange data with read-only API keys and on-chain activity through RPC endpoints you control, and it is open source so you can verify how it works. It is built to give you accurate accounting and tax reports without your data leaving your machine.
+
+## Privacy and ownership
+
+This is the heart of the comparison. A long-lived hosted account accumulates years of your financial history in one place. rotki keeps that history local and self-custodied, so there is no vendor-side store to breach and no dependence on someone else's security or retention practices.
+
+## The trade-off
+
+rotki does not aim to match every report in a hosted catalog. It focuses on accurate core accounting, transparent on-chain decoding, and keeping your data local. That focus is deliberate: the work happens on your machine, in software you can audit, with your history never handed to a vendor. For privacy, open source, and self-custody, that is the trade worth making, and the reason to choose rotki.

--- a/packages/website/content/comparisons/koinly.md
+++ b/packages/website/content/comparisons/koinly.md
@@ -1,0 +1,113 @@
+---
+slug: koinly
+competitor: "Koinly"
+competitorUrl: "https://koinly.io"
+image: "/img/compare/koinly.svg"
+tagline: "rotki vs Koinly: the open-source, local-first alternative"
+intro: "Koinly is a popular hosted crypto tax service that imports your transactions into its cloud. rotki is the open-source, local-first alternative: it runs on your own computer, keeps your data encrypted locally, and queries exchanges and blockchains directly using your own API keys and RPC endpoints."
+metaDescription: "rotki is the open-source, local-first alternative to Koinly. It runs on your own computer and keeps your crypto data encrypted locally, never in the cloud."
+keywords: "rotki vs koinly, koinly alternative, open source koinly alternative, private crypto tax software, local crypto tax software"
+keyTakeaways:
+  - "rotki keeps your transaction history encrypted on your own machine; Koinly stores it in its cloud."
+  - "rotki is open source and fully auditable; Koinly is a closed-source hosted service."
+  - "Koinly is known for broad country coverage and a polished hosted dashboard; rotki is the choice when privacy and self-custody come first."
+  - "rotki has a free local tier and integrates with 180+ exchanges, blockchains, and DeFi protocols."
+verdict: "Koinly gives you a polished hosted dashboard, but only by taking your full transaction history into its cloud. rotki delivers the same core portfolio tracking, accounting, and tax reporting on your own machine, as open-source software you can audit. If privacy and self-custody matter to you, rotki is the one to choose."
+updatedAt: "June 2026"
+ctaPlan: free
+dimensions:
+  - label: "Data storage"
+    rotki: "Local and encrypted on your own machine"
+    competitor: "Uploaded to and stored on the vendor cloud"
+    highlight: true
+  - label: "Open source"
+    rotki: "Yes, fully auditable on GitHub"
+    competitor: "Closed-source"
+    highlight: true
+  - label: "Data custody"
+    rotki: "Self-custodied; you keep your data"
+    competitor: "You hand your full history to the vendor"
+    highlight: true
+  - label: "Breach blast radius"
+    rotki: "Your device only"
+    competitor: "Centralized; one vendor breach can affect many users"
+    highlight: true
+  - label: "API keys and RPC"
+    rotki: "Your own read-only keys and endpoints, used locally"
+    competitor: "Keys and data processed on the vendor servers"
+    highlight: true
+  - label: "Deployment"
+    rotki: "Desktop app for Windows, macOS, and Linux, or self-hosted via Docker"
+    competitor: "Hosted web app, with a mobile app"
+  - label: "Free tier"
+    rotki: "Free local tier covers core tracking, accounting, and reporting (with limits)"
+    competitor: "Free to import and preview; a paid plan is needed to download full tax reports"
+  - label: "Pricing model"
+    rotki: "Free, plus an optional subscription (Basic, Advanced, Custom)"
+    competitor: "Tiered plans, typically priced by transaction volume"
+  - label: "Tax country coverage"
+    rotki: "Localized reports and standard exports generated on your machine"
+    competitor: "Broad country-specific report coverage"
+  - label: "On-chain decoding"
+    rotki: "Decodes on-chain activity into readable events with full PnL accounting"
+    competitor: "Cloud import and categorization; coverage varies"
+rotkiAdvantages:
+  - "Your transaction history never leaves your computer; rotki reads exchanges and chains directly with your own keys and endpoints."
+  - "The entire application is open source and auditable, so you can verify exactly how your data is handled."
+  - "Self-custodied data: there is no vendor account holding your full financial history."
+  - "A free local tier covers core portfolio tracking, accounting, and tax reporting."
+  - "On-chain activity is decoded into readable events, so your DeFi and wallet history is accounted for transparently."
+tradeoffs:
+  - "rotki is a desktop app you run yourself rather than a hosted dashboard in a browser. That is exactly what keeps your data on your own machine instead of in a vendor's cloud, and it is worth running an app for."
+  - "Your data lives on the device where you run rotki, so you handle your own backups. Premium adds optional zero-knowledge sync, and either way your transaction history stays encrypted and under your control."
+  - "rotki is desktop-first rather than mobile-first. That is the deliberate cost of processing everything locally with your own keys, so your full history never has to leave your computer to be useful."
+whoShouldRotki:
+  - "You want your transaction history to stay on your own computer."
+  - "You value open-source software you can audit and self-host."
+  - "You hold meaningful DeFi or on-chain activity and want it decoded transparently."
+  - "You would rather own your data than trade it for cloud convenience."
+relatedIntegrations:
+  - slug: kraken
+    label: "Kraken"
+  - slug: binance
+    label: "Binance"
+  - slug: coinbase
+    label: "Coinbase"
+  - slug: ethereum
+    label: "Ethereum"
+  - slug: uniswap
+    label: "Uniswap"
+faq:
+  - q: "Is Koinly open source?"
+    a: "No. Koinly is a closed-source, hosted service. rotki is open source and its code can be audited on GitHub."
+  - q: "Does Koinly store my data in the cloud?"
+    a: "Yes. Like other hosted crypto tax tools, Koinly imports and stores your transaction data on its servers. rotki keeps your data encrypted on your own machine."
+  - q: "Is rotki a good alternative to Koinly?"
+    a: "If privacy, self-custody, and open source matter to you, yes. rotki covers portfolio tracking, accounting, and tax reporting locally, with a free tier and an optional subscription for more."
+  - q: "Can rotki handle DeFi like Koinly?"
+    a: "Yes. rotki decodes on-chain activity, including many DeFi protocols, into readable events with full profit and loss accounting, all processed locally on your machine."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core functionality with some limits. A premium subscription unlocks higher limits and additional features."
+---
+
+Koinly and rotki solve the same problem from opposite ends. Both connect to your exchanges and wallets, reconcile your trades and transfers, and produce portfolio views and tax reports. The difference is architectural: Koinly is a hosted cloud service, and rotki is a local-first desktop application.
+
+## How Koinly works
+
+Koinly is a web application. You create an account, link your exchanges through API connections or file uploads, add your public wallet addresses, and Koinly imports that history into its servers. From there it builds your dashboard and generates tax reports, with broad coverage of country-specific forms. It runs in a browser and has a mobile app, but the cost of that convenience is that your complete financial history lives in someone else's cloud.
+
+## How rotki works
+
+rotki runs on your own computer. It connects to exchanges using read-only API keys and reads your on-chain activity through RPC endpoints you control, then stores everything in an encrypted local database. Nothing passes through rotki-operated servers. Because rotki is open source, you can read the code and verify exactly how your data is handled, rather than trusting a closed system.
+
+## Privacy and ownership
+
+This is the core reason to pick rotki. A hosted tool concentrates the transaction histories of many users in one place, which makes the vendor a target and means a single breach can expose a lot of people. With rotki, the blast radius of a problem is your own device. You are not handing your full financial history to a third party, and you are not depending on a vendor's data-retention or security practices.
+
+## Tax reporting and DeFi
+
+rotki produces accounting and tax reports locally, and it decodes on-chain activity into readable events so that DeFi positions, swaps, and rewards are accounted for with proper profit and loss. Koinly's strength is the breadth of its ready-made country reports; rotki's strength is doing the same core work without your data leaving your machine.
+
+## The trade-off
+
+rotki asks a little more of you than a hosted tool does: you run a desktop app and keep your own backups. What you get back is ownership. Your transaction history stays on your machine, encrypted and under your control, in software you can audit line by line. For anyone who cares about privacy and self-custody, that is a trade worth making, and it is the reason to choose rotki.

--- a/packages/website/content/comparisons/zenledger.md
+++ b/packages/website/content/comparisons/zenledger.md
@@ -1,0 +1,107 @@
+---
+slug: zenledger
+competitor: "ZenLedger"
+competitorUrl: "https://www.zenledger.io"
+image: "/img/compare/zenledger.svg"
+tagline: "rotki vs ZenLedger: keep your tax data local and auditable"
+intro: "ZenLedger is a hosted crypto tax platform aimed at investors and tax professionals. rotki is the open-source, local-first alternative: your transaction history stays encrypted on your own machine instead of being uploaded to a vendor cloud."
+metaDescription: "rotki is the open-source, local-first alternative to ZenLedger. Your transaction history stays encrypted on your own machine, not in a vendor cloud."
+keywords: "rotki vs zenledger, zenledger alternative, open source zenledger alternative, private crypto tax software, local crypto tax software"
+keyTakeaways:
+  - "ZenLedger is a hosted platform with workflows aimed at investors and tax professionals."
+  - "rotki keeps your data on your own machine and is fully open source; ZenLedger is a closed-source cloud service."
+  - "Choose ZenLedger for a managed account and pro-facing features; choose rotki for privacy and self-custody."
+  - "rotki has a free local tier and integrates with 180+ exchanges, blockchains, and DeFi protocols."
+verdict: "ZenLedger offers a hosted workflow with options aimed at tax professionals, but it stores your data on its servers to do so. rotki keeps your data on your own computer, is fully open source, and covers portfolio tracking, accounting, and tax reporting. If privacy and self-custody matter to you, rotki is the one to choose."
+updatedAt: "June 2026"
+ctaPlan: free
+dimensions:
+  - label: "Data storage"
+    rotki: "Local and encrypted on your own machine"
+    competitor: "Uploaded to and stored on the vendor cloud"
+    highlight: true
+  - label: "Open source"
+    rotki: "Yes, fully auditable on GitHub"
+    competitor: "Closed-source"
+    highlight: true
+  - label: "Data custody"
+    rotki: "Self-custodied; you keep your data"
+    competitor: "You hand your full history to the vendor"
+    highlight: true
+  - label: "Breach blast radius"
+    rotki: "Your device only"
+    competitor: "Centralized; one vendor breach can affect many users"
+    highlight: true
+  - label: "API keys and RPC"
+    rotki: "Your own read-only keys and endpoints, used locally"
+    competitor: "Keys and data processed on the vendor servers"
+    highlight: true
+  - label: "Deployment"
+    rotki: "Desktop app for Windows, macOS, and Linux, or self-hosted via Docker"
+    competitor: "Hosted web app, with a mobile app where offered"
+  - label: "Free tier"
+    rotki: "Free local tier covers core tracking, accounting, and reporting (with limits)"
+    competitor: "Free to import transactions; a paid plan is needed to view or download tax reports"
+  - label: "Pricing model"
+    rotki: "Free, plus an optional subscription (Basic, Advanced, Custom)"
+    competitor: "Tiered plans, typically priced by transaction volume"
+  - label: "Tax-professional workflows"
+    rotki: "Self-serve local reports and exports"
+    competitor: "Hosted features aimed at working with tax professionals"
+  - label: "On-chain decoding"
+    rotki: "Decodes on-chain activity into readable events with full PnL accounting"
+    competitor: "Cloud import and categorization; coverage varies"
+rotkiAdvantages:
+  - "Your transaction history never leaves your computer; rotki reads exchanges and chains directly with your own keys and endpoints."
+  - "The entire application is open source and auditable, so you can verify exactly how your data is handled."
+  - "Self-custodied data: there is no vendor account holding your full financial history."
+  - "A free local tier covers core portfolio tracking, accounting, and tax reporting."
+  - "On-chain activity is decoded into readable events, so your DeFi and wallet history is accounted for transparently."
+tradeoffs:
+  - "rotki is a desktop app you run yourself rather than a hosted service in a browser. That is what keeps your data on your own machine instead of in a vendor's cloud, and it is worth running an app for."
+  - "Your data lives on the device where you run rotki, so you handle your own backups. Premium adds optional zero-knowledge sync, and either way your history stays encrypted and under your control."
+  - "rotki is self-serve rather than built around a hosted tax-professional workflow, and you can still export reports to share with an accountant. Keeping your data local and auditable is the deliberate trade and the reason to choose it."
+whoShouldRotki:
+  - "You want your transaction history to stay on your own computer."
+  - "You value open-source software you can audit and self-host."
+  - "You want transparent on-chain decoding behind your tax numbers."
+  - "You would rather own your data than trade it for cloud convenience."
+relatedIntegrations:
+  - slug: coinbase
+    label: "Coinbase"
+  - slug: kraken
+    label: "Kraken"
+  - slug: ethereum
+    label: "Ethereum"
+  - slug: aave
+    label: "Aave"
+faq:
+  - q: "Is ZenLedger open source?"
+    a: "No. ZenLedger is a closed-source, hosted service. rotki is open source and its code can be audited on GitHub."
+  - q: "Does ZenLedger store my data in the cloud?"
+    a: "Yes. ZenLedger imports and stores your transaction data on its servers. rotki keeps your data encrypted on your own machine."
+  - q: "Is rotki a good alternative to ZenLedger?"
+    a: "If privacy, self-custody, and open source matter to you, yes. rotki covers portfolio tracking, accounting, and tax reporting locally, with a free tier and an optional subscription for more."
+  - q: "Does rotki work with tax professionals?"
+    a: "rotki generates accounting and tax reports and standard exports locally that you can share with an accountant. ZenLedger emphasizes hosted features built specifically around tax professionals, which is a different model."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core functionality with some limits. A premium subscription unlocks higher limits and additional features."
+---
+
+ZenLedger is a hosted crypto tax platform with features aimed at investors and the tax professionals who serve them. rotki is a local-first, open-source desktop application. Both produce accounting and tax reports; the difference is whether your records live in a managed cloud account or on your own machine.
+
+## How ZenLedger works
+
+ZenLedger is a cloud service. You connect exchanges and wallets, your history is imported to its servers, and it builds reports with workflows oriented toward tax filing and working with professionals. The familiar cost is that your full transaction history is stored by the vendor.
+
+## How rotki works
+
+rotki runs on your computer and keeps your data in an encrypted local database. It reads exchanges through read-only API keys and chains through RPC endpoints you control, and it is open source so you can verify its behavior. It produces reports and exports you can share with an accountant, all without your data leaving your machine.
+
+## Privacy and ownership
+
+This is the deciding factor. A hosted tax platform holds your complete financial history on its servers. rotki keeps that history local and self-custodied, removing the central store that could be breached and the dependence on a vendor's security and retention choices.
+
+## The trade-off
+
+rotki does not replicate the hosted, professional-managed account model, and it asks you to run a desktop app and manage your own backups. In return it gives you privacy, self-custody, and open-source transparency, with your data on your own machine; you can still export reports to share with an accountant. For anyone who would rather keep their financial history local than hand it to a platform, that is the trade worth making, and the reason to choose rotki.

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -749,6 +749,53 @@
     },
     "title": "Connect your blockchains, connect your exchanges"
   },
+  "compare": {
+    "header": "Compare",
+    "title": "rotki vs the cloud crypto tax tools",
+    "description": "rotki is the open-source, local-first alternative to cloud crypto tax tools. Your transaction data stays encrypted on your own machine, never uploaded.",
+    "hub": {
+      "takeaways_title": "Key takeaways",
+      "summary_title": "At a glance",
+      "col_tool": "Tool",
+      "col_storage": "Data storage",
+      "col_open_source": "Open source",
+      "col_custody": "Self-custody",
+      "col_deployment": "Deployment",
+      "rotki_storage": "Local, on your machine",
+      "rotki_open_source": "Yes",
+      "rotki_custody": "Yes",
+      "rotki_deployment": "Desktop app or self-hosted",
+      "competitor_storage": "Vendor cloud",
+      "competitor_open_source": "No",
+      "competitor_custody": "No",
+      "competitor_deployment": "Hosted web app",
+      "list_title": "Head-to-head comparisons",
+      "why_title": "Why rotki is the privacy-first choice for crypto tax software",
+      "faq_title": "Frequently asked questions"
+    },
+    "detail": {
+      "updated": "Updated {date}",
+      "takeaways_title": "Key takeaways",
+      "verdict": "The verdict",
+      "table_title": "rotki vs {competitor}: side by side",
+      "advantages_title": "What sets rotki apart",
+      "tradeoffs_title": "Trade-offs",
+      "tradeoffs_subtitle": "Running locally comes with real trade-offs. Here is what to know, and why we think it is worth it.",
+      "who_title": "Who rotki is for",
+      "who_rotki": "Choose rotki if",
+      "related_title": "Related rotki integrations",
+      "related_subtitle": "rotki integrates with 180+ exchanges, blockchains, and DeFi protocols. A few that are relevant here:",
+      "deepdive_title": "rotki vs {competitor} in depth",
+      "faq_title": "Frequently asked questions",
+      "visit_competitor": "Visit {competitor}",
+      "cta": {
+        "title": "Try the private, open-source alternative",
+        "description": "Download rotki for free. Your keys and data never leave your machine.",
+        "download": "Download rotki",
+        "all": "All comparisons"
+      }
+    }
+  },
   "jobs": {
     "description": "Our mission is to empower users to take control of their finances both in and out of crypto in a transparent and auditable way while enabling them to own their data through a self-sovereign application.",
     "header": "We’re looking for talented people",
@@ -775,6 +822,10 @@
       "title": "Blog"
     },
     "company": "Company",
+    "compare": {
+      "description": "How rotki compares to cloud crypto tax tools",
+      "title": "Compare"
+    },
     "documentation": {
       "description": "Everything you need to know about the app",
       "title": "Documentation"

--- a/packages/website/modules/comparison-seo/module.ts
+++ b/packages/website/modules/comparison-seo/module.ts
@@ -1,0 +1,203 @@
+import type { Buffer } from 'node:buffer';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineNuxtModule, useLogger } from '@nuxt/kit';
+import { parse as parseYaml } from 'yaml';
+import { type OgFonts, renderOgImage } from '../integration-seo/og-image';
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Build-time augmentation for the `/compare/<slug>` pages, mirroring the
+ * integration-seo module:
+ *
+ * 1. Open Graph card images. `nuxi generate` bakes the per-page head/JSON-LD into
+ *    each route but cannot produce the OG card, so this module renders one PNG per
+ *    comparison into `img/og/compare/<slug>.png` during `prerender:generate` (with a
+ *    share.png fallback so `og:image` always resolves).
+ *
+ * 2. Markdown body for nuxt-llms. Comparison content lives entirely in frontmatter,
+ *    so a `content:file:afterParse` hook synthesises a body (intro + verdict +
+ *    comparison rows + advantages + trade-offs + FAQ) so `llms-full.txt` and the
+ *    `/raw/*.md` endpoint expose real content. This does not affect the rendered page.
+ */
+
+interface ComparisonFrontmatter {
+  competitor?: string;
+  tagline?: string;
+}
+
+// minimark AST node: [tag, props, ...children].
+type MinimarkNode = [string, Record<string, unknown>, ...unknown[]];
+
+interface ComparisonDoc {
+  competitor?: string;
+  title?: string;
+  description?: string;
+  intro?: string;
+  verdict?: string;
+  dimensions?: Array<{ label: string; rotki: string; competitor: string }>;
+  rotkiAdvantages?: string[];
+  tradeoffs?: string[];
+  faq?: Array<{ q: string; a: string }>;
+  body?: { value?: unknown[] };
+}
+
+function listSection(heading: string, items: string[] | undefined): MinimarkNode[] {
+  if (!Array.isArray(items) || items.length === 0)
+    return [];
+
+  return [
+    ['h2', {}, heading],
+    ['ul', {}, ...items.map((item): MinimarkNode => ['li', {}, item])],
+  ];
+}
+
+// Synthesise a markdown body AST from comparison frontmatter. Starts with an h1 so
+// nuxt-llms' full generator and the /raw endpoint render it verbatim (no double title).
+function buildComparisonBody(doc: ComparisonDoc): MinimarkNode[] {
+  const competitor = doc.competitor ?? doc.title ?? '';
+  const value: MinimarkNode[] = [['h1', {}, `rotki vs ${competitor}`]];
+  if (doc.intro)
+    value.push(['p', {}, doc.intro]);
+
+  if (doc.verdict) {
+    value.push(['h2', {}, 'The verdict'], ['p', {}, doc.verdict]);
+  }
+
+  if (Array.isArray(doc.dimensions) && doc.dimensions.length > 0) {
+    value.push(['h2', {}, `rotki vs ${competitor}: side by side`]);
+    value.push(['ul', {}, ...doc.dimensions.map((row): MinimarkNode => (
+      ['li', {}, `${row.label}. rotki: ${row.rotki}; ${competitor}: ${row.competitor}`]
+    ))]);
+  }
+
+  value.push(...listSection('What sets rotki apart', doc.rotkiAdvantages));
+  value.push(...listSection('Trade-offs', doc.tradeoffs));
+
+  if (Array.isArray(doc.faq) && doc.faq.length > 0) {
+    value.push(['h2', {}, 'FAQ']);
+    for (const { q, a } of doc.faq) {
+      value.push(['h3', {}, q], ['p', {}, a]);
+    }
+  }
+  return value;
+}
+
+function readFrontmatter(file: string): ComparisonFrontmatter | undefined {
+  const raw = readFileSync(file, 'utf8');
+  const match = raw.match(/^---\r?\n([\S\s]*?)\r?\n---/);
+  if (!match?.[1])
+    return undefined;
+
+  return parseYaml(match[1]) as ComparisonFrontmatter;
+}
+
+function buildFrontmatterMap(contentDir: string): Map<string, ComparisonFrontmatter> {
+  const map = new Map<string, ComparisonFrontmatter>();
+  for (const file of readdirSync(contentDir)) {
+    if (!file.endsWith('.md') || file.startsWith('_'))
+      continue;
+
+    const fm = readFrontmatter(resolve(contentDir, file));
+    if (fm)
+      map.set(file.replace(/\.md$/, ''), fm);
+  }
+  return map;
+}
+
+export default defineNuxtModule({
+  meta: { name: 'comparison-seo' },
+  setup(_options, nuxt) {
+    const logger = useLogger('comparison-seo');
+    const contentDir = resolve(nuxt.options.rootDir, 'content/comparisons');
+    let fonts: OgFonts | undefined;
+    try {
+      fonts = {
+        regular: readFileSync(resolve(moduleDir, '../integration-seo/fonts/roboto-400.woff')),
+        bold: readFileSync(resolve(moduleDir, '../integration-seo/fonts/roboto-700.woff')),
+      };
+    }
+    catch {
+      logger.warn('OG fonts not found; falling back to the shared share.png');
+    }
+
+    // Synthesise a markdown body from frontmatter so nuxt-llms (llms-full.txt + /raw)
+    // emits real content instead of empty docs.
+    nuxt.hook('content:file:afterParse', (ctx) => {
+      const { collection, content: doc } = ctx as unknown as { collection?: string | { name?: string }; content?: ComparisonDoc };
+      const name = typeof collection === 'string' ? collection : collection?.name;
+      if (name !== 'comparisons' || !doc?.intro || !Array.isArray(doc.body?.value))
+        return;
+
+      if (doc.competitor)
+        doc.title = `rotki vs ${doc.competitor}`;
+      if (!doc.description)
+        doc.description = doc.intro;
+      if (doc.body.value.length === 0)
+        doc.body.value = buildComparisonBody(doc);
+    });
+
+    nuxt.hook('nitro:init', (nitro) => {
+      const publicDir = nitro.options.output.publicDir;
+      let map: Map<string, ComparisonFrontmatter> | undefined;
+      let sharePng: Buffer | undefined;
+      let ogGenerated = 0;
+      let fallback = 0;
+      const skipped = new Set<string>();
+
+      const writeFallback = (relPath: string): void => {
+        try {
+          sharePng ??= readFileSync(resolve(publicDir, 'img/og/share.png'));
+          mkdirSync(resolve(publicDir, dirname(relPath)), { recursive: true });
+          writeFileSync(resolve(publicDir, relPath), sharePng);
+          fallback += 1;
+        }
+        catch (error) {
+          logger.warn(`OG fallback copy failed for ${relPath}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      };
+
+      nitro.hooks.hook('prerender:generate', async (route) => {
+        const slug = route.route.match(/^\/compare\/([^/]+)\/?$/)?.[1];
+        if (!slug)
+          return;
+
+        map ??= buildFrontmatterMap(contentDir);
+        const fm = map.get(slug);
+        if (!fm) {
+          skipped.add(slug);
+          return;
+        }
+
+        const relPath = `img/og/compare/${slug}.png`;
+        if (!fonts) {
+          writeFallback(relPath);
+          return;
+        }
+
+        try {
+          const png = await renderOgImage({
+            label: `rotki vs ${fm.competitor ?? slug}`,
+            tagline: fm.tagline ?? '',
+            typeLabel: 'Comparison',
+            fonts,
+          });
+          mkdirSync(resolve(publicDir, dirname(relPath)), { recursive: true });
+          writeFileSync(resolve(publicDir, relPath), png);
+          ogGenerated += 1;
+        }
+        catch (error) {
+          logger.warn(`OG image generation failed for ${slug}: ${error instanceof Error ? error.message : String(error)}`);
+          writeFallback(relPath);
+        }
+      });
+
+      nitro.hooks.hook('close', () => {
+        const suffix = skipped.size > 0 ? `; skipped ${skipped.size} slug(s) with no content page: ${[...skipped].sort().join(', ')}` : '';
+        logger.info(`generated ${ogGenerated} comparison OG images (${fallback} share.png fallbacks)${suffix}`);
+      });
+    });
+  },
+});

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import { SIGIL_SCRIPT_URL, SIGIL_TRACKED_DOMAIN, SIGIL_WEBSITE_ID } from '@rotki/sigil';
 import rotkiTheme from '@rotki/ui-library/theme';
+import { comparisonPrerenderRoutes } from './app/utils/comparison-prerender';
 import { integrationPrerenderRoutes } from './app/utils/integration-prerender';
 import { llms } from './app/utils/llms-config';
 
@@ -161,6 +162,7 @@ export default defineNuxtConfig({
     '@nuxt/test-utils/module',
     './modules/integration-images/module.ts',
     './modules/integration-seo/module.ts',
+    './modules/comparison-seo/module.ts',
     './modules/ui-library/module.ts',
   ],
 
@@ -284,7 +286,7 @@ export default defineNuxtConfig({
       crawlLinks: true,
       // Guardrail: fail the build if an indexable route errors while rendering — make it ssr:false instead.
       failOnError: true,
-      routes: integrationPrerenderRoutes(),
+      routes: [...integrationPrerenderRoutes(), ...comparisonPrerenderRoutes()],
     },
   },
 
@@ -391,9 +393,7 @@ export default defineNuxtConfig({
       mode: 'jit',
       plugins: [rotkiTheme],
       theme: {
-        container: {
-          center: true,
-        },
+        container: { center: true },
       },
     },
   },

--- a/packages/website/public/img/compare/awaken.svg
+++ b/packages/website/public/img/compare/awaken.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" role="img" aria-label="awaken">
+  <rect width="80" height="80" rx="16" fill="#f3ede9"/>
+  <text x="50%" y="50%" dy="2" text-anchor="middle" dominant-baseline="central" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="700" fill="#4e352e">A</text>
+</svg>

--- a/packages/website/public/img/compare/coinledger.svg
+++ b/packages/website/public/img/compare/coinledger.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" role="img" aria-label="coinledger">
+  <rect width="80" height="80" rx="16" fill="#f3ede9"/>
+  <text x="50%" y="50%" dy="2" text-anchor="middle" dominant-baseline="central" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="700" fill="#4e352e">C</text>
+</svg>

--- a/packages/website/public/img/compare/cointracker.svg
+++ b/packages/website/public/img/compare/cointracker.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" role="img" aria-label="cointracker">
+  <rect width="80" height="80" rx="16" fill="#f3ede9"/>
+  <text x="50%" y="50%" dy="2" text-anchor="middle" dominant-baseline="central" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="700" fill="#4e352e">C</text>
+</svg>

--- a/packages/website/public/img/compare/cointracking.svg
+++ b/packages/website/public/img/compare/cointracking.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" role="img" aria-label="cointracking">
+  <rect width="80" height="80" rx="16" fill="#f3ede9"/>
+  <text x="50%" y="50%" dy="2" text-anchor="middle" dominant-baseline="central" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="700" fill="#4e352e">C</text>
+</svg>

--- a/packages/website/public/img/compare/koinly.svg
+++ b/packages/website/public/img/compare/koinly.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" role="img" aria-label="koinly">
+  <rect width="80" height="80" rx="16" fill="#f3ede9"/>
+  <text x="50%" y="50%" dy="2" text-anchor="middle" dominant-baseline="central" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="700" fill="#4e352e">K</text>
+</svg>

--- a/packages/website/public/img/compare/zenledger.svg
+++ b/packages/website/public/img/compare/zenledger.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" role="img" aria-label="zenledger">
+  <rect width="80" height="80" rx="16" fill="#f3ede9"/>
+  <text x="50%" y="50%" dy="2" text-anchor="middle" dominant-baseline="central" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="700" fill="#4e352e">Z</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds comparison pages positioning rotki against popular crypto-tax tools (Koinly, CoinTracker, CoinTracking, CoinLedger, ZenLedger, Awaken).

- `comparisons` + `comparisonHub` `@nuxt/content` collections (content authored in markdown; only UI labels in i18n)
- `/compare` hub (roundup, at-a-glance table, key takeaways, FAQ) and `/compare/[slug]` detail pages with structured data, per-slug Open Graph images, and sitemap entries
- Build module generating per-slug OG cards and markdown bodies
- `ComparisonTable` component; neutral monogram placeholders (no competitor trademarks)
- At-a-glance table includes Self-custody + Deployment columns (rotki = "Desktop app or self-hosted")

## SEO

A deterministic SEO audit (`scripts/seo-audit.ts`) over the generated static site confirms the compare pages are clean:

- Titles < 60 chars (`rotki vs {competitor}` — `titleTemplate` appends ` | rotki`)
- Dedicated `metaDescription` field (145–156 chars) kept separate from the longer visible `intro` paragraph
- Single `<h1>`, full Open Graph set (4/4), zero uncrawlable anchors (CTAs use the real-`<a>` `ButtonLink` component, mirroring the recent integration-page fix)
- Hub meta description trimmed to 151 chars

Lighthouse (throttled-mobile lab, median of 3): hub Perf 94 / detail 93, A11y 99, Best-practices 96, SEO 92. The SEO 92 is the known `canonical` false-positive under localhost (absolute canonical is correct in prod).

## Follow-ups (out of scope here)

- **Site-wide performance**: LCP/FCP on these pages are gated by the shared render-blocking CSS + Vue bundle + fonts (affects all ~167 pages), not compare-specific. Worth a dedicated critical-CSS / bundle pass.
- **Intermittent hydration mismatch**: observed occasionally on the hub under static serving; races the (backend-less) `/api/config` request and isn't reliably reproducible. Worth confirming against a real backend.

## Test plan

- [x] `pnpm lint` (website package) — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 16 files, 149 tests pass
- [x] `pnpm generate` — 503 routes, 6 comparison OG images
- [x] `scripts/seo-audit.ts` — no error/warn findings on any compare page
