### PR TITLE
feat(seo): add /features use-case landing pages

### DIFF
--- a/packages/website/app/components/footer/FooterNavigation.vue
+++ b/packages/website/app/components/footer/FooterNavigation.vue
@@ -40,6 +40,11 @@ const menus: MenuGroup[] = [
         to: '/compare',
         highlightActive: true,
       },
+      {
+        label: t('navigation_menu.features.title'),
+        to: '/features',
+        highlightActive: true,
+      },
     ],
   },
   {

--- a/packages/website/app/pages/features/[slug].vue
+++ b/packages/website/app/pages/features/[slug].vue
@@ -1,0 +1,413 @@
+<script setup lang="ts">
+import { isDefined } from '@vueuse/core';
+import { get } from '@vueuse/shared';
+import ButtonLink from '~/components/common/ButtonLink.vue';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+const { path } = useRoute();
+const { t } = useI18n({ useScope: 'global' });
+const { public: { baseUrl } } = useRuntimeConfig();
+
+const { data: feature } = await useAsyncData(
+  path,
+  () => queryCollection('features').path(path).first(),
+  { dedupe: 'defer' },
+);
+
+if (!isDefined(feature)) {
+  showError({ message: `Page not found: ${path}`, status: 404 });
+}
+else {
+  const item = get(feature);
+  const slug = path.replace(/\/+$/, '').split('/').pop() ?? '';
+  // Keep the SERP title short (<60 chars); titleTemplate appends " | rotki".
+  const title = item.label;
+  // OG image is generated per-slug at build time by the feature-seo module
+  // (with a share.png fallback written to the same path), so this URL always resolves.
+  usePageSeo(title, item.metaDescription, path, { keywords: item.keywords, ogImage: `features/${slug}.png` });
+
+  const url = `${baseUrl}${path}`;
+
+  const ldBlocks: string[] = [];
+
+  ldBlocks.push(JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': [
+      { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': baseUrl },
+      { '@type': 'ListItem', 'position': 2, 'name': 'Features', 'item': `${baseUrl}/features` },
+      { '@type': 'ListItem', 'position': 3, 'name': item.label, 'item': url },
+    ],
+  }));
+
+  ldBlocks.push(JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    'name': 'rotki',
+    'description': item.intro,
+    'url': url,
+    'applicationCategory': 'FinanceApplication',
+    'operatingSystem': 'Windows, macOS, Linux',
+    'offers': { '@type': 'Offer', 'price': '0', 'priceCurrency': 'USD' },
+  }));
+
+  if ((item.faq?.length ?? 0) > 0) {
+    ldBlocks.push(JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      'mainEntity': item.faq!.map(({ q, a }) => ({
+        '@type': 'Question',
+        'name': q,
+        'acceptedAnswer': { '@type': 'Answer', 'text': a },
+      })),
+    }));
+  }
+
+  useHead({
+    // Escape the angle bracket so a closing-script sequence inside the JSON-LD
+    // (e.g. from FAQ content) cannot break out of the server-rendered script tag.
+    script: ldBlocks.map(block => ({
+      type: 'application/ld+json',
+      innerHTML: block.replaceAll('<', '\\u003c'),
+    })),
+  });
+}
+
+const tierBadge = computed<string | undefined>(() => {
+  const item = get(feature);
+  if (!item)
+    return undefined;
+
+  switch (item.ctaPlan) {
+    case 'basic': return t('features.detail.tier.basic');
+    case 'advanced': return t('features.detail.tier.advanced');
+    default: return undefined;
+  }
+});
+
+definePageMeta({
+  landing: true,
+});
+</script>
+
+<template>
+  <div v-if="feature">
+    <section class="py-10 md:py-16 bg-rui-primary/[.04]">
+      <div class="container">
+        <nav class="text-sm text-rui-text-secondary mb-4">
+          <NuxtLink
+            to="/features"
+            class="hover:text-rui-primary"
+          >
+            {{ t('features.header') }}
+          </NuxtLink>
+          <span class="mx-2">/</span>
+          <span>{{ feature.label }}</span>
+        </nav>
+        <div class="flex items-center gap-4 md:gap-5">
+          <div class="w-16 h-16 md:w-20 md:h-20 border-2 border-rui-primary rounded-xl p-3 bg-white shadow-sm shrink-0 flex items-center justify-center">
+            <img
+              v-if="feature.icon"
+              :src="feature.icon"
+              :alt="feature.label"
+              class="w-full h-full object-contain"
+              width="80"
+              height="80"
+              loading="eager"
+            />
+            <RuiIcon
+              v-else
+              name="lu-sparkles"
+              size="36"
+              color="primary"
+            />
+          </div>
+        </div>
+        <div class="w-16 h-1 bg-rui-primary rounded-full mt-8" />
+        <h1 class="text-h4 md:text-h3 font-bold mt-4">
+          {{ feature.tagline }}
+        </h1>
+        <p class="text-body-1 text-rui-text-secondary mt-4 max-w-3xl">
+          {{ feature.intro }}
+        </p>
+        <div class="flex items-center gap-3 mt-5">
+          <span
+            v-if="tierBadge"
+            class="inline-flex items-center rounded-full bg-rui-primary/10 text-rui-primary text-body-2 font-medium px-3 py-1"
+          >
+            {{ tierBadge }}
+          </span>
+          <span class="block text-body-2 text-rui-text-secondary">
+            {{ t('features.detail.updated', { date: feature.updatedAt }) }}
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(feature.keyTakeaways?.length ?? 0) > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <div class="max-w-3xl border border-rui-primary/20 border-l-4 border-l-rui-primary bg-rui-primary/[.04] rounded-r-xl p-6 md:p-8">
+          <h2 class="text-h6 font-bold mb-4 uppercase tracking-wide text-rui-primary">
+            {{ t('features.detail.takeaways_title') }}
+          </h2>
+          <ul class="space-y-3">
+            <li
+              v-for="takeaway in feature.keyTakeaways"
+              :key="takeaway"
+              class="flex items-start gap-3 text-body-1"
+            >
+              <RuiIcon
+                name="lu-circle-check"
+                size="20"
+                color="primary"
+                class="shrink-0 mt-0.5"
+              />
+              <span>{{ takeaway }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(feature.capabilities?.length ?? 0) > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-4">
+          {{ t('features.detail.capabilities_title') }}
+        </h2>
+        <ul class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+          <li
+            v-for="capability in feature.capabilities"
+            :key="capability"
+            class="flex items-start gap-3 text-body-1"
+          >
+            <RuiIcon
+              name="lu-circle-check"
+              size="20"
+              color="primary"
+              class="shrink-0 mt-0.5"
+            />
+            <span>{{ capability }}</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section
+      v-if="(feature.setup?.length ?? 0) > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('features.detail.setup_title') }}
+        </h2>
+        <ol class="space-y-4 max-w-3xl">
+          <li
+            v-for="(step, index) in feature.setup"
+            :key="step"
+            class="flex items-start gap-4 text-body-1"
+          >
+            <span class="flex items-center justify-center w-8 h-8 rounded-full bg-rui-primary text-white text-body-2 font-bold shrink-0">
+              {{ index + 1 }}
+            </span>
+            <span class="mt-1">{{ step }}</span>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section
+      v-if="(feature.limitations?.length ?? 0) > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-4">
+          {{ t('features.detail.limitations_title') }}
+        </h2>
+        <ul class="space-y-3 max-w-3xl">
+          <li
+            v-for="limitation in feature.limitations"
+            :key="limitation"
+            class="flex items-start gap-3 text-body-1"
+          >
+            <RuiIcon
+              name="lu-circle-alert"
+              size="20"
+              color="warning"
+              class="shrink-0 mt-0.5"
+            />
+            <span>{{ limitation }}</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="py-10 md:py-14">
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('features.detail.deepdive_title', { label: feature.label }) }}
+        </h2>
+        <div class="max-w-[820px]">
+          <ContentRenderer :value="feature" />
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(feature.troubleshooting?.length ?? 0) > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('features.detail.troubleshooting_title') }}
+        </h2>
+        <div class="space-y-4 max-w-3xl">
+          <div
+            v-for="entry in feature.troubleshooting"
+            :key="entry.problem"
+            class="border border-rui-grey-200 rounded-xl p-5 bg-white"
+          >
+            <h3 class="text-h6 font-semibold mb-1 flex items-start gap-2">
+              <RuiIcon
+                name="lu-circle-alert"
+                size="20"
+                color="primary"
+                class="shrink-0 mt-0.5"
+              />
+              <span>{{ entry.problem }}</span>
+            </h3>
+            <p class="text-body-1 text-rui-text-secondary pl-7">
+              {{ entry.fix }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(feature.relatedIntegrations?.length ?? 0) > 0 || (feature.relatedComparisons?.length ?? 0) > 0 || (feature.relatedFeatures?.length ?? 0) > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container space-y-8">
+        <div v-if="(feature.relatedIntegrations?.length ?? 0) > 0">
+          <h2 class="text-h6 font-bold mb-4">
+            {{ t('features.detail.related_integrations') }}
+          </h2>
+          <div class="flex flex-wrap gap-3">
+            <NuxtLink
+              v-for="related in feature.relatedIntegrations"
+              :key="related.slug"
+              :to="`/integrations/${related.slug}`"
+              class="inline-flex items-center gap-2 border border-rui-grey-200 rounded-full px-4 py-2 text-body-2 bg-white hover:border-rui-primary hover:text-rui-primary transition-colors"
+            >
+              {{ related.label }}
+            </NuxtLink>
+            <NuxtLink
+              to="/integrations"
+              class="inline-flex items-center gap-2 border border-rui-primary rounded-full px-4 py-2 text-body-2 text-rui-primary bg-white hover:bg-rui-primary/[.04] transition-colors"
+            >
+              {{ t('integration.detail.cta.all') }}
+            </NuxtLink>
+          </div>
+        </div>
+        <div v-if="(feature.relatedComparisons?.length ?? 0) > 0">
+          <h2 class="text-h6 font-bold mb-4">
+            {{ t('features.detail.related_comparisons') }}
+          </h2>
+          <div class="flex flex-wrap gap-3">
+            <NuxtLink
+              v-for="related in feature.relatedComparisons"
+              :key="related.slug"
+              :to="`/compare/${related.slug}`"
+              class="inline-flex items-center gap-2 border border-rui-grey-200 rounded-full px-4 py-2 text-body-2 bg-white hover:border-rui-primary hover:text-rui-primary transition-colors"
+            >
+              {{ related.label }}
+            </NuxtLink>
+          </div>
+        </div>
+        <div v-if="(feature.relatedFeatures?.length ?? 0) > 0">
+          <h2 class="text-h6 font-bold mb-4">
+            {{ t('features.detail.related_features') }}
+          </h2>
+          <div class="flex flex-wrap gap-3">
+            <NuxtLink
+              v-for="related in feature.relatedFeatures"
+              :key="related.slug"
+              :to="`/features/${related.slug}`"
+              class="inline-flex items-center gap-2 border border-rui-grey-200 rounded-full px-4 py-2 text-body-2 bg-white hover:border-rui-primary hover:text-rui-primary transition-colors"
+            >
+              {{ related.label }}
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="(feature.faq?.length ?? 0) > 0"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('features.detail.faq_title') }}
+        </h2>
+        <div class="space-y-4 max-w-3xl">
+          <div
+            v-for="entry in feature.faq"
+            :key="entry.q"
+            class="flex items-start gap-4 border border-rui-grey-200 rounded-xl p-5 bg-white"
+          >
+            <div class="flex items-center justify-center w-9 h-9 rounded-full bg-rui-primary/10 shrink-0">
+              <RuiIcon
+                name="lu-message-circle"
+                size="20"
+                color="primary"
+              />
+            </div>
+            <div>
+              <h3 class="text-h6 font-semibold mb-1">
+                {{ entry.q }}
+              </h3>
+              <p class="text-body-1 text-rui-text-secondary">
+                {{ entry.a }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-12 md:py-16 bg-rui-primary/[.04]">
+      <div class="container flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
+        <div class="max-w-2xl">
+          <h2 class="text-h5 font-bold mb-2">
+            {{ t('features.detail.cta.title') }}
+          </h2>
+          <p class="text-body-1 text-rui-text-secondary">
+            {{ t('features.detail.cta.description') }}
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <ButtonLink
+            to="/download"
+            color="primary"
+            variant="default"
+          >
+            {{ t('features.detail.cta.download') }}
+          </ButtonLink>
+          <ButtonLink
+            to="/features"
+            variant="outlined"
+          >
+            {{ t('features.detail.cta.all') }}
+          </ButtonLink>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/packages/website/app/pages/features/[slug].vue
+++ b/packages/website/app/pages/features/[slug].vue
@@ -255,6 +255,19 @@ definePageMeta({
         <div class="max-w-[820px]">
           <ContentRenderer :value="feature" />
         </div>
+        <a
+          v-if="feature.docsUrl"
+          :href="feature.docsUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 mt-6 text-body-1 font-medium text-rui-primary hover:underline"
+        >
+          {{ t('features.detail.docs_link') }}
+          <RuiIcon
+            name="lu-external-link"
+            size="18"
+          />
+        </a>
       </div>
     </section>
 

--- a/packages/website/app/pages/features/index.vue
+++ b/packages/website/app/pages/features/index.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+import type { FeatureHubCollectionItem, FeaturesCollectionItem } from '@nuxt/content';
+import { get } from '@vueuse/shared';
+import { usePageSeo } from '~/composables/use-page-seo';
+
+const { t } = useI18n({ useScope: 'global' });
+const { public: { baseUrl } } = useRuntimeConfig();
+
+usePageSeo(
+  t('features.title'),
+  t('features.description'),
+  '/features',
+);
+
+const { data: hub } = await useAsyncData(
+  'feature-hub',
+  () => queryCollection('featureHub').first(),
+  { dedupe: 'defer' },
+);
+
+const { data: features } = await useAsyncData(
+  'features-hub',
+  () => queryCollection('features').order('label', 'ASC').all(),
+  { dedupe: 'defer' },
+);
+
+const items = computed<FeaturesCollectionItem[]>(() => get(features) ?? []);
+const hubData = computed<FeatureHubCollectionItem | undefined>(() => get(hub) ?? undefined);
+const keyTakeaways = computed<string[]>(() => get(hubData)?.keyTakeaways ?? []);
+const rotkiHighlights = computed<string[]>(() => get(hubData)?.rotkiHighlights ?? []);
+const faq = computed<{ q: string; a: string }[]>(() => get(hubData)?.faq ?? []);
+
+const jsonLd = computed<string[]>(() => {
+  const list = get(items);
+  const blocks: string[] = [];
+
+  blocks.push(JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    'name': 'rotki feature guides',
+    'description': t('features.description'),
+    'url': `${baseUrl}/features`,
+    'numberOfItems': list.length,
+    'itemListElement': list.map((item, index) => ({
+      '@type': 'ListItem',
+      'position': index + 1,
+      'name': item.label,
+      'item': `${baseUrl}${item.path}`,
+    })),
+  }));
+
+  const faqItems = get(faq);
+  if (faqItems.length > 0) {
+    blocks.push(JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      'mainEntity': faqItems.map(({ q, a }) => ({
+        '@type': 'Question',
+        'name': q,
+        'acceptedAnswer': { '@type': 'Answer', 'text': a },
+      })),
+    }));
+  }
+
+  return blocks;
+});
+
+useHead({
+  script: jsonLd.value.map(block => ({
+    type: 'application/ld+json',
+    innerHTML: block.replaceAll('<', '\\u003c'),
+  })),
+});
+
+definePageMeta({
+  landing: true,
+});
+</script>
+
+<template>
+  <div>
+    <section class="py-10 md:py-20 bg-rui-primary/[.04]">
+      <div class="container">
+        <div class="max-w-[820px]">
+          <span class="text-h6 text-rui-primary uppercase tracking-wide font-bold">
+            {{ t('features.header') }}
+          </span>
+          <div class="w-16 h-1 bg-rui-primary rounded-full mt-4" />
+          <h1 class="text-h4 md:text-h3 font-bold mt-4">
+            {{ t('features.title') }}
+          </h1>
+          <p
+            v-if="hubData"
+            class="text-body-1 mt-4"
+          >
+            {{ hubData.intro }}
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="keyTakeaways.length > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('features.hub.takeaways_title') }}
+        </h2>
+        <div class="max-w-3xl border border-rui-primary/20 border-l-4 border-l-rui-primary bg-rui-primary/[.04] rounded-r-xl p-6 md:p-8">
+          <ul class="space-y-3">
+            <li
+              v-for="takeaway in keyTakeaways"
+              :key="takeaway"
+              class="flex items-start gap-3 text-body-1"
+            >
+              <RuiIcon
+                name="lu-circle-check"
+                size="20"
+                color="primary"
+                class="shrink-0 mt-0.5"
+              />
+              <span>{{ takeaway }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-10 md:py-14 bg-rui-primary/[.04]">
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('features.hub.list_title') }}
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <NuxtLink
+            v-for="item in items"
+            :key="item.path"
+            :to="item.path"
+            class="flex items-start gap-4 border border-rui-grey-200 rounded-xl p-5 bg-white hover:border-rui-primary transition-colors"
+          >
+            <div class="w-12 h-12 border border-rui-grey-200 rounded-lg p-2 bg-white shrink-0 flex items-center justify-center">
+              <img
+                v-if="item.icon"
+                :src="item.icon"
+                :alt="item.label"
+                class="w-full h-full object-contain"
+                width="48"
+                height="48"
+                loading="lazy"
+              />
+              <RuiIcon
+                v-else
+                name="lu-sparkles"
+                size="24"
+                color="primary"
+              />
+            </div>
+            <div>
+              <h3 class="text-h6 font-semibold">
+                {{ item.label }}
+              </h3>
+              <p class="text-body-2 text-rui-text-secondary mt-1 line-clamp-2">
+                {{ item.tagline }}
+              </p>
+            </div>
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="rotkiHighlights.length > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-4">
+          {{ t('features.hub.why_title') }}
+        </h2>
+        <ul class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+          <li
+            v-for="highlight in rotkiHighlights"
+            :key="highlight"
+            class="flex items-start gap-3 text-body-1"
+          >
+            <RuiIcon
+              name="lu-circle-check"
+              size="20"
+              color="primary"
+              class="shrink-0 mt-0.5"
+            />
+            <span>{{ highlight }}</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section
+      v-if="hubData"
+      class="py-10 md:py-14 bg-rui-primary/[.04]"
+    >
+      <div class="container">
+        <div class="max-w-[820px]">
+          <ContentRenderer :value="hubData" />
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="faq.length > 0"
+      class="py-10 md:py-14"
+    >
+      <div class="container">
+        <h2 class="text-h5 font-bold mb-6">
+          {{ t('features.hub.faq_title') }}
+        </h2>
+        <div class="space-y-4 max-w-3xl">
+          <div
+            v-for="entry in faq"
+            :key="entry.q"
+            class="flex items-start gap-4 border border-rui-grey-200 rounded-xl p-5 bg-white"
+          >
+            <div class="flex items-center justify-center w-9 h-9 rounded-full bg-rui-primary/10 shrink-0">
+              <RuiIcon
+                name="lu-message-circle"
+                size="20"
+                color="primary"
+              />
+            </div>
+            <div>
+              <h3 class="text-h6 font-semibold mb-1">
+                {{ entry.q }}
+              </h3>
+              <p class="text-body-1 text-rui-text-secondary">
+                {{ entry.a }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/packages/website/app/utils/feature-prerender.ts
+++ b/packages/website/app/utils/feature-prerender.ts
@@ -1,0 +1,15 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Build-time helper: resolves the list of `/features/<slug>` routes to prerender
+ * from the markdown files in `content/features`. Mirrors the comparisons prerender
+ * helper so every feature page is statically generated (and its OG card rendered)
+ * even if it is not reachable via crawled links.
+ */
+export function featurePrerenderRoutes(): string[] {
+  const dir = path.resolve(import.meta.dirname, '../../content/features');
+  return readdirSync(dir)
+    .filter(file => file.endsWith('.md') && !file.startsWith('_'))
+    .map(file => `/features/${file.replace(/\.md$/, '')}`);
+}

--- a/packages/website/app/utils/llms-config.ts
+++ b/packages/website/app/utils/llms-config.ts
@@ -47,6 +47,14 @@ export const llms: ContentLlmsOptions = {
         { field: 'extension', operator: '=', value: 'md' },
       ],
     },
+    {
+      title: 'Features',
+      description: 'Use-case and concept guides for what rotki does — CSV import, local-first accounting, privacy-first portfolio tracking, DeFi tracking, open-source crypto tax — covering capabilities, setup steps, limitations, and FAQs. rotki runs locally and reads your exchanges and chains with your own keys.',
+      contentCollection: 'features',
+      contentFilters: [
+        { field: 'extension', operator: '=', value: 'md' },
+      ],
+    },
   ],
   contentRawMarkdown: {
     rewriteLLMSTxt: true,

--- a/packages/website/content.config.ts
+++ b/packages/website/content.config.ts
@@ -9,6 +9,8 @@ const SPONSORSHIP_TIERS = 'content/sponsorship-tiers/*.md';
 const INTEGRATIONS = 'content/integrations/*.md';
 const COMPARISONS = 'content/comparisons/*.md';
 const COMPARISON_HUB = 'content/comparison-hub/*.md';
+const FEATURES = 'content/features/*.md';
+const FEATURE_HUB = 'content/feature-hub/*.md';
 
 const documentSchema = z.object({
   address: z.string().optional(),
@@ -120,6 +122,70 @@ const comparisonHubSchema = z.object({
   })).default([]),
 });
 
+// Feature pages are concept/use-case landing pages (e.g. "CSV import",
+// "local-first crypto accounting"). Modeled on `comparisonSchema` but reshaped
+// for use-case intent: no competitor/dimensions, plus capabilities/setup/troubleshooting.
+const featureSchema = z.object({
+  slug: z.string(),
+  // Short label used in nav/cards/breadcrumb, e.g. "CSV import".
+  label: z.string(),
+  // Optional icon in public/img/features (svg). Index cards fall back to a glyph when absent.
+  icon: z.string().optional(),
+  tagline: z.string(),
+  intro: z.string(),
+  // SERP/meta description (<160 chars). Kept separate from `intro` so the visible
+  // intro paragraph can stay longer than the meta description allows.
+  metaDescription: z.string(),
+  keywords: z.string().optional(),
+  // Scannable "why rotki for X" bullets shown near the top.
+  keyTakeaways: z.array(z.string()).default([]),
+  // What rotki actually does for this use-case.
+  capabilities: z.array(z.string()).default([]),
+  // Honest limits / what rotki does NOT do — avoid overclaiming.
+  limitations: z.array(z.string()).default([]),
+  // Ordered setup steps.
+  setup: z.array(z.string()).default([]),
+  // Common problems and their fixes.
+  troubleshooting: z.array(z.object({
+    problem: z.string(),
+    fix: z.string(),
+  })).default([]),
+  // Cross-links to /integrations/<slug>.
+  relatedIntegrations: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  // Cross-links to /compare/<slug>.
+  relatedComparisons: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  // Cross-links to other /features/<slug> pages.
+  relatedFeatures: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  faq: z.array(z.object({
+    q: z.string(),
+    a: z.string(),
+  })).default([]),
+  // Freshness stamp shown on the page (e.g. "June 2026").
+  updatedAt: z.string(),
+  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
+});
+
+// Hub content (intro, takeaways, shared rotki highlights, FAQ) lives in markdown so it
+// is editable alongside the feature pages rather than in i18n. Mirrors comparisonHubSchema.
+const featureHubSchema = z.object({
+  intro: z.string(),
+  keyTakeaways: z.array(z.string()).default([]),
+  rotkiHighlights: z.array(z.string()).default([]),
+  faq: z.array(z.object({
+    q: z.string(),
+    a: z.string(),
+  })).default([]),
+});
+
 export default defineContentConfig({
   collections: {
     documents: defineCollection({
@@ -184,6 +250,26 @@ export default defineContentConfig({
         cwd: '~~/',
         include: COMPARISON_HUB,
         prefix: 'comparison-hub',
+      },
+      type: 'page',
+    }),
+    features: defineCollection({
+      schema: featureSchema.extend({ sitemap: defineSitemapSchema() }),
+      source: {
+        cwd: '~~/',
+        include: FEATURES,
+        // Prefix matches the page route (`/features/<slug>`) so
+        // `queryCollection('features').path(...)` in features/[slug].vue resolves.
+        prefix: 'features',
+      },
+      type: 'page',
+    }),
+    featureHub: defineCollection({
+      schema: featureHubSchema,
+      source: {
+        cwd: '~~/',
+        include: FEATURE_HUB,
+        prefix: 'feature-hub',
       },
       type: 'page',
     }),

--- a/packages/website/content.config.ts
+++ b/packages/website/content.config.ts
@@ -169,6 +169,9 @@ const featureSchema = z.object({
     q: z.string(),
     a: z.string(),
   })).default([]),
+  // Optional deep link into the user docs (docs.rotki.com) for this use-case.
+  // Rendered as a "read the documentation" link in the deep-dive section.
+  docsUrl: z.string().url().optional(),
   // Freshness stamp shown on the page (e.g. "June 2026").
   updatedAt: z.string(),
   ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),

--- a/packages/website/content/feature-hub/index.md
+++ b/packages/website/content/feature-hub/index.md
@@ -1,0 +1,29 @@
+---
+intro: "rotki is the open-source, local-first crypto portfolio tracker, accounting and tax tool. These guides walk through what rotki actually does for common use cases, including importing data, tracking your portfolio privately, accounting for DeFi, and producing tax reports, and how it does all of it on your own machine."
+keyTakeaways:
+  - "rotki runs locally: it reads your exchanges through read-only API keys and your chains through RPC endpoints you choose, and stores everything encrypted on your own device."
+  - "It is open source and auditable on GitHub, so you can verify exactly how your data is handled."
+  - "A free local tier covers core portfolio tracking, accounting and tax reporting; a premium subscription unlocks higher limits and extra features."
+  - "Each guide below is a practical walkthrough of one use case, with setup steps, honest limitations, and common fixes."
+rotkiHighlights:
+  - "Local-first: your transaction history is read and stored on your own machine, not uploaded to a vendor cloud."
+  - "Open source: the entire application is auditable on GitHub, so you can verify what it does with your data."
+  - "Self-custodied data: you connect exchanges with read-only API keys and query chains via your own endpoints; you never hand over your full history."
+  - "On-chain decoding: rotki turns raw blockchain activity into readable events with full profit-and-loss accounting."
+  - "Free local tier: core tracking, accounting and reporting work locally for free, with premium features available by subscription."
+faq:
+  - q: "What does rotki do?"
+    a: "rotki is a local-first crypto portfolio tracker, accounting and tax tool. It pulls together your exchange and on-chain activity, tracks your portfolio, decodes DeFi and wallet history into readable events, and produces accounting and tax reports, all on your own computer."
+  - q: "Is rotki really local and private?"
+    a: "Yes. rotki runs as a desktop app on your machine. It reads exchanges with read-only API keys and chains via RPC endpoints you choose, and stores your data in a local database encrypted with SQLCipher (256-bit AES). By default nothing passes through rotki-operated servers."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier that covers core portfolio tracking, accounting and tax reporting with some limits. A premium subscription unlocks higher limits and additional features."
+---
+
+## What these guides cover
+
+Every guide on this page focuses on one thing rotki does and walks you through it end to end: what it supports, how to set it up, what the honest limitations are, and how to fix the problems people most commonly hit.
+
+The same idea runs through all of them: rotki is **local-first and open source**. It runs on your own computer, reads your exchange data through read-only API keys and your on-chain activity through RPC endpoints you choose, and stores everything in a local database encrypted with SQLCipher using 256-bit AES. Because the code is public, you can verify exactly how your data is handled rather than trusting a closed cloud service.
+
+If you are comparing rotki against hosted tools like Koinly or CoinTracker, the comparison pages cover that trade-off in detail. These feature guides are about getting things done with rotki itself.

--- a/packages/website/content/features/csv-import.md
+++ b/packages/website/content/features/csv-import.md
@@ -1,0 +1,82 @@
+---
+slug: csv-import
+label: "CSV import"
+tagline: "Import exchange and wallet history into rotki from CSV files"
+intro: "rotki can import your crypto history from CSV files, so activity from exchanges and sources that rotki does not read through an API still ends up in your local portfolio and accounting. Imports are processed on your own computer and stored in your local encrypted database."
+metaDescription: "Import crypto history into rotki from CSV files. Bring in exchange and wallet data that has no API connection, processed locally on your own machine."
+keywords: "crypto csv import, import csv crypto tax, exchange csv import, rotki csv import, import transactions csv crypto"
+updatedAt: "June 2026"
+ctaPlan: free
+keyTakeaways:
+  - "rotki imports transaction history from CSV files for sources without a live API connection."
+  - "Imported data is processed locally and stored in your encrypted database on your own machine."
+  - "CSV import complements rotki's read-only API and on-chain connections to fill in the gaps."
+  - "Imported events are accounted for alongside the rest of your portfolio and tax reports."
+capabilities:
+  - "Imports historical trades and transactions from CSV files exported by exchanges and other tools."
+  - "Supports import formats for several exchanges, plus a generic import for custom data."
+  - "Processes every import locally, so your files are read on your machine, not uploaded to a cloud."
+  - "Merges imported activity with API and on-chain data into one portfolio and accounting view."
+  - "Lets you review and edit imported events so your records stay accurate."
+limitations:
+  - "CSV exports differ between providers; a format rotki does not recognise may need to be mapped to the generic importer."
+  - "A CSV is a snapshot. Unlike a read-only API key, it will not keep updating as you trade, so you re-import to stay current."
+  - "Incomplete or inconsistent exports can produce gaps that need a manual fix after import."
+setup:
+  - "Export your transaction history as CSV from the exchange or tool."
+  - "In rotki, open the import section and choose the matching exchange importer, or the generic importer for custom data."
+  - "Select your CSV file and run the import."
+  - "Review the imported events for any rows that need mapping or correction."
+  - "Confirm the activity appears in your portfolio and reports."
+troubleshooting:
+  - problem: "My CSV is rejected or columns are not recognised."
+    fix: "The export format probably does not match the selected importer. Use the generic importer and map the columns, or adjust the file to the expected format, then import again."
+  - problem: "Imported amounts or dates look off."
+    fix: "Check the timezone and decimal formatting in the source export, and confirm you picked the right importer. You can edit imported events in rotki to correct individual rows."
+relatedIntegrations:
+  - slug: kraken
+    label: "Kraken"
+  - slug: binance
+    label: "Binance"
+  - slug: coinbase
+    label: "Coinbase"
+relatedComparisons:
+  - slug: koinly
+    label: "rotki vs Koinly"
+  - slug: cointracking
+    label: "rotki vs CoinTracking"
+relatedFeatures:
+  - slug: local-first-crypto-accounting
+    label: "Local-first crypto accounting"
+  - slug: open-source-crypto-tax
+    label: "Open-source crypto tax software"
+faq:
+  - q: "Can I import crypto transactions into rotki from CSV?"
+    a: "Yes. rotki imports transaction history from CSV files, including formats for several exchanges and a generic importer for custom data. Imports are processed locally on your machine."
+  - q: "When should I use CSV import instead of an API connection?"
+    a: "Use CSV import for sources rotki does not read through a read-only API, or for historical data that predates your API key. For supported exchanges, a read-only API key keeps updating automatically, so it is usually the better default."
+  - q: "Are my CSV files uploaded anywhere?"
+    a: "No. rotki reads and processes your CSV files locally and stores the result in your encrypted database. Your files are not uploaded to rotki-operated servers."
+  - q: "Which exchanges and tools can I import by CSV?"
+    a: "rotki has dedicated CSV importers for exchanges such as Binance, KuCoin, Bitstamp, Bittrex, Coinbase Pro, Crypto.com, BitMEX, Uphold, Bisq, ShapeShift, BlockFi and Nexo, plus tax and portfolio tools including CoinTracking, CoinLedger, Blockpit and Bitcoin.tax. A generic CSV format covers anything else."
+  - q: "What if my exchange's CSV format is not supported?"
+    a: "Use the generic importer and map your columns to the expected fields, or adjust the export to match. You can then review and edit the imported events."
+---
+
+Not every source can be connected with an API key, and you often have older history that predates any key you hold. CSV import is how rotki fills those gaps: you bring in the file, rotki reads it on your machine, and the activity joins the rest of your portfolio and accounting.
+
+## When CSV import is the right tool
+
+For supported exchanges, a read-only API key is usually the better default because it keeps updating as you trade. CSV import is for everything else: exchanges or tools without an API connection in rotki, accounts you have closed, or historical data you exported once. It is what lets you complete your records.
+
+## How importing works
+
+You export a CSV from the source, pick the matching importer in rotki (or the generic importer for custom data), and run it. Because exports differ between providers, a format rotki does not recognise can be mapped through the generic importer. Everything is processed locally and stored in your encrypted database, and you can review and edit imported events afterwards.
+
+## Which sources have a built-in importer
+
+rotki ships dedicated CSV importers for a range of exchanges and tools, including Binance, KuCoin, Bitstamp, Bittrex, Coinbase Pro, Crypto.com, BitMEX, Uphold, Bisq, ShapeShift, BlockFi and Nexo. It also imports from other tax and portfolio tools, including CoinTracking, CoinLedger, Blockpit and Bitcoin.tax, which helps if you are moving over from one of them. For anything without a dedicated importer, the generic rotki CSV format lets you map your own columns.
+
+## Keeping it accurate
+
+A CSV is a snapshot, so you re-import to stay current, and messy exports can leave gaps worth a quick manual fix. Once imported, the data is accounted for alongside your API and on-chain activity, so your portfolio view and tax reports reflect your full history, all without anything leaving your computer.

--- a/packages/website/content/features/csv-import.md
+++ b/packages/website/content/features/csv-import.md
@@ -6,6 +6,7 @@ intro: "rotki can import your crypto history from CSV files, so activity from ex
 metaDescription: "Import crypto history into rotki from CSV files. Bring in exchange and wallet data that has no API connection, processed locally on your own machine."
 keywords: "crypto csv import, import csv crypto tax, exchange csv import, rotki csv import, import transactions csv crypto"
 updatedAt: "June 2026"
+docsUrl: "https://docs.rotki.com/usage-guides/history/import-data.html"
 ctaPlan: free
 keyTakeaways:
   - "rotki imports transaction history from CSV files for sources without a live API connection."

--- a/packages/website/content/features/defi-portfolio-tracking.md
+++ b/packages/website/content/features/defi-portfolio-tracking.md
@@ -6,6 +6,7 @@ intro: "rotki tracks your DeFi portfolio by reading your on-chain activity and d
 metaDescription: "rotki is a local-first DeFi portfolio tracker. It decodes on-chain swaps, LP, staking and rewards into readable events with PnL across multiple chains."
 keywords: "defi portfolio tracker, defi portfolio tracking, track defi positions, on-chain portfolio tracker, defi pnl tracker, multi-chain defi tracker"
 updatedAt: "June 2026"
+docsUrl: "https://docs.rotki.com/usage-guides/history/events.html"
 ctaPlan: free
 keyTakeaways:
   - "rotki decodes raw on-chain transactions into readable events instead of leaving you with hashes."

--- a/packages/website/content/features/defi-portfolio-tracking.md
+++ b/packages/website/content/features/defi-portfolio-tracking.md
@@ -1,0 +1,84 @@
+---
+slug: defi-portfolio-tracking
+label: "DeFi portfolio tracking"
+tagline: "DeFi portfolio tracking with on-chain activity decoded into readable events"
+intro: "rotki tracks your DeFi portfolio by reading your on-chain activity and decoding it into readable events with full profit-and-loss accounting. It runs locally and queries chains through endpoints you choose, so you can follow swaps, liquidity positions, staking and rewards across multiple networks from one app."
+metaDescription: "rotki is a local-first DeFi portfolio tracker. It decodes on-chain swaps, LP, staking and rewards into readable events with PnL across multiple chains."
+keywords: "defi portfolio tracker, defi portfolio tracking, track defi positions, on-chain portfolio tracker, defi pnl tracker, multi-chain defi tracker"
+updatedAt: "June 2026"
+ctaPlan: free
+keyTakeaways:
+  - "rotki decodes raw on-chain transactions into readable events instead of leaving you with hashes."
+  - "It accounts for DeFi swaps, transfers, liquidity and rewards with profit-and-loss."
+  - "It tracks activity across multiple EVM chains and other supported networks from one local app."
+  - "You choose the RPC endpoints or data providers used to read chain data, so you control who sees those queries."
+capabilities:
+  - "Reads your wallet activity across supported chains and decodes it into categorised, readable events."
+  - "Accounts for DeFi actions such as swaps, transfers, liquidity provision and rewards, with profit-and-loss."
+  - "Tracks balances and positions across multiple networks in a single view."
+  - "Lets you choose your own RPC endpoints or data providers for chain queries."
+  - "Stores the decoded history in a local encrypted database you control."
+limitations:
+  - "DeFi is broad; decoding coverage for specific protocols varies, and some niche or brand-new protocols may need manual handling."
+  - "Reading chain data depends on the RPC endpoint or data provider you configure, and public endpoints can rate-limit large histories."
+  - "Complex or unusual on-chain transactions may need a manual review to be categorised correctly."
+setup:
+  - "Install the rotki desktop app and create a local account."
+  - "Add your public wallet addresses for each chain you use."
+  - "Choose the RPC endpoints or data providers rotki should use to read chain data."
+  - "Let rotki pull and decode your transaction history into events."
+  - "Review the decoded positions and events, correcting any that need a manual touch."
+troubleshooting:
+  - problem: "Some DeFi transactions are not decoded or are categorised generically."
+    fix: "Decoding coverage varies by protocol. For transactions rotki cannot fully classify, open the event and set the correct type manually. Many protocols are supported out of the box and coverage continues to expand."
+  - problem: "Pulling my history is slow or fails partway."
+    fix: "This usually comes down to the RPC endpoint or data provider. Large histories can hit public-endpoint rate limits, so configure a more capable endpoint or your own node, then retry the query."
+relatedIntegrations:
+  - slug: uniswap
+    label: "Uniswap"
+  - slug: aave
+    label: "Aave"
+  - slug: ethereum
+    label: "Ethereum"
+  - slug: arbitrum-one
+    label: "Arbitrum One"
+relatedComparisons:
+  - slug: koinly
+    label: "rotki vs Koinly"
+  - slug: cointracker
+    label: "rotki vs CoinTracker"
+relatedFeatures:
+  - slug: local-first-crypto-accounting
+    label: "Local-first crypto accounting"
+  - slug: privacy-first-portfolio-management
+    label: "Privacy-first portfolio management"
+faq:
+  - q: "Can rotki track my DeFi portfolio?"
+    a: "Yes. rotki reads your on-chain activity and decodes it into readable events such as swaps, transfers, liquidity and rewards, with profit-and-loss accounting, across multiple supported chains, all processed locally."
+  - q: "Does rotki support multiple chains?"
+    a: "Yes. rotki tracks activity across multiple EVM chains and other supported networks. You add your addresses and choose which endpoints to query for each chain."
+  - q: "Which chains does rotki support?"
+    a: "rotki covers several EVM chains, including Ethereum, Arbitrum One, Base, Optimism, Polygon PoS, Gnosis, BNB Smart Chain, Scroll, Avalanche and zkSync Lite, plus non-EVM networks such as Bitcoin, Solana, Polkadot and Kusama. The integrations directory lists the current set."
+  - q: "Who sees my on-chain queries?"
+    a: "rotki reads chain data through an RPC endpoint or data provider that you configure. Because you choose the endpoint, you control who sees those requests: a provider you trust or your own node."
+  - q: "What if a protocol is not decoded?"
+    a: "Coverage varies by protocol and keeps expanding. For transactions rotki cannot fully classify, you can open the event and set the correct type manually."
+---
+
+DeFi is where many portfolio trackers fall short: a block explorer shows you hashes, not what actually happened. rotki turns that raw on-chain activity into a portfolio you can read, and it does so locally, with endpoints you control.
+
+## From raw transactions to readable events
+
+rotki reads the activity for the addresses you add and decodes each transaction into a categorised event: a swap, a deposit into a liquidity pool, a staking reward, a transfer. Those events carry the accounting through to profit and loss, so your DeFi history is both visible and properly accounted for.
+
+## You choose how chains are read
+
+To read on-chain data, rotki queries an RPC endpoint or data provider. You decide which one, whether a public provider, a service you trust, or your own node, so you control who sees those requests and how much throughput you get for large histories. Decoded results are stored in your local encrypted database.
+
+## Which chains rotki covers
+
+rotki tracks activity across several EVM chains, including Ethereum, Arbitrum One, Base, Optimism, Polygon PoS, Gnosis, BNB Smart Chain, Scroll, Avalanche and zkSync Lite, alongside non-EVM networks such as Bitcoin, Solana, Polkadot and Kusama. The supported set grows over time; the [integrations directory](/integrations) lists every chain, exchange and protocol rotki currently reads.
+
+## Protocol coverage
+
+New DeFi protocols appear constantly, and decoding coverage for specific protocols varies; brand-new or niche protocols may need a manual review to categorise. Many protocols are supported out of the box and coverage keeps growing, and where rotki needs a hand you can correct an event yourself. The result is a multi-chain DeFi portfolio you can follow clearly, tracked privately on your own machine.

--- a/packages/website/content/features/local-first-crypto-accounting.md
+++ b/packages/website/content/features/local-first-crypto-accounting.md
@@ -6,6 +6,7 @@ intro: "rotki is a local-first crypto accounting tool. It reconciles your trades
 metaDescription: "rotki is local-first crypto accounting software. Reconcile trades, transfers and on-chain activity and produce reports on your own machine, not a cloud."
 keywords: "local-first crypto accounting, local crypto accounting software, self-hosted crypto accounting, crypto bookkeeping local, offline crypto accounting"
 updatedAt: "June 2026"
+docsUrl: "https://docs.rotki.com/usage-guides/tax-accounting/guide.html"
 ctaPlan: free
 keyTakeaways:
   - "rotki runs locally and keeps your accounting data in an encrypted database on your own device."

--- a/packages/website/content/features/local-first-crypto-accounting.md
+++ b/packages/website/content/features/local-first-crypto-accounting.md
@@ -1,0 +1,76 @@
+---
+slug: local-first-crypto-accounting
+label: "Local-first crypto accounting"
+tagline: "Local-first crypto accounting that keeps your books on your machine"
+intro: "rotki is a local-first crypto accounting tool. It reconciles your trades, transfers and on-chain activity into a complete picture of your portfolio and produces accounting and tax reports, all on your own computer, with your data stored in a local encrypted database."
+metaDescription: "rotki is local-first crypto accounting software. Reconcile trades, transfers and on-chain activity and produce reports on your own machine, not a cloud."
+keywords: "local-first crypto accounting, local crypto accounting software, self-hosted crypto accounting, crypto bookkeeping local, offline crypto accounting"
+updatedAt: "June 2026"
+ctaPlan: free
+keyTakeaways:
+  - "rotki runs locally and keeps your accounting data in an encrypted database on your own device."
+  - "It reconciles exchange and on-chain activity into readable events with full profit-and-loss accounting."
+  - "Accounting settings such as cost-basis method and period are configurable and applied on your machine."
+  - "A free local tier covers core accounting; premium raises limits and adds features."
+capabilities:
+  - "Aggregates balances and transactions across exchanges, wallets and chains into one local ledger."
+  - "Decodes on-chain activity into readable, categorised events instead of raw hashes."
+  - "Calculates profit and loss using configurable accounting settings, processed locally."
+  - "Lets you add manual entries and edit events to keep your books accurate."
+  - "Produces exportable reports for review or for your accountant."
+limitations:
+  - "rotki provides the accounting and reports; it is not a replacement for advice from a tax professional."
+  - "It is a desktop app, not a hosted multi-user bookkeeping platform."
+  - "You keep your own backups of the local database. Premium adds optional encrypted sync."
+setup:
+  - "Install the rotki desktop app and create a local, password-protected account."
+  - "Connect exchanges with read-only API keys and add your wallet addresses."
+  - "Let rotki import and decode your history into events."
+  - "Set your cost-basis method and accounting period in settings."
+  - "Review events, add any manual entries, then generate and export your report."
+troubleshooting:
+  - problem: "Some transactions are uncategorised or look wrong."
+    fix: "Open the event, check the detected type, and correct it if needed. rotki lets you edit events and add manual entries so your books stay accurate; re-run the report afterwards."
+  - problem: "Transfers between my own accounts look like taxable disposals."
+    fix: "Make sure both the sending and receiving accounts or addresses are added to rotki so it can match the two sides of the transfer and treat it as an internal movement rather than a disposal."
+relatedIntegrations:
+  - slug: kraken
+    label: "Kraken"
+  - slug: binance
+    label: "Binance"
+  - slug: ethereum
+    label: "Ethereum"
+relatedComparisons:
+  - slug: cointracking
+    label: "rotki vs CoinTracking"
+  - slug: koinly
+    label: "rotki vs Koinly"
+relatedFeatures:
+  - slug: open-source-crypto-tax
+    label: "Open-source crypto tax software"
+  - slug: defi-portfolio-tracking
+    label: "DeFi portfolio tracking"
+faq:
+  - q: "What is local-first crypto accounting?"
+    a: "It means your books are kept and processed on your own device rather than in a cloud service. rotki reads your accounts, reconciles activity, and runs the accounting locally, storing the data in an encrypted database on your machine."
+  - q: "Can rotki handle transfers between my own wallets?"
+    a: "Yes. If both sides are added to rotki, it matches the sending and receiving addresses and treats the movement as an internal transfer rather than a taxable disposal."
+  - q: "Does my accounting data leave my computer?"
+    a: "No, not by default. rotki processes and stores your accounting locally. Optional premium sync uploads only data already encrypted on your device."
+  - q: "Is rotki free?"
+    a: "rotki has a free local tier covering core accounting and reporting with some limits, plus a premium subscription for higher limits and extra features."
+---
+
+Crypto accounting means turning a messy stream of trades, transfers and on-chain events into a coherent ledger you can report from. rotki does that work locally: it lives on your computer, reads your accounts, and keeps the resulting books in an encrypted database that never has to leave your machine.
+
+## Building an accurate ledger
+
+rotki pulls balances and transactions from the exchanges and wallets you add and decodes on-chain activity into readable, categorised events. Where automation needs a hand, for example an unusual transaction or an off-exchange trade, you can edit events and add manual entries so the ledger reflects reality.
+
+## Accounting you control
+
+You choose the cost-basis method and accounting period, and rotki applies them on your machine to calculate profit and loss. Because it is local and open source, you can see how each figure is derived rather than relying on calculations you cannot inspect.
+
+## Who it is for
+
+rotki gives you the accounting foundation and exportable reports. It is not multi-user bookkeeping software and it is not tax advice. For an individual or a small operation that wants accurate, private, auditable crypto books, doing the accounting locally is a good fit.

--- a/packages/website/content/features/open-source-crypto-tax.md
+++ b/packages/website/content/features/open-source-crypto-tax.md
@@ -1,0 +1,82 @@
+---
+slug: open-source-crypto-tax
+label: "Open-source crypto tax software"
+tagline: "Open-source crypto tax software you can audit and run yourself"
+intro: "rotki is open-source crypto tax and accounting software. The entire application is public on GitHub, so you can read the code, verify exactly how your transactions are processed, and run it on your own computer instead of trusting a closed cloud service with your financial history."
+metaDescription: "rotki is open-source crypto tax software you can audit on GitHub and run locally. Produce cost-basis tax reports on your own machine, not in a cloud."
+keywords: "open source crypto tax software, open source crypto tax, auditable crypto tax tool, self-hosted crypto tax, crypto tax report local"
+updatedAt: "June 2026"
+ctaPlan: free
+keyTakeaways:
+  - "rotki's source code is public and auditable on GitHub, so you can verify how it calculates your taxes."
+  - "Tax and accounting reports are generated locally on your machine, not uploaded to a vendor cloud."
+  - "It supports common cost-basis methods and produces a detailed, exportable report of your taxable events."
+  - "A free local tier covers core accounting and reporting; premium raises limits and adds features."
+capabilities:
+  - "Generates profit-and-loss and cost-basis reports from your exchange and on-chain history, processed on your own computer."
+  - "Supports configurable accounting settings, including cost-basis method and the accounting period."
+  - "Decodes on-chain activity into readable events so DeFi swaps, transfers and rewards are accounted for."
+  - "Exports a detailed report of taxable events you can review or hand to your accountant."
+  - "Is fully open source, so the calculation logic can be inspected and verified."
+limitations:
+  - "rotki gives you the underlying accounting and a detailed events report; it is not a substitute for advice from a tax professional in your jurisdiction."
+  - "It does not pre-fill country-specific government tax forms the way some hosted services do. It produces the figures and an exportable report."
+  - "You run rotki as a desktop app and keep your own backups, which is the trade-off for processing everything locally."
+setup:
+  - "Download and install the rotki desktop app for Windows, macOS or Linux."
+  - "Add your exchanges with read-only API keys and your wallet addresses so rotki can build your history."
+  - "Open the accounting settings and choose your cost-basis method and accounting period."
+  - "Run the profit-and-loss report for the tax year and review the breakdown of taxable events."
+  - "Export the report for your records or your accountant."
+troubleshooting:
+  - problem: "My tax report has gaps or unknown transactions."
+    fix: "Gaps usually mean a source is missing. Make sure every exchange account and wallet address is added, then re-run the report. rotki flags events it could not fully process so you can resolve them."
+  - problem: "The numbers do not match what I expected."
+    fix: "Check the cost-basis method and accounting period in settings, since different methods produce different results. Because rotki is open source, the calculation logic is documented and auditable if you want to verify it."
+relatedIntegrations:
+  - slug: kraken
+    label: "Kraken"
+  - slug: coinbase
+    label: "Coinbase"
+  - slug: ethereum
+    label: "Ethereum"
+relatedComparisons:
+  - slug: koinly
+    label: "rotki vs Koinly"
+  - slug: cointracking
+    label: "rotki vs CoinTracking"
+relatedFeatures:
+  - slug: privacy-first-portfolio-management
+    label: "Privacy-first portfolio management"
+  - slug: local-first-crypto-accounting
+    label: "Local-first crypto accounting"
+faq:
+  - q: "Is there open-source crypto tax software?"
+    a: "Yes. rotki is open-source crypto tax and accounting software. Its full source code is public on GitHub, and it runs locally on your computer, so you can audit how it works and keep your data on your own machine."
+  - q: "Does rotki file my taxes for me?"
+    a: "No. rotki does the accounting and produces a detailed report of your taxable events and gains using your chosen cost-basis method. You or your accountant use that to file. It is not a replacement for professional tax advice."
+  - q: "Where are my tax calculations performed?"
+    a: "On your own computer. rotki reads your data and runs the accounting locally; the resulting reports are not uploaded to rotki-operated servers."
+  - q: "Which cost-basis methods does rotki support?"
+    a: "rotki supports FIFO, LIFO, HIFO and ACB (average cost basis). You choose the method and the accounting period in settings, and rotki applies it locally when generating your report."
+  - q: "Is rotki free for tax reports?"
+    a: "rotki has a free local tier that covers core accounting and reporting with some limits. A premium subscription raises those limits and adds features."
+---
+
+rotki approaches crypto taxes differently from most tools: it is open source, and it runs on your computer. That combination is deliberate. You are not uploading your transaction history to a service and trusting calculations you cannot see; you can read exactly how rotki turns your trades and on-chain activity into a tax report.
+
+## Why open source matters for taxes
+
+Tax calculations involve judgement calls: which cost-basis method to use, how to treat a transfer between your own wallets, how to value a DeFi reward. With closed software you have to take the vendor's word for how those decisions are made. Because rotki is open source, the accounting logic is public and auditable. If a number looks wrong, you can trace why.
+
+## How rotki produces your report
+
+rotki builds your history from the exchanges and wallets you add, decodes on-chain activity into readable events, and then applies your accounting settings to calculate gains and losses. It produces a detailed, exportable report of taxable events for the period you choose. All of that happens locally on your machine.
+
+## Cost-basis methods rotki supports
+
+rotki supports four cost-basis methods: FIFO (first in, first out), LIFO (last in, first out), HIFO (highest in, first out) and ACB (average cost basis). You pick the method and the accounting period in settings, and rotki applies it locally when it builds the report. The profit-and-loss report and its underlying events can be exported as CSV for your records or your accountant.
+
+## What rotki does and does not do
+
+rotki gives you accurate, auditable accounting and a clear report of taxable events. It does not pre-fill your country's specific government forms, and it is not tax advice. If you want to understand and own your crypto accounting while keeping it private, running open-source software locally is a solid basis for that.

--- a/packages/website/content/features/open-source-crypto-tax.md
+++ b/packages/website/content/features/open-source-crypto-tax.md
@@ -6,6 +6,7 @@ intro: "rotki is open-source crypto tax and accounting software. The entire appl
 metaDescription: "rotki is open-source crypto tax software you can audit on GitHub and run locally. Produce cost-basis tax reports on your own machine, not in a cloud."
 keywords: "open source crypto tax software, open source crypto tax, auditable crypto tax tool, self-hosted crypto tax, crypto tax report local"
 updatedAt: "June 2026"
+docsUrl: "https://docs.rotki.com/usage-guides/history/pnl.html"
 ctaPlan: free
 keyTakeaways:
   - "rotki's source code is public and auditable on GitHub, so you can verify how it calculates your taxes."

--- a/packages/website/content/features/privacy-first-portfolio-management.md
+++ b/packages/website/content/features/privacy-first-portfolio-management.md
@@ -1,0 +1,76 @@
+---
+slug: privacy-first-portfolio-management
+label: "Privacy-first portfolio management"
+tagline: "Privacy-first crypto portfolio management on your own machine"
+intro: "rotki is a privacy-first crypto portfolio tracker. It runs as a desktop app on your own computer, reads your exchanges through read-only API keys and your wallets through endpoints you choose, and stores everything in a local database encrypted with SQLCipher. By default nothing passes through rotki-operated servers."
+metaDescription: "rotki is a privacy-first crypto portfolio tracker. Track balances and history locally in an encrypted database; by default nothing goes to rotki servers."
+keywords: "privacy-first portfolio management, private crypto portfolio tracker, encrypted crypto tracker, local crypto portfolio tracker, no-cloud crypto tracker"
+updatedAt: "June 2026"
+ctaPlan: free
+keyTakeaways:
+  - "rotki runs locally and stores your data in a database encrypted with SQLCipher (256-bit AES) on your own device."
+  - "Exchanges are read with read-only API keys; you never hand over withdrawal access or your full history to a cloud."
+  - "By default nothing passes through rotki-operated servers. Optional premium sync is zero-knowledge."
+  - "It is open source, so the privacy claims can be verified in the code rather than taken on trust."
+capabilities:
+  - "Tracks balances and transaction history across exchanges, wallets and chains from one local app."
+  - "Stores everything in a local database encrypted with SQLCipher using 256-bit AES."
+  - "Connects to exchanges using read-only API keys, so rotki only reads data and cannot move funds."
+  - "Offers optional premium backup and multi-device sync that is zero-knowledge: your database is encrypted on your device before upload."
+  - "Is open source, so you can verify how and where your data is handled."
+limitations:
+  - "rotki is desktop-first; it is not a hosted web dashboard you log into from any browser."
+  - "Because your data lives on your device, you are responsible for backups. Premium adds optional encrypted sync."
+  - "Reading public chain data requires querying an RPC endpoint or data provider; you choose which one, which determines who sees those requests."
+setup:
+  - "Download and install the rotki desktop app and create a local account with a password. Your encryption key is derived from it."
+  - "Add exchanges using read-only API keys with no withdrawal permissions."
+  - "Add your public wallet addresses to track on-chain balances and activity."
+  - "Optionally choose your own RPC endpoints or data providers for chain queries."
+  - "Optionally enable premium sync for zero-knowledge encrypted backups across devices."
+troubleshooting:
+  - problem: "Will my API keys or data be uploaded anywhere?"
+    fix: "No. rotki uses your API keys locally to read balances and trades, and stores everything in your local encrypted database. By default nothing is sent to rotki-operated servers; premium sync only uploads data already encrypted on your device."
+  - problem: "I want to track a wallet without exposing my requests."
+    fix: "Chain balances are read by querying an RPC endpoint or data provider. You choose which endpoint to use, so you control who sees those queries, for example a provider you trust or your own node."
+relatedIntegrations:
+  - slug: ethereum
+    label: "Ethereum"
+  - slug: kraken
+    label: "Kraken"
+  - slug: bitcoin
+    label: "Bitcoin"
+relatedComparisons:
+  - slug: cointracker
+    label: "rotki vs CoinTracker"
+  - slug: koinly
+    label: "rotki vs Koinly"
+relatedFeatures:
+  - slug: local-first-crypto-accounting
+    label: "Local-first crypto accounting"
+  - slug: open-source-crypto-tax
+    label: "Open-source crypto tax software"
+faq:
+  - q: "What is a privacy-first crypto portfolio tracker?"
+    a: "It is a tracker that keeps your financial data under your control rather than in a vendor's cloud. rotki does this by running locally, reading exchanges with read-only API keys, and storing everything in an encrypted database on your own device."
+  - q: "Does rotki store my portfolio in the cloud?"
+    a: "No. By default your data stays in a local encrypted database on your machine. rotki offers optional premium sync, and even that is zero-knowledge: your database is encrypted on your device with a key derived from your password before it is uploaded, so rotki cannot read it."
+  - q: "Can rotki move my funds?"
+    a: "No. You connect exchanges with read-only API keys that have no withdrawal permissions, so rotki can only read balances and trades."
+  - q: "How is my local data protected?"
+    a: "rotki stores your data in a database encrypted with SQLCipher using 256-bit AES, with the key derived from your account password."
+---
+
+Most portfolio trackers ask you to upload your accounts and addresses to their servers. That is convenient, but it means your complete financial history lives in someone else's cloud. rotki is built the other way around: it is a privacy-first desktop application that keeps your data on your own machine.
+
+## Where your data lives
+
+rotki stores everything in a local database encrypted with SQLCipher using 256-bit AES, with the encryption key derived from your account password. Your balances, transactions and notes are on your device, not in a vendor account. Because rotki is open source, you can read the code that handles your data and confirm this for yourself.
+
+## How rotki reads your accounts
+
+Exchanges are connected with read-only API keys, so rotki can see your balances and trades but cannot withdraw. On-chain balances are read by querying chain data through an RPC endpoint or data provider that you choose, so you decide who sees those requests: a provider you trust, or your own node.
+
+## The trade-off
+
+A local-first tracker asks a bit more of you: you run a desktop app and you keep your own backups. In return you get ownership and privacy, plus an optional zero-knowledge sync if you want multi-device backups without giving up that control. If you would rather not hand your full portfolio to a cloud service, that is a trade worth making.

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -796,6 +796,40 @@
       }
     }
   },
+  "features": {
+    "header": "Features",
+    "title": "What rotki does, by use case",
+    "description": "Use-case guides for rotki: CSV import, local-first accounting, privacy-first tracking, DeFi, and open-source crypto tax — all running locally on your machine.",
+    "hub": {
+      "takeaways_title": "Key takeaways",
+      "list_title": "Browse features",
+      "why_title": "Why rotki",
+      "faq_title": "Frequently asked questions"
+    },
+    "detail": {
+      "updated": "Updated {date}",
+      "takeaways_title": "Key takeaways",
+      "capabilities_title": "What rotki supports",
+      "setup_title": "How to set it up",
+      "limitations_title": "Good to know",
+      "deepdive_title": "{label} in rotki",
+      "troubleshooting_title": "Common problems and fixes",
+      "related_integrations": "Related integrations",
+      "related_comparisons": "Related comparisons",
+      "related_features": "Related features",
+      "faq_title": "Frequently asked questions",
+      "tier": {
+        "basic": "Basic plan",
+        "advanced": "Advanced plan"
+      },
+      "cta": {
+        "title": "Try rotki for free",
+        "description": "Download rotki and track everything locally. Your keys and data never leave your machine.",
+        "download": "Download rotki",
+        "all": "All features"
+      }
+    }
+  },
   "jobs": {
     "description": "Our mission is to empower users to take control of their finances both in and out of crypto in a transparent and auditable way while enabling them to own their data through a self-sovereign application.",
     "header": "We’re looking for talented people",
@@ -825,6 +859,10 @@
     "compare": {
       "description": "How rotki compares to cloud crypto tax tools",
       "title": "Compare"
+    },
+    "features": {
+      "description": "What rotki does, by use case",
+      "title": "Features"
     },
     "documentation": {
       "description": "Everything you need to know about the app",

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -813,6 +813,7 @@
       "setup_title": "How to set it up",
       "limitations_title": "Good to know",
       "deepdive_title": "{label} in rotki",
+      "docs_link": "Read the documentation",
       "troubleshooting_title": "Common problems and fixes",
       "related_integrations": "Related integrations",
       "related_comparisons": "Related comparisons",

--- a/packages/website/modules/feature-seo/module.ts
+++ b/packages/website/modules/feature-seo/module.ts
@@ -1,0 +1,200 @@
+import type { Buffer } from 'node:buffer';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineNuxtModule, useLogger } from '@nuxt/kit';
+import { parse as parseYaml } from 'yaml';
+import { type OgFonts, renderOgImage } from '../integration-seo/og-image';
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Build-time augmentation for the `/features/<slug>` pages, mirroring the
+ * comparison-seo module:
+ *
+ * 1. Open Graph card images. `nuxi generate` bakes the per-page head/JSON-LD into
+ *    each route but cannot produce the OG card, so this module renders one PNG per
+ *    feature into `img/og/features/<slug>.png` during `prerender:generate` (with a
+ *    share.png fallback so `og:image` always resolves).
+ *
+ * 2. Markdown body for nuxt-llms. Feature content lives mostly in frontmatter, so a
+ *    `content:file:afterParse` hook synthesises a body (intro + capabilities + setup
+ *    + limitations + troubleshooting + FAQ) so `llms-full.txt` and the `/raw/*.md`
+ *    endpoint expose real content. This does not affect the rendered page.
+ */
+
+interface FeatureFrontmatter {
+  label?: string;
+  tagline?: string;
+}
+
+// minimark AST node: [tag, props, ...children].
+type MinimarkNode = [string, Record<string, unknown>, ...unknown[]];
+
+interface FeatureDoc {
+  label?: string;
+  title?: string;
+  description?: string;
+  intro?: string;
+  capabilities?: string[];
+  setup?: string[];
+  limitations?: string[];
+  troubleshooting?: Array<{ problem: string; fix: string }>;
+  faq?: Array<{ q: string; a: string }>;
+  body?: { value?: unknown[] };
+}
+
+function listSection(heading: string, items: string[] | undefined): MinimarkNode[] {
+  if (!Array.isArray(items) || items.length === 0)
+    return [];
+
+  return [
+    ['h2', {}, heading],
+    ['ul', {}, ...items.map((item): MinimarkNode => ['li', {}, item])],
+  ];
+}
+
+// Synthesise a markdown body AST from feature frontmatter. Starts with an h1 so
+// nuxt-llms' full generator and the /raw endpoint render it verbatim (no double title).
+function buildFeatureBody(doc: FeatureDoc): MinimarkNode[] {
+  const label = doc.label ?? doc.title ?? '';
+  const value: MinimarkNode[] = [['h1', {}, label]];
+  if (doc.intro)
+    value.push(['p', {}, doc.intro]);
+
+  value.push(...listSection('What rotki supports', doc.capabilities));
+  value.push(...listSection('How to set it up', doc.setup));
+  value.push(...listSection('Good to know', doc.limitations));
+
+  if (Array.isArray(doc.troubleshooting) && doc.troubleshooting.length > 0) {
+    value.push(['h2', {}, 'Common problems and fixes']);
+    for (const { problem, fix } of doc.troubleshooting) {
+      value.push(['h3', {}, problem], ['p', {}, fix]);
+    }
+  }
+
+  if (Array.isArray(doc.faq) && doc.faq.length > 0) {
+    value.push(['h2', {}, 'FAQ']);
+    for (const { q, a } of doc.faq) {
+      value.push(['h3', {}, q], ['p', {}, a]);
+    }
+  }
+  return value;
+}
+
+function readFrontmatter(file: string): FeatureFrontmatter | undefined {
+  const raw = readFileSync(file, 'utf8');
+  const match = raw.match(/^---\r?\n([\S\s]*?)\r?\n---/);
+  if (!match?.[1])
+    return undefined;
+
+  return parseYaml(match[1]) as FeatureFrontmatter;
+}
+
+function buildFrontmatterMap(contentDir: string): Map<string, FeatureFrontmatter> {
+  const map = new Map<string, FeatureFrontmatter>();
+  for (const file of readdirSync(contentDir)) {
+    if (!file.endsWith('.md') || file.startsWith('_'))
+      continue;
+
+    const fm = readFrontmatter(resolve(contentDir, file));
+    if (fm)
+      map.set(file.replace(/\.md$/, ''), fm);
+  }
+  return map;
+}
+
+export default defineNuxtModule({
+  meta: { name: 'feature-seo' },
+  setup(_options, nuxt) {
+    const logger = useLogger('feature-seo');
+    const contentDir = resolve(nuxt.options.rootDir, 'content/features');
+    let fonts: OgFonts | undefined;
+    try {
+      fonts = {
+        regular: readFileSync(resolve(moduleDir, '../integration-seo/fonts/roboto-400.woff')),
+        bold: readFileSync(resolve(moduleDir, '../integration-seo/fonts/roboto-700.woff')),
+      };
+    }
+    catch {
+      logger.warn('OG fonts not found; falling back to the shared share.png');
+    }
+
+    // Synthesise a markdown body from frontmatter so nuxt-llms (llms-full.txt + /raw)
+    // emits real content instead of empty docs.
+    nuxt.hook('content:file:afterParse', (ctx) => {
+      const { collection, content: doc } = ctx as unknown as { collection?: string | { name?: string }; content?: FeatureDoc };
+      const name = typeof collection === 'string' ? collection : collection?.name;
+      if (name !== 'features' || !doc?.intro || !Array.isArray(doc.body?.value))
+        return;
+
+      if (doc.label)
+        doc.title = doc.label;
+      if (!doc.description)
+        doc.description = doc.intro;
+      if (doc.body.value.length === 0)
+        doc.body.value = buildFeatureBody(doc);
+    });
+
+    nuxt.hook('nitro:init', (nitro) => {
+      const publicDir = nitro.options.output.publicDir;
+      let map: Map<string, FeatureFrontmatter> | undefined;
+      let sharePng: Buffer | undefined;
+      let ogGenerated = 0;
+      let fallback = 0;
+      const skipped = new Set<string>();
+
+      const writeFallback = (relPath: string): void => {
+        try {
+          sharePng ??= readFileSync(resolve(publicDir, 'img/og/share.png'));
+          mkdirSync(resolve(publicDir, dirname(relPath)), { recursive: true });
+          writeFileSync(resolve(publicDir, relPath), sharePng);
+          fallback += 1;
+        }
+        catch (error) {
+          logger.warn(`OG fallback copy failed for ${relPath}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      };
+
+      nitro.hooks.hook('prerender:generate', async (route) => {
+        const slug = route.route.match(/^\/features\/([^/]+)\/?$/)?.[1];
+        if (!slug)
+          return;
+
+        map ??= buildFrontmatterMap(contentDir);
+        const fm = map.get(slug);
+        if (!fm) {
+          skipped.add(slug);
+          return;
+        }
+
+        const relPath = `img/og/features/${slug}.png`;
+        if (!fonts) {
+          writeFallback(relPath);
+          return;
+        }
+
+        try {
+          const png = await renderOgImage({
+            label: fm.label ?? slug,
+            tagline: fm.tagline ?? '',
+            typeLabel: 'Feature',
+            fonts,
+          });
+          mkdirSync(resolve(publicDir, dirname(relPath)), { recursive: true });
+          writeFileSync(resolve(publicDir, relPath), png);
+          ogGenerated += 1;
+        }
+        catch (error) {
+          logger.warn(`OG image generation failed for ${slug}: ${error instanceof Error ? error.message : String(error)}`);
+          writeFallback(relPath);
+        }
+      });
+
+      nitro.hooks.hook('close', () => {
+        const suffix = skipped.size > 0 ? `; skipped ${skipped.size} slug(s) with no content page: ${[...skipped].sort().join(', ')}` : '';
+        logger.info(`generated ${ogGenerated} feature OG images (${fallback} share.png fallbacks)${suffix}`);
+      });
+    });
+  },
+});

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -2,6 +2,7 @@ import process from 'node:process';
 import { SIGIL_SCRIPT_URL, SIGIL_TRACKED_DOMAIN, SIGIL_WEBSITE_ID } from '@rotki/sigil';
 import rotkiTheme from '@rotki/ui-library/theme';
 import { comparisonPrerenderRoutes } from './app/utils/comparison-prerender';
+import { featurePrerenderRoutes } from './app/utils/feature-prerender';
 import { integrationPrerenderRoutes } from './app/utils/integration-prerender';
 import { llms } from './app/utils/llms-config';
 
@@ -163,6 +164,7 @@ export default defineNuxtConfig({
     './modules/integration-images/module.ts',
     './modules/integration-seo/module.ts',
     './modules/comparison-seo/module.ts',
+    './modules/feature-seo/module.ts',
     './modules/ui-library/module.ts',
   ],
 
@@ -286,10 +288,9 @@ export default defineNuxtConfig({
       crawlLinks: true,
       // Guardrail: fail the build if an indexable route errors while rendering — make it ssr:false instead.
       failOnError: true,
-      routes: [...integrationPrerenderRoutes(), ...comparisonPrerenderRoutes()],
+      routes: [...integrationPrerenderRoutes(), ...comparisonPrerenderRoutes(), ...featurePrerenderRoutes()],
     },
   },
-
   routeRules: {
     // Redirect /pricing to /checkout/pay
     '/pricing': { redirect: { to: '/checkout/pay', statusCode: 301 } },
@@ -314,7 +315,6 @@ export default defineNuxtConfig({
     // Web3-wallet utility page, noindex — no SEO value, so keep it client-only.
     '/sponsor/submit-name': { ssr: false, prerender: false },
   },
-
   runtimeConfig: {
     public: {
       baseUrl: '',


### PR DESCRIPTION
## Summary

Adds the `/features/<slug>` SEO landing-page slice of rotki/rotki-web#202 (SEO Structured landing pages), the last unstarted slice after integration pages (#595) and the comparison pages (shipped in v2026.6.3). Clones the comparison-pages content model and ships the full reusable infrastructure plus a 5-page flagship pilot.

## What's included

**Infrastructure (supports the full 10-20 page target):**
- `content.config.ts`: `features` + `featureHub` collections with Zod schemas
- `app/pages/features/index.vue` (hub) + `[slug].vue` (detail), with `BreadcrumbList`, `SoftwareApplication`, `FAQPage` and `ItemList` JSON-LD
- `modules/feature-seo`: build-time per-slug OG cards + synthesized `llms.txt` bodies (clone of `comparison-seo`)
- `feature-prerender` util, `nuxt.config` prerender routes + module registration
- Discoverability: footer nav entry, `llms-config` Features section, sitemap (automatic), `en.json` UI strings

**Pilot pages (`/features/<slug>`):**
- `open-source-crypto-tax`
- `privacy-first-portfolio-management`
- `local-first-crypto-accounting`
- `defi-portfolio-tracking`
- `csv-import`

Copy is grounded in rotki's actual capabilities (local-first, open-source, read-only API keys, user-supplied RPC, on-chain decoding, cost-basis tax reports) with honest limitations. The three head-term pages carry concrete facts sourced from the rotki codebase: cost-basis methods (FIFO/LIFO/HIFO/ACB), the built-in CSV importer list, and supported chains.

## Verification
- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm generate` clean (5 OG cards, 0 fallbacks)
- `pnpm seo:audit` clean (single canonical, title <60, description <160, h1, OG tags per page)

## Backlog (follow-up PR, infra already supports)
self-hosted-crypto-tracker, read-only-api-key-tracking, crypto-tax-report, multi-chain-portfolio-tracker, nft-portfolio-tracking, cost-basis-tracking, encrypted-local-database — to reach the issue's 10-20 target.

Refs rotki/rotki-web#202