### PR TITLE
fix(download): prevent button/version overlap on mobile

### DIFF
--- a/packages/website/app/components/download/DownloadHeading.vue
+++ b/packages/website/app/components/download/DownloadHeading.vue
@@ -71,7 +71,7 @@ function onDownloadClick(platform: string): void {
           {{ t('download.heading.description') }}
         </h3>
         <div class="flex flex-col items-center gap-3 pt-2 min-h-[106px]">
-          <div class="flex gap-2 flex-wrap justify-center h-[42px] items-center">
+          <div class="flex gap-2 flex-wrap justify-center min-h-[42px] items-center">
             <RuiButton
               v-if="loading"
               rounded


### PR DESCRIPTION
## Summary
On the download page, the highlighted download row used a fixed `h-[42px]`. On Linux the row renders two buttons (AppImage + deb), which wrap to a second line on narrow/mobile viewports. The fixed height clamped the container to one row, so the wrapped second button overflowed and overlapped the "Download for other OSes" link and "Latest Release: <version>" text.

Switching to `min-h-[42px]` lets the row grow to fit wrapped content while preserving the original minimum height when there's only one button.

## Testing
Verified via Chrome DevTools at 375px width:
- **Before:** "Download for LINUX deb" overlapped the other-OS link and version text.
- **After:** both buttons stack cleanly with the version text below — no overlap.