### PR TITLE
refactor(types): replace `as` casts with type-safe alternatives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,21 @@ Follow this order in `<script setup>`:
 
 - If you have to create a ref where there is a possibility for it to be empty, always use `const name = ref<string>()` instead of `const name = ref<string | null>(null)`.
 
+#### Exposing readonly refs — use `shallowReadonly`, not a cast
+
+- When a composable exposes internal state as `Readonly<Ref<T>>`, use `shallowReadonly(ref)`, **not** `readonly(ref) as Readonly<Ref<T>>`.
+- `readonly()` returns `DeepReadonly<UnwrapNestedRefs<T>>`, which does not match `Readonly<Ref<T>>` (it also deep-freezes array/object elements, breaking consumers that assign to a mutable `T[]`). That mismatch is what forces the `as` cast.
+- `shallowReadonly<T>(target): Readonly<T>` returns the plain TS `Readonly<T>` — so `shallowReadonly(ref)` is exactly `Readonly<Ref<T>>` with no cast and no deep-freezing.
+- Do **not** wrap in `computed(() => get(ref))` just to get the readonly shape — `ComputedRef` carries extra internal brand and adds caching overhead for no benefit here.
+
+  ```typescript
+  // ✅ Correct
+  return { items: shallowReadonly(items) };
+
+  // ❌ Incorrect — cast hides the DeepReadonly mismatch (and can silently strip `| null`)
+  return { items: readonly(items) as Readonly<Ref<Item[]>> };
+  ```
+
 #### Correct Examples:
 
 ```typescript

--- a/packages/sigil/src/case.ts
+++ b/packages/sigil/src/case.ts
@@ -1,29 +1,6 @@
-// Typed camelCase → snake_case key conversion.
+// camelCase → snake_case key conversion.
 // Used at tracking boundaries so payload interfaces stay camelCase (matching
 // the codebase convention) while the analytics layer receives snake_case keys.
-
-/**
- * Convert a camelCase string literal to snake_case at the type level.
- *
- * Examples:
- *   CamelToSnakeCase<'paymentMethod'>  → 'payment_method'
- *   CamelToSnakeCase<'planId'>         → 'plan_id'
- *   CamelToSnakeCase<'isUpgrade'>      → 'is_upgrade'
- *   CamelToSnakeCase<'currency'>       → 'currency'
- */
-export type CamelToSnakeCase<S extends string> =
-  S extends `${infer Head}${infer Tail}`
-    ? Tail extends Uncapitalize<Tail>
-      ? `${Lowercase<Head>}${CamelToSnakeCase<Tail>}`
-      : `${Lowercase<Head>}_${CamelToSnakeCase<Tail>}`
-    : S;
-
-/**
- * Map every key of `T` from camelCase to snake_case, preserving value types.
- */
-export type SnakeCaseKeys<T> = {
-  [K in keyof T as K extends string ? CamelToSnakeCase<K> : K]: T[K];
-};
 
 /**
  * Convert a single camelCase string to snake_case at runtime.
@@ -35,11 +12,15 @@ function camelToSnake(str: string): string {
 /**
  * Convert all keys of a flat object from camelCase to snake_case.
  * Returns a new object — the input is not mutated.
+ *
+ * The return type is intentionally the loose `Record<string, unknown>`: every
+ * consumer (sigilTrack/buildTrackedEventData/JSON.stringify) only needs that, so
+ * there is no reason to assert a precise mapped type the runtime can't verify.
  */
-export function toSnakeCaseKeys<T extends object>(obj: T): SnakeCaseKeys<T> {
+export function toSnakeCaseKeys<T extends object>(obj: T): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     result[camelToSnake(key)] = value;
   }
-  return result as SnakeCaseKeys<T>;
+  return result;
 }

--- a/packages/sigil/src/failures.ts
+++ b/packages/sigil/src/failures.ts
@@ -29,16 +29,32 @@ export type PaymentFailedReason = EnumValueOf<typeof PaymentFailures>['reason'];
 
 export type PaymentServerEvent = EnumValueOf<typeof PaymentFailures>['serverEvent'];
 
-// Convenience: key → serverEvent string, preserving literal types.
-export const PaymentServerEvents = Object.fromEntries(
-  (Object.entries(PaymentFailures) as [PaymentFailureKey, (typeof PaymentFailures)[PaymentFailureKey]][])
-    .map(([k, v]) => [k, v.serverEvent]),
-) as { [K in PaymentFailureKey]: (typeof PaymentFailures)[K]['serverEvent'] };
+// Convenience: key → serverEvent string, preserving literal types. Built as an
+// explicit literal (values derived from PaymentFailures, so no string duplication)
+// so the precise per-key type is inferred with no assertion. `satisfies` enforces
+// that every PaymentFailureKey is present — adding an entry above without adding it
+// here is a compile error.
+export const PaymentServerEvents = {
+  BRAINTREE_INIT_FAILED: PaymentFailures.BRAINTREE_INIT_FAILED.serverEvent,
+  THREE_DS_VERIFICATION_FAILED: PaymentFailures.THREE_DS_VERIFICATION_FAILED.serverEvent,
+  THREE_DS_LIABILITY_SHIFT_FAILED: PaymentFailures.THREE_DS_LIABILITY_SHIFT_FAILED.serverEvent,
+  CARD_PAYMENT_API_ERROR: PaymentFailures.CARD_PAYMENT_API_ERROR.serverEvent,
+  PAYPAL_SDK_INIT_FAILED: PaymentFailures.PAYPAL_SDK_INIT_FAILED.serverEvent,
+  PAYPAL_PAYMENT_ERROR: PaymentFailures.PAYPAL_PAYMENT_ERROR.serverEvent,
+  PAYPAL_SUBMIT_ERROR: PaymentFailures.PAYPAL_SUBMIT_ERROR.serverEvent,
+  CRYPTO_WALLET_NOT_CONNECTED: PaymentFailures.CRYPTO_WALLET_NOT_CONNECTED.serverEvent,
+  CRYPTO_WRONG_CHAIN: PaymentFailures.CRYPTO_WRONG_CHAIN.serverEvent,
+  CRYPTO_INSUFFICIENT_FUNDS: PaymentFailures.CRYPTO_INSUFFICIENT_FUNDS.serverEvent,
+  CRYPTO_USER_REJECTED: PaymentFailures.CRYPTO_USER_REJECTED.serverEvent,
+  CRYPTO_TX_FAILED: PaymentFailures.CRYPTO_TX_FAILED.serverEvent,
+  CRYPTO_PAYMENT_API_ERROR: PaymentFailures.CRYPTO_PAYMENT_API_ERROR.serverEvent,
+  CHECKOUT_ERROR: PaymentFailures.CHECKOUT_ERROR.serverEvent,
+} satisfies Record<PaymentFailureKey, PaymentServerEvent>;
 
 const SERVER_EVENT_TO_REASON: Readonly<Record<string, PaymentFailedReason>> = Object.freeze(
   Object.fromEntries(
-    Object.values(PaymentFailures).map(entry => [entry.serverEvent, entry.reason]),
-  ) as Record<string, PaymentFailedReason>,
+    Object.values(PaymentFailures).map((entry): [string, PaymentFailedReason] => [entry.serverEvent, entry.reason]),
+  ),
 );
 
 /**
@@ -63,7 +79,7 @@ interface CryptoErrorShape {
  * the function only duck-types the error.
  */
 export function classifyCryptoTxError(error: unknown): PaymentFailureKey {
-  const err = (error ?? {}) as CryptoErrorShape;
+  const err: CryptoErrorShape = typeof error === 'object' && error !== null ? error : {};
   const code = err.code;
 
   if (code === 'ACTION_REJECTED' || code === 4001)

--- a/packages/sigil/src/index.spec.ts
+++ b/packages/sigil/src/index.spec.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildTrackedEventData,
-  type CamelToSnakeCase,
   classifyCryptoTxError,
   createTrackingSession,
   monthsToPlanDuration,
@@ -15,7 +14,6 @@ import {
   reasonForServerEvent,
   type SigilEventPayloadMap,
   SigilEvents,
-  type SnakeCaseKeys,
   toSnakeCaseKeys,
   type TrackingSession,
 } from './index';
@@ -42,9 +40,10 @@ describe('monthsToPlanDuration', () => {
 
 describe('payment failure catalog', () => {
   it('derives server event strings that match the catalog entries', () => {
-    for (const [key, entry] of Object.entries(PaymentFailures)) {
-      expect(PaymentServerEvents[key as keyof typeof PaymentFailures]).toBe(entry.serverEvent);
-    }
+    const expected = Object.fromEntries(
+      Object.entries(PaymentFailures).map(([key, entry]) => [key, entry.serverEvent]),
+    );
+    expect(PaymentServerEvents).toEqual(expected);
   });
 
   it('round-trips server event → reason for every entry', () => {
@@ -310,7 +309,7 @@ describe('buildTrackedEventData', () => {
 });
 
 describe('postPaymentLog', () => {
-  const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+  const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
 
   beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock);
@@ -332,14 +331,14 @@ describe('postPaymentLog', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
     expect(url).toBe(PAYMENT_LOG_ENDPOINT);
-    expect(init.method).toBe('POST');
-    expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
-    expect(init.keepalive).toBe(true);
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(init?.keepalive).toBe(true);
 
     // Verify the body is sent with snake_case keys
-    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const body: Record<string, unknown> = JSON.parse(String(init?.body));
     expect(body.payment_method).toBe('card');
     expect(body.error_message).toBe('oops');
     expect(body.plan_id).toBe(42);
@@ -356,8 +355,8 @@ describe('postPaymentLog', () => {
     });
     const after = Date.now();
 
-    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-    const body = JSON.parse(init.body as string) as { timestamp: number; payment_method: string; event: string };
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body: { timestamp: number; payment_method: string; event: string } = JSON.parse(String(init?.body));
     expect(body.timestamp).toBeGreaterThanOrEqual(before);
     expect(body.timestamp).toBeLessThanOrEqual(after);
     expect(body.payment_method).toBe('paypal');
@@ -444,30 +443,6 @@ describe('toSnakeCaseKeys', () => {
     const input = { planId: 42, isUpgrade: false };
     toSnakeCaseKeys(input);
     expect(input).toEqual({ planId: 42, isUpgrade: false });
-  });
-
-  it('produces correct types at compile time', () => {
-    // These type assertions verify the CamelToSnakeCase utility type works correctly.
-    const checkPaymentMethod: CamelToSnakeCase<'paymentMethod'> = 'payment_method';
-    const checkPlanId: CamelToSnakeCase<'planId'> = 'plan_id';
-    const checkIsUpgrade: CamelToSnakeCase<'isUpgrade'> = 'is_upgrade';
-    const checkCurrency: CamelToSnakeCase<'currency'> = 'currency';
-    const checkFromPlanName: CamelToSnakeCase<'fromPlanName'> = 'from_plan_name';
-
-    // Mapped type check
-    interface Input { paymentMethod: string; planId: number; isUpgrade: boolean }
-    const mapped: SnakeCaseKeys<Input> = {
-      payment_method: 'card',
-      plan_id: 42,
-      is_upgrade: true,
-    };
-
-    expect(checkPaymentMethod).toBe('payment_method');
-    expect(checkPlanId).toBe('plan_id');
-    expect(checkIsUpgrade).toBe('is_upgrade');
-    expect(checkCurrency).toBe('currency');
-    expect(checkFromPlanName).toBe('from_plan_name');
-    expect(mapped.payment_method).toBe('card');
   });
 
   it('converts all PaymentLogPayload keys correctly', () => {

--- a/packages/website/app/components/account/activation/AccountActivate.vue
+++ b/packages/website/app/components/account/activation/AccountActivate.vue
@@ -8,14 +8,15 @@ import { useAccountRefresh } from '~/composables/use-app-events';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { useRedirectUrl } from '~/composables/use-redirect-url';
 import { useMainStore } from '~/store';
+import { getSingleRouteParam } from '~/utils/query';
 import { getSafeRedirectUrl } from '~/utils/redirect';
 import { useLogger } from '~/utils/use-logger';
 
 const { t } = useI18n({ useScope: 'global' });
 const route = useRoute();
 
-const uid = route.params.uid as string;
-const token = route.params.token as string;
+const uid = getSingleRouteParam(route.params.uid);
+const token = getSingleRouteParam(route.params.token);
 
 const validating = ref<boolean>(true);
 const isValid = ref<boolean>(false);

--- a/packages/website/app/components/account/home/PremiumPlaceholder.vue
+++ b/packages/website/app/components/account/home/PremiumPlaceholder.vue
@@ -36,7 +36,7 @@ const suggestedTier = computed<PremiumTierInfo | undefined>(() => {
 
 const monthlyPrice = computed<string | undefined>(() => get(suggestedTier)?.monthlyPlan?.price);
 
-const features = computed<PremiumTierInfoDescription[]>(() => get(suggestedTier)?.description.slice(0, 4) || []);
+const features = computed<PremiumTierInfoDescription[]>(() => get(suggestedTier)?.description?.slice(0, 4) || []);
 
 const [DefineFeaturesSkeleton, ReuseFeaturesSkeleton] = createReusableTemplate();
 </script>

--- a/packages/website/app/components/account/login/LoginForm.vue
+++ b/packages/website/app/components/account/login/LoginForm.vue
@@ -6,6 +6,7 @@ import { get, set } from '@vueuse/shared';
 import ButtonLink from '~/components/common/ButtonLink.vue';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useMainStore } from '~/store';
+import { getSingleRouteParam } from '~/utils/query';
 import { getSafeRedirectUrl } from '~/utils/redirect';
 
 const username = ref<string>('');
@@ -53,9 +54,9 @@ async function performLogin() {
 
   if (!get(error)) {
     chronicle(SigilEvents.LOGIN_COMPLETED, {});
-    const { redirectUrl } = route.query;
+    const redirectUrl = getSingleRouteParam(route.query.redirectUrl);
     if (redirectUrl)
-      window.location.href = getSafeRedirectUrl(redirectUrl as string);
+      window.location.href = getSafeRedirectUrl(redirectUrl);
     else
       await navigateTo('/home/subscription');
   }

--- a/packages/website/app/components/account/signup/SignupForm.vue
+++ b/packages/website/app/components/account/signup/SignupForm.vue
@@ -18,6 +18,7 @@ import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { useRecaptcha } from '~/composables/use-recaptcha';
 import { useRedirectUrl } from '~/composables/use-redirect-url';
+import { getSingleRouteParam } from '~/utils/query';
 import { getSafeRedirectUrl } from '~/utils/redirect';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -103,9 +104,9 @@ async function signup({
     });
     if (result) {
       chronicle(SigilEvents.SIGNUP_COMPLETED, {});
-      const { redirectUrl } = route.query;
+      const redirectUrl = getSingleRouteParam(route.query.redirectUrl);
       if (redirectUrl) {
-        const safeUrl = getSafeRedirectUrl(redirectUrl as string);
+        const safeUrl = getSafeRedirectUrl(redirectUrl);
         if (safeUrl !== '/home/subscription')
           saveRedirectUrl(payload.username, safeUrl);
       }

--- a/packages/website/app/components/integration/IntegrationDetails.vue
+++ b/packages/website/app/components/integration/IntegrationDetails.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { get, set } from '@vueuse/shared';
+import { z } from 'zod';
 import { useIntegrationsData } from '~/composables/use-integrations-data';
 import { integrationSlug } from '~/utils/integration-slug';
+import { parseRouteParam } from '~/utils/query';
 
 enum TabCategory {
   ALL = 'all',
@@ -20,8 +22,8 @@ const route = useRoute();
 
 // Set initial tab based on URL hash
 onMounted(() => {
-  const hash = get(route).hash?.replace('#', '') as TabCategory;
-  if (hash && Object.values(TabCategory).includes(hash)) {
+  const hash = parseRouteParam(get(route).hash?.replace('#', ''), z.nativeEnum(TabCategory));
+  if (hash) {
     set(tab, hash);
     router.replace({ hash: '' });
   }

--- a/packages/website/app/components/jobs/JobDetail.vue
+++ b/packages/website/app/components/jobs/JobDetail.vue
@@ -9,10 +9,14 @@ const { data } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
+function isMinimarkTree(value: unknown): value is MinimarkTree {
+  return typeof value === 'object' && value !== null && 'type' in value && value.type === 'minimark';
+}
+
 function filterBy(filterMethod: (tag: string) => boolean) {
   return computed(() => {
-    const body = data.body as any as MinimarkTree;
-    assert(body.type === 'minimark');
+    const { body } = data;
+    assert(isMinimarkTree(body));
 
     const elements = body.value.filter(node => filterMethod(node[0]));
 

--- a/packages/website/app/components/oauth/OAuthPage.vue
+++ b/packages/website/app/components/oauth/OAuthPage.vue
@@ -27,6 +27,11 @@ defineSlots<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+function selectText(event: MouseEvent): void {
+  if (event.target instanceof HTMLTextAreaElement)
+    event.target.select();
+}
 </script>
 
 <template>
@@ -73,7 +78,7 @@ const { t } = useI18n({ useScope: 'global' });
             variant="outlined"
             color="primary"
             rows="4"
-            @click="($event.target as HTMLTextAreaElement).select()"
+            @click="selectText($event)"
           >
             <template #append>
               <CopyButton :model-value="accessToken" />
@@ -87,7 +92,7 @@ const { t } = useI18n({ useScope: 'global' });
             variant="outlined"
             color="primary"
             rows="4"
-            @click="($event.target as HTMLTextAreaElement).select()"
+            @click="selectText($event)"
           >
             <template #append>
               <CopyButton :model-value="refreshToken" />

--- a/packages/website/app/components/sponsor/ImageUploadPreview.vue
+++ b/packages/website/app/components/sponsor/ImageUploadPreview.vue
@@ -16,7 +16,10 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 function handleImageChange(event: Event): void {
-  const target = event.target as HTMLInputElement;
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement))
+    return;
+
   const file = target.files?.[0];
   if (file) {
     emit('file-selected', file);

--- a/packages/website/app/components/sponsor/NftSubmissionForm.vue
+++ b/packages/website/app/components/sponsor/NftSubmissionForm.vue
@@ -13,6 +13,7 @@ import { useSponsorshipData } from '~/composables/rotki-sponsorship/use-sponsors
 import { findTierById } from '~/composables/rotki-sponsorship/utils';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { getTierClasses } from '~/utils/nft-tiers';
+import { getSingleRouteParam } from '~/utils/query';
 import { useLogger } from '~/utils/use-logger';
 import { toMessages } from '~/utils/validation';
 
@@ -161,7 +162,8 @@ function handleImageSelected(file: File): void {
   // Create preview
   const reader = new FileReader();
   reader.onloadend = () => {
-    set(imagePreview, reader.result as string);
+    if (typeof reader.result === 'string')
+      set(imagePreview, reader.result);
   };
   reader.readAsDataURL(file);
 }
@@ -443,7 +445,7 @@ watch(() => editingSubmission, (submission) => {
 }, { immediate: true });
 
 onMounted(() => {
-  const tokenIdParam = route.query.tokenId as string;
+  const tokenIdParam = getSingleRouteParam(route.query.tokenId);
   if (tokenIdParam && !editingSubmission) {
     set(tokenId, tokenIdParam);
     checkNftMetadata();

--- a/packages/website/app/composables/account/use-profile-update.ts
+++ b/packages/website/app/composables/account/use-profile-update.ts
@@ -45,7 +45,7 @@ export function useProfileUpdate() {
         ...state,
       },
       omitFields,
-    ) as ProfilePayload;
+    );
 
     const result = await accountApi.updateProfile(payload);
 

--- a/packages/website/app/composables/account/use-user-devices.ts
+++ b/packages/website/app/composables/account/use-user-devices.ts
@@ -80,6 +80,6 @@ export function useUserDevices(): UseUserDevicesReturn {
     loading: readonly(loading),
     refresh,
     renameDevice,
-    userDevices: readonly(userDevices) as Readonly<Ref<UserDevice[]>>,
+    userDevices: shallowReadonly(userDevices),
   };
 }

--- a/packages/website/app/composables/account/use-user-payments.ts
+++ b/packages/website/app/composables/account/use-user-payments.ts
@@ -44,6 +44,6 @@ export function useUserPayments(): UseUserPaymentsReturn {
   return {
     loading: readonly(loading),
     refresh,
-    userPayments: readonly(userPayments) as Readonly<Ref<UserPayment[]>>,
+    userPayments: shallowReadonly(userPayments),
   };
 }

--- a/packages/website/app/composables/chronicling/use-utm-tracking.ts
+++ b/packages/website/app/composables/chronicling/use-utm-tracking.ts
@@ -15,7 +15,7 @@ export function useUtmTracking() {
       return;
 
     const route = useRoute();
-    const utm = parseUtmFromQuery(route.query as Record<string, unknown>);
+    const utm = parseUtmFromQuery(route.query);
     const hasUtm = Object.values(utm).some(v => !!v);
 
     set(utmCookie, createTrackingSession({

--- a/packages/website/app/composables/rotki-sponsorship/use-payment.ts
+++ b/packages/website/app/composables/rotki-sponsorship/use-payment.ts
@@ -227,7 +227,7 @@ export function useRotkiSponsorshipPayment() {
           try {
             const parsedLog = contract.interface.parseLog({
               data: log.data,
-              topics: log.topics as string[],
+              topics: [...log.topics],
             });
 
             if (parsedLog?.name === 'NFTMinted' && parsedLog.args.minter.toLowerCase() === get(address)?.toLowerCase()) {

--- a/packages/website/app/composables/subscription/use-user-subscriptions.ts
+++ b/packages/website/app/composables/subscription/use-user-subscriptions.ts
@@ -94,6 +94,6 @@ export function useUserSubscriptions(): UseUserSubscriptionsReturn {
     initialLoading: readonly(initialLoading),
     loading: readonly(loading),
     refresh,
-    userSubscriptions: readonly(userSubscriptions) as Readonly<Ref<UserSubscription[]>>,
+    userSubscriptions: shallowReadonly(userSubscriptions),
   };
 }

--- a/packages/website/app/composables/web3/use-web3-connection.ts
+++ b/packages/website/app/composables/web3/use-web3-connection.ts
@@ -1,9 +1,10 @@
 import type { AppKit } from '@reown/appkit';
 import type { AppKitNetwork } from '@reown/appkit/networks';
-import type { Signer } from 'ethers';
+import type { Eip1193Provider, Signer } from 'ethers';
 import { get, set } from '@vueuse/shared';
 import { useAppConfig } from '~/composables/use-app-config';
 import { useSharedWeb3State } from '~/composables/web3/use-shared-web3-state';
+import { assert } from '~/utils/assert';
 import { useLogger } from '~/utils/use-logger';
 
 // Lazy-loaded module cache
@@ -198,8 +199,9 @@ export function useWeb3Connection(config: Web3ConnectionConfig = {}) {
   async function getBrowserProvider(): Promise<InstanceType<typeof import('ethers/providers').BrowserProvider>> {
     const appKit = await ensureInitialized();
     const { BrowserProvider } = await import('ethers/providers');
-    const walletProvider = appKit.getProvider('eip155');
-    return new BrowserProvider(walletProvider as any);
+    const walletProvider = appKit.getProvider<Eip1193Provider>('eip155');
+    assert(walletProvider, 'No EIP-1193 wallet provider available');
+    return new BrowserProvider(walletProvider);
   }
 
   function getNetwork(networkChainId?: number): AppKitNetwork | undefined {

--- a/packages/website/app/middleware/valid-plan-id.ts
+++ b/packages/website/app/middleware/valid-plan-id.ts
@@ -1,5 +1,7 @@
 import { get } from '@vueuse/shared';
+import { z } from 'zod';
 import { useAvailablePlans } from '~/composables/tiers/use-available-plans';
+import { parseRouteParam } from '~/utils/query';
 
 export default defineNuxtRouteMiddleware(async (to) => {
   const { availablePlans, execute } = useAvailablePlans();
@@ -14,7 +16,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
   }
 
   // Get planId from the route query directly
-  const currentPlanId = to.query.planId ? Number.parseInt(to.query.planId as string) : undefined;
+  const currentPlanId = parseRouteParam(to.query.planId, z.coerce.number().int().positive());
 
   // If planId doesn't exist in route params, redirect to checkout
   if (!currentPlanId) {

--- a/packages/website/app/modules/checkout/composables/use-crypto-payment.ts
+++ b/packages/website/app/modules/checkout/composables/use-crypto-payment.ts
@@ -133,7 +133,10 @@ export function useWeb3Payment(data: MaybeRefOrGetter<CryptoPayment>, options: U
       const transfer = contract.transfer;
       if (!transfer)
         throw new Error('Token contract does not support transfer');
-      tx = await (transfer(to, value) as Promise<TransactionResponse>);
+      // `.send()` is the typed entrypoint for a state-changing method: it returns
+      // `Promise<ContractTransactionResponse>` (a `TransactionResponse`), whereas calling
+      // the method proxy directly is typed `Promise<any>` and forces a cast.
+      tx = await transfer.send(to, value);
     }
 
     logger.info(`transaction is pending: ${tx.hash}`);

--- a/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
+++ b/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
@@ -31,6 +31,13 @@ interface PaypalButtonActions {
   disable: () => void;
 }
 
+// The PayPal SDK types the `onInit` `actions` argument as a bare `object`, so narrow
+// it to the enable/disable shape we use via a guard instead of asserting.
+function isPaypalButtonActions(value: object): value is PaypalButtonActions {
+  return 'enable' in value && typeof value.enable === 'function'
+    && 'disable' in value && typeof value.disable === 'function';
+}
+
 interface PaypalButtonCallbacks {
   onPaymentStart: () => void;
   onPaymentSuccess: (nonce: string) => void;
@@ -158,7 +165,7 @@ export function usePaypalPaymentFlow(options: UsePaypalPaymentFlowOptions = {}):
         set(paying, true);
         callbacks.onPaymentStart();
         return btPayPalCheckoutInstance!.createPayment({
-          flow: 'vault' as any,
+          flow: 'vault',
           amount: get(currentAmount),
           currency: 'EUR',
         });
@@ -205,8 +212,11 @@ export function usePaypalPaymentFlow(options: UsePaypalPaymentFlowOptions = {}):
         callbacks.onPaymentCancel();
       },
       onInit: (_, actions) => {
-        set(paypalActions, actions as PaypalButtonActions);
-        (actions as PaypalButtonActions).disable();
+        if (!isPaypalButtonActions(actions))
+          return;
+
+        set(paypalActions, actions);
+        actions.disable();
       },
     }).render('#paypal-button');
 

--- a/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
@@ -203,7 +203,7 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
         return payEvent;
       }
       else {
-        const status = (threeDSecureInfo as any)?.status as string | undefined;
+        const { status } = threeDSecureInfo;
         const errorMsg = `Authentication failed${status ? `: ${status.replaceAll('_', ' ')}` : ''}`;
 
         set(error, errorMsg);

--- a/packages/website/app/pages/oauth/monerium.vue
+++ b/packages/website/app/pages/oauth/monerium.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import type {
-  OAuthStateWithStorage,
-  OAuthTokenResponse,
-} from '~/types/oauth';
 import { get, set } from '@vueuse/shared';
 import OAuthPage from '~/components/oauth/OAuthPage.vue';
 import { useOAuth } from '~/composables/account/use-oauth';
 import { usePkce } from '~/composables/account/use-pkce';
 import { usePageSeoNoIndex } from '~/composables/use-page-seo';
+import {
+  type OAuthStateWithStorage,
+  OAuthStateWithStorageSchema,
+  type OAuthTokenResponse,
+} from '~/types/oauth';
 import { removeTrailingSlash } from '~/utils/text';
 import { useLogger } from '~/utils/use-logger';
 
@@ -107,7 +108,7 @@ async function handleMoneriumAuth() {
 }
 
 function parseState(stateString: string): OAuthStateWithStorage {
-  return JSON.parse(atob(stateString)) as OAuthStateWithStorage;
+  return OAuthStateWithStorageSchema.parse(JSON.parse(atob(stateString)));
 }
 
 async function exchangeCodeForToken(code: string, redirectUri: string, codeVerifier: string): Promise<OAuthTokenResponse> {

--- a/packages/website/app/pages/sponsor/mint.vue
+++ b/packages/website/app/pages/sponsor/mint.vue
@@ -161,7 +161,7 @@ const availableTokens = computed<PaymentToken[]>(() =>
 
     // Check if at least one tier has a non-zero price
     return SPONSORSHIP_TIERS.some((tier) => {
-      const price = token.prices[tier.key as TierKey];
+      const price = token.prices[tier.key];
       return price && parseFloat(price) > 0;
     });
   }),
@@ -213,7 +213,7 @@ const needsApproval = computed<boolean>(() => {
   if (!token || token.address === ETH_ADDRESS)
     return false;
 
-  const price = token.prices[selectedTierKey as TierKey];
+  const price = token.prices[selectedTierKey];
   const allowance = get(tokenAllowance);
 
   // Check if allowance is less than required price

--- a/packages/website/app/types/oauth.ts
+++ b/packages/website/app/types/oauth.ts
@@ -1,4 +1,8 @@
-export type OAuthMode = 'app' | 'docker';
+import { z } from 'zod';
+
+const OAuthModeSchema = z.enum(['app', 'docker']);
+
+export type OAuthMode = z.infer<typeof OAuthModeSchema>;
 
 export interface OAuthTokenResponse {
   access_token: string;
@@ -7,14 +11,18 @@ export interface OAuthTokenResponse {
   token_type?: string;
 }
 
-interface OAuthState {
-  mode: OAuthMode;
-  timestamp: number;
-}
+/**
+ * Shape of the OAuth `state` payload we round-trip through the provider. It is
+ * attacker-controllable by the time it comes back, so it must be validated at
+ * the boundary rather than cast — see `parseState` in the monerium page.
+ */
+export const OAuthStateWithStorageSchema = z.object({
+  mode: OAuthModeSchema,
+  timestamp: z.number(),
+  storageKey: z.string(),
+});
 
-export interface OAuthStateWithStorage extends OAuthState {
-  storageKey: string;
-}
+export type OAuthStateWithStorage = z.infer<typeof OAuthStateWithStorageSchema>;
 
 export interface OAuthCallbackParams {
   code: string;

--- a/packages/website/app/types/tiers.ts
+++ b/packages/website/app/types/tiers.ts
@@ -13,7 +13,10 @@ export const PremiumTierInfoDescription = z.object({
 export type PremiumTierInfoDescription = z.infer<typeof PremiumTierInfoDescription>;
 
 export const PremiumTierInfo = z.object({
-  description: z.array(PremiumTierInfoDescription),
+  // Optional: the backend may omit `description` for a tier. Keeping it required
+  // made `PremiumTiersInfoSchema.safeParse` reject the whole response (falling back
+  // to defaults) whenever any tier lacked one — `parseTiersInfo` already skips such tiers.
+  description: z.array(PremiumTierInfoDescription).optional(),
   limits: z.record(z.string(), z.union([z.boolean(), z.number()])),
   monthlyPlan: PremiumTierPlan,
   name: z.string(),

--- a/packages/website/app/utils/query.ts
+++ b/packages/website/app/utils/query.ts
@@ -1,3 +1,36 @@
+import type { LocationQueryValue, RouteParamValue } from 'vue-router';
+import type { ZodType } from 'zod';
+
+type RouteValue = RouteParamValue | RouteParamValue[] | LocationQueryValue | LocationQueryValue[] | undefined;
+
+/**
+ * Extracts a single non-empty string from a route param or query value.
+ *
+ * Vue Router types params/query as `string | string[]` (query also allows
+ * `null`), so reading a single value normally requires an unchecked `as string`
+ * cast. This narrows safely instead: arrays collapse to their first entry, and
+ * anything that is not a non-empty string yields `undefined`.
+ *
+ * Use this for opaque string params (ids, tokens, redirect urls). For params
+ * with a shape to validate (numbers, enums) use {@link parseRouteParam}.
+ */
+export function getSingleRouteParam(value: RouteValue): string | undefined {
+  const single = Array.isArray(value) ? value[0] : value;
+  return typeof single === 'string' && single.length > 0 ? single : undefined;
+}
+
+/**
+ * Normalizes a route value to a single string and validates it against a Zod
+ * schema, returning the parsed value or `undefined` when it is absent/invalid.
+ *
+ * Prefer this over `Number.parseInt(value as string)` or `value as SomeEnum`:
+ * the schema both narrows the type and rejects malformed input at the boundary.
+ */
+export function parseRouteParam<T>(value: RouteValue, schema: ZodType<T>): T | undefined {
+  const result = schema.safeParse(getSingleRouteParam(value));
+  return result.success ? result.data : undefined;
+}
+
 /**
  * Builds query parameters from an object, filtering out null, undefined, and empty string values
  * @param params - Object containing potential query parameters

--- a/packages/website/content.config.ts
+++ b/packages/website/content.config.ts
@@ -1,6 +1,7 @@
 import { defineCollection, defineContentConfig, z } from '@nuxt/content';
 import { defineRobotsSchema } from '@nuxtjs/robots/content';
 import { defineSitemapSchema } from '@nuxtjs/sitemap/content';
+import { comparisonSchema, featureSchema, integrationSchema } from './shared/content-schemas';
 
 const DOCUMENTS = 'content/documents/*.md';
 const JOBS = 'content/jobs/*.md';
@@ -42,74 +43,6 @@ const sponsorshipTierSchema = z.object({
   tier: z.enum(['bronze', 'silver', 'gold']),
 });
 
-const integrationSchema = z.object({
-  slug: z.string(),
-  label: z.string(),
-  type: z.enum(['exchange', 'blockchain', 'protocol']),
-  image: z.string(),
-  tagline: z.string().optional(),
-  intro: z.string(),
-  // SERP/meta description (<160 chars). Kept separate from `intro` so the
-  // visible intro paragraph can stay longer than the meta description allows.
-  metaDescription: z.string(),
-  features: z.array(z.string()).default([]),
-  limitations: z.array(z.string()).default([]),
-  setup: z.array(z.string()).default([]),
-  screenshots: z.array(z.object({
-    src: z.string(),
-    alt: z.string(),
-  })).default([]),
-  faq: z.array(z.object({
-    q: z.string(),
-    a: z.string(),
-  })).default([]),
-  keywords: z.string().optional(),
-  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
-  isExchangeWithKey: z.boolean().optional(),
-});
-
-const comparisonSchema = z.object({
-  slug: z.string(),
-  competitor: z.string(),
-  competitorUrl: z.string().optional(),
-  image: z.string(),
-  tagline: z.string(),
-  intro: z.string(),
-  // SERP/meta description (<160 chars). Kept separate from `intro` so the
-  // visible intro paragraph can stay longer than the meta description allows.
-  metaDescription: z.string(),
-  keywords: z.string().optional(),
-  // Short, scannable summary bullets shown near the top of the page.
-  keyTakeaways: z.array(z.string()).default([]),
-  // One-paragraph summary shown near the top and reused for the verdict block.
-  verdict: z.string(),
-  // Side-by-side table rows. rotki is always the left column. `highlight` emphasises
-  // the rows that are most relevant to rotki's positioning (privacy, open source, self-custody).
-  dimensions: z.array(z.object({
-    label: z.string(),
-    rotki: z.string(),
-    competitor: z.string(),
-    highlight: z.boolean().optional(),
-  })).default([]),
-  rotkiAdvantages: z.array(z.string()).default([]),
-  // Cases where the competitor may be a better fit. Shown openly so the comparison stays balanced.
-  tradeoffs: z.array(z.string()).default([]),
-  // "Who rotki is for" bullets, to address switcher intent.
-  whoShouldRotki: z.array(z.string()).default([]),
-  // Links to relevant /integrations/<slug> pages.
-  relatedIntegrations: z.array(z.object({
-    slug: z.string(),
-    label: z.string(),
-  })).default([]),
-  faq: z.array(z.object({
-    q: z.string(),
-    a: z.string(),
-  })).default([]),
-  // Freshness stamp shown on the page (e.g. "Updated June 2026").
-  updatedAt: z.string(),
-  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
-});
-
 // Hub content (intro, takeaways, shared rotki highlights, FAQ) lives in markdown so it
 // is editable alongside the comparison pages rather than in i18n. Only UI labels stay in en.json.
 const comparisonHubSchema = z.object({
@@ -120,61 +53,6 @@ const comparisonHubSchema = z.object({
     q: z.string(),
     a: z.string(),
   })).default([]),
-});
-
-// Feature pages are concept/use-case landing pages (e.g. "CSV import",
-// "local-first crypto accounting"). Modeled on `comparisonSchema` but reshaped
-// for use-case intent: no competitor/dimensions, plus capabilities/setup/troubleshooting.
-const featureSchema = z.object({
-  slug: z.string(),
-  // Short label used in nav/cards/breadcrumb, e.g. "CSV import".
-  label: z.string(),
-  // Optional icon in public/img/features (svg). Index cards fall back to a glyph when absent.
-  icon: z.string().optional(),
-  tagline: z.string(),
-  intro: z.string(),
-  // SERP/meta description (<160 chars). Kept separate from `intro` so the visible
-  // intro paragraph can stay longer than the meta description allows.
-  metaDescription: z.string(),
-  keywords: z.string().optional(),
-  // Scannable "why rotki for X" bullets shown near the top.
-  keyTakeaways: z.array(z.string()).default([]),
-  // What rotki actually does for this use-case.
-  capabilities: z.array(z.string()).default([]),
-  // Honest limits / what rotki does NOT do — avoid overclaiming.
-  limitations: z.array(z.string()).default([]),
-  // Ordered setup steps.
-  setup: z.array(z.string()).default([]),
-  // Common problems and their fixes.
-  troubleshooting: z.array(z.object({
-    problem: z.string(),
-    fix: z.string(),
-  })).default([]),
-  // Cross-links to /integrations/<slug>.
-  relatedIntegrations: z.array(z.object({
-    slug: z.string(),
-    label: z.string(),
-  })).default([]),
-  // Cross-links to /compare/<slug>.
-  relatedComparisons: z.array(z.object({
-    slug: z.string(),
-    label: z.string(),
-  })).default([]),
-  // Cross-links to other /features/<slug> pages.
-  relatedFeatures: z.array(z.object({
-    slug: z.string(),
-    label: z.string(),
-  })).default([]),
-  faq: z.array(z.object({
-    q: z.string(),
-    a: z.string(),
-  })).default([]),
-  // Optional deep link into the user docs (docs.rotki.com) for this use-case.
-  // Rendered as a "read the documentation" link in the deep-dive section.
-  docsUrl: z.string().url().optional(),
-  // Freshness stamp shown on the page (e.g. "June 2026").
-  updatedAt: z.string(),
-  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
 });
 
 // Hub content (intro, takeaways, shared rotki highlights, FAQ) lives in markdown so it

--- a/packages/website/modules/comparison-seo/module.ts
+++ b/packages/website/modules/comparison-seo/module.ts
@@ -1,9 +1,12 @@
+import type { ParsedContentFile } from '@nuxt/content';
 import type { Buffer } from 'node:buffer';
+import type { z } from 'zod';
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineNuxtModule, useLogger } from '@nuxt/kit';
 import { parse as parseYaml } from 'yaml';
+import { comparisonSchema } from '../../shared/content-schemas';
 import { type OgFonts, renderOgImage } from '../integration-seo/og-image';
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
@@ -23,10 +26,11 @@ const moduleDir = dirname(fileURLToPath(import.meta.url));
  *    `/raw/*.md` endpoint expose real content. This does not affect the rendered page.
  */
 
-interface ComparisonFrontmatter {
-  competitor?: string;
-  tagline?: string;
-}
+// Only competitor/tagline are needed for OG cards; pick them off the canonical
+// collection schema (made optional, since this runs before content validation).
+const ComparisonFrontmatterSchema = comparisonSchema.pick({ competitor: true, tagline: true }).partial();
+
+type ComparisonFrontmatter = z.infer<typeof ComparisonFrontmatterSchema>;
 
 // minimark AST node: [tag, props, ...children].
 type MinimarkNode = [string, Record<string, unknown>, ...unknown[]];
@@ -42,6 +46,18 @@ interface ComparisonDoc {
   tradeoffs?: string[];
   faq?: Array<{ q: string; a: string }>;
   body?: { value?: unknown[] };
+}
+
+// Narrow the generic parsed-content shape to this collection's view via a runtime
+// guard (no cast). Requires the two fields the hook actually reads — `intro` and a
+// `body.value` array — so the body-synthesis branch can run; the rest of
+// `ComparisonDoc` is the asserted frontmatter view.
+function isComparisonDoc(
+  content: ParsedContentFile,
+): content is ParsedContentFile & ComparisonDoc & { intro: string; body: { value: unknown[] } } {
+  return typeof content.intro === 'string' && content.intro.length > 0
+    && typeof content.body === 'object' && content.body !== null
+    && 'value' in content.body && Array.isArray(content.body.value);
 }
 
 function listSection(heading: string, items: string[] | undefined): MinimarkNode[] {
@@ -91,7 +107,8 @@ function readFrontmatter(file: string): ComparisonFrontmatter | undefined {
   if (!match?.[1])
     return undefined;
 
-  return parseYaml(match[1]) as ComparisonFrontmatter;
+  const parsed = ComparisonFrontmatterSchema.safeParse(parseYaml(match[1]));
+  return parsed.success ? parsed.data : undefined;
 }
 
 function buildFrontmatterMap(contentDir: string): Map<string, ComparisonFrontmatter> {
@@ -126,10 +143,14 @@ export default defineNuxtModule({
     // Synthesise a markdown body from frontmatter so nuxt-llms (llms-full.txt + /raw)
     // emits real content instead of empty docs.
     nuxt.hook('content:file:afterParse', (ctx) => {
-      const { collection, content: doc } = ctx as unknown as { collection?: string | { name?: string }; content?: ComparisonDoc };
-      const name = typeof collection === 'string' ? collection : collection?.name;
-      if (name !== 'comparisons' || !doc?.intro || !Array.isArray(doc.body?.value))
+      if (ctx.collection.name !== 'comparisons')
         return;
+
+      if (!isComparisonDoc(ctx.content))
+        return;
+
+      // Mutations below write back through the same reference.
+      const doc = ctx.content;
 
       if (doc.competitor)
         doc.title = `rotki vs ${doc.competitor}`;

--- a/packages/website/modules/feature-seo/module.ts
+++ b/packages/website/modules/feature-seo/module.ts
@@ -1,9 +1,12 @@
+import type { ParsedContentFile } from '@nuxt/content';
 import type { Buffer } from 'node:buffer';
+import type { z } from 'zod';
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineNuxtModule, useLogger } from '@nuxt/kit';
 import { parse as parseYaml } from 'yaml';
+import { featureSchema } from '../../shared/content-schemas';
 import { type OgFonts, renderOgImage } from '../integration-seo/og-image';
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
@@ -23,10 +26,11 @@ const moduleDir = dirname(fileURLToPath(import.meta.url));
  *    endpoint expose real content. This does not affect the rendered page.
  */
 
-interface FeatureFrontmatter {
-  label?: string;
-  tagline?: string;
-}
+// Only label/tagline are needed for OG cards; pick them off the canonical
+// collection schema (made optional, since this runs before content validation).
+const FeatureFrontmatterSchema = featureSchema.pick({ label: true, tagline: true }).partial();
+
+type FeatureFrontmatter = z.infer<typeof FeatureFrontmatterSchema>;
 
 // minimark AST node: [tag, props, ...children].
 type MinimarkNode = [string, Record<string, unknown>, ...unknown[]];
@@ -42,6 +46,18 @@ interface FeatureDoc {
   troubleshooting?: Array<{ problem: string; fix: string }>;
   faq?: Array<{ q: string; a: string }>;
   body?: { value?: unknown[] };
+}
+
+// Narrow the generic parsed-content shape to this collection's view via a runtime
+// guard (no cast). Requires the two fields the hook actually reads — `intro` and a
+// `body.value` array — so the body-synthesis branch can run; the rest of `FeatureDoc`
+// is the asserted frontmatter view.
+function isFeatureDoc(
+  content: ParsedContentFile,
+): content is ParsedContentFile & FeatureDoc & { intro: string; body: { value: unknown[] } } {
+  return typeof content.intro === 'string' && content.intro.length > 0
+    && typeof content.body === 'object' && content.body !== null
+    && 'value' in content.body && Array.isArray(content.body.value);
 }
 
 function listSection(heading: string, items: string[] | undefined): MinimarkNode[] {
@@ -88,7 +104,8 @@ function readFrontmatter(file: string): FeatureFrontmatter | undefined {
   if (!match?.[1])
     return undefined;
 
-  return parseYaml(match[1]) as FeatureFrontmatter;
+  const parsed = FeatureFrontmatterSchema.safeParse(parseYaml(match[1]));
+  return parsed.success ? parsed.data : undefined;
 }
 
 function buildFrontmatterMap(contentDir: string): Map<string, FeatureFrontmatter> {
@@ -123,10 +140,14 @@ export default defineNuxtModule({
     // Synthesise a markdown body from frontmatter so nuxt-llms (llms-full.txt + /raw)
     // emits real content instead of empty docs.
     nuxt.hook('content:file:afterParse', (ctx) => {
-      const { collection, content: doc } = ctx as unknown as { collection?: string | { name?: string }; content?: FeatureDoc };
-      const name = typeof collection === 'string' ? collection : collection?.name;
-      if (name !== 'features' || !doc?.intro || !Array.isArray(doc.body?.value))
+      if (ctx.collection.name !== 'features')
         return;
+
+      if (!isFeatureDoc(ctx.content))
+        return;
+
+      // Mutations below write back through the same reference.
+      const doc = ctx.content;
 
       if (doc.label)
         doc.title = doc.label;

--- a/packages/website/modules/integration-images/module.ts
+++ b/packages/website/modules/integration-images/module.ts
@@ -3,16 +3,19 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 import { defineNuxtModule } from '@nuxt/kit';
+import { z } from 'zod';
 
 const CONCURRENCY = 20;
 const MANIFEST_FILE = '.manifest.json';
 
-interface ManifestEntry {
-  etag: string;
-  filename: string;
-}
+const ManifestEntrySchema = z.object({
+  etag: z.string(),
+  filename: z.string(),
+});
 
-type Manifest = Record<string, ManifestEntry>;
+const ManifestSchema = z.record(z.string(), ManifestEntrySchema);
+
+type Manifest = z.infer<typeof ManifestSchema>;
 
 interface DownloadTask {
   url: string;
@@ -32,7 +35,9 @@ async function readManifest(manifestPath: string): Promise<Manifest> {
     return {};
 
   const raw = await readFile(manifestPath, 'utf-8');
-  return JSON.parse(raw) as Manifest;
+  // A corrupt/outdated manifest should just trigger a re-download, not crash the build.
+  const parsed = ManifestSchema.safeParse(JSON.parse(raw));
+  return parsed.success ? parsed.data : {};
 }
 
 async function writeManifest(manifestPath: string, manifest: Manifest): Promise<void> {

--- a/packages/website/modules/integration-seo/module.ts
+++ b/packages/website/modules/integration-seo/module.ts
@@ -1,9 +1,12 @@
+import type { ParsedContentFile } from '@nuxt/content';
 import type { Buffer } from 'node:buffer';
+import type { z } from 'zod';
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineNuxtModule, useLogger } from '@nuxt/kit';
 import { parse as parseYaml } from 'yaml';
+import { integrationSchema } from '../../shared/content-schemas';
 import { type OgFonts, renderOgImage } from './og-image';
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
@@ -24,11 +27,11 @@ const moduleDir = dirname(fileURLToPath(import.meta.url));
  *    rendered page, which reads the frontmatter fields directly.
  */
 
-interface IntegrationFrontmatter {
-  label?: string;
-  type?: 'exchange' | 'blockchain' | 'protocol';
-  tagline?: string;
-}
+// Only label/type/tagline are needed for OG cards; pick them off the canonical
+// collection schema (made optional, since this runs before content validation).
+const IntegrationFrontmatterSchema = integrationSchema.pick({ label: true, type: true, tagline: true }).partial();
+
+type IntegrationFrontmatter = z.infer<typeof IntegrationFrontmatterSchema>;
 
 // minimark AST node: [tag, props, ...children]. Children are loosely typed as
 // `unknown` because a recursive tuple-rest alias isn't allowed in TypeScript.
@@ -45,6 +48,18 @@ interface IntegrationDoc {
   setup?: string[];
   faq?: Array<{ q: string; a: string }>;
   body?: { value?: unknown[] };
+}
+
+// Narrow the generic parsed-content shape to this collection's view via a runtime
+// guard (no cast). Requires the two fields the hook actually reads — `intro` and a
+// `body.value` array — so the body-synthesis branch can run; the rest of
+// `IntegrationDoc` is the asserted frontmatter view.
+function isIntegrationDoc(
+  content: ParsedContentFile,
+): content is ParsedContentFile & IntegrationDoc & { intro: string; body: { value: unknown[] } } {
+  return typeof content.intro === 'string' && content.intro.length > 0
+    && typeof content.body === 'object' && content.body !== null
+    && 'value' in content.body && Array.isArray(content.body.value);
 }
 
 function listSection(heading: string, items: string[] | undefined, tag: 'ul' | 'ol'): MinimarkNode[] {
@@ -89,7 +104,8 @@ function readFrontmatter(file: string): IntegrationFrontmatter | undefined {
   if (!match?.[1])
     return undefined;
 
-  return parseYaml(match[1]) as IntegrationFrontmatter;
+  const parsed = IntegrationFrontmatterSchema.safeParse(parseYaml(match[1]));
+  return parsed.success ? parsed.data : undefined;
 }
 
 function buildFrontmatterMap(contentDir: string): Map<string, IntegrationFrontmatter> {
@@ -124,10 +140,14 @@ export default defineNuxtModule({
     // Synthesise a markdown body from frontmatter so nuxt-llms (llms-full.txt + /raw)
     // emits real content instead of empty docs.
     nuxt.hook('content:file:afterParse', (ctx) => {
-      const { collection, content: doc } = ctx as unknown as { collection?: string | { name?: string }; content?: IntegrationDoc };
-      const name = typeof collection === 'string' ? collection : collection?.name;
-      if (name !== 'integrations' || !doc?.intro || !Array.isArray(doc.body?.value))
+      if (ctx.collection.name !== 'integrations')
         return;
+
+      if (!isIntegrationDoc(ctx.content))
+        return;
+
+      // Mutations below write back through the same reference.
+      const doc = ctx.content;
 
       // Content auto-derives the title as PascalCase of the filename ("Binance Us");
       // prefer the proper label. `description` is unused by integrations — fill it from

--- a/packages/website/modules/integration-seo/og-image.ts
+++ b/packages/website/modules/integration-seo/og-image.ts
@@ -14,98 +14,76 @@ interface OgImageOptions {
   fonts: OgFonts;
 }
 
+type OgStyle = Record<string, string | number>;
+
+type OgChild = OgElement | string;
+
+/**
+ * `ReactElement`-shaped div node satori consumes. We hand-build these instead of
+ * importing React or satori's `satori/jsx` `createElement` (which always wraps
+ * children in an array and so trips satori's flex-layout validation). The explicit
+ * `key` is what makes the literal structurally a `ReactElement`, so it is assignable
+ * to satori's `ReactNode` parameter without a cast.
+ */
+interface OgElement {
+  type: 'div';
+  key: string | null;
+  props: {
+    style: OgStyle;
+    children?: OgChild | OgChild[];
+  };
+}
+
+function el(style: OgStyle, children?: OgChild | OgChild[]): OgElement {
+  return {
+    type: 'div',
+    key: null,
+    props: children === undefined ? { style } : { style, children },
+  };
+}
+
 /**
  * Renders a 1200x630 Open Graph card for an integration using Satori (HTML/flexbox -> SVG)
  * and resvg (SVG -> PNG). Runs at build time inside the prerender hook.
  */
 export async function renderOgImage({ label, tagline, typeLabel, fonts }: OgImageOptions): Promise<Buffer> {
-  const element = {
-    type: 'div',
-    props: {
-      style: {
-        width: '1200px',
-        height: '630px',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'space-between',
-        padding: '80px',
-        backgroundColor: '#faf6f3',
-        fontFamily: 'Roboto',
-      },
-      children: [
-        {
-          type: 'div',
-          props: {
-            style: { display: 'flex' },
-            children: [
-              {
-                type: 'div',
-                props: {
-                  style: {
-                    display: 'flex',
-                    backgroundColor: '#4e352e',
-                    color: '#ffffff',
-                    fontSize: '28px',
-                    fontWeight: 700,
-                    letterSpacing: '2px',
-                    textTransform: 'uppercase',
-                    padding: '10px 26px',
-                    borderRadius: '9999px',
-                  },
-                  children: typeLabel,
-                },
-              },
-            ],
-          },
-        },
-        {
-          type: 'div',
-          props: {
-            style: { display: 'flex', flexDirection: 'column' },
-            children: [
-              {
-                type: 'div',
-                props: {
-                  style: { fontSize: '92px', fontWeight: 700, color: '#2d1e1c', lineHeight: 1.05 },
-                  children: label,
-                },
-              },
-              {
-                type: 'div',
-                props: {
-                  style: { fontSize: '40px', color: '#6b5d57', marginTop: '28px', maxWidth: '1000px', lineHeight: 1.3 },
-                  children: tagline,
-                },
-              },
-            ],
-          },
-        },
-        {
-          type: 'div',
-          props: {
-            style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
-            children: [
-              {
-                type: 'div',
-                props: {
-                  style: { fontSize: '46px', fontWeight: 700, color: '#4e352e' },
-                  children: 'rotki',
-                },
-              },
-              {
-                type: 'div',
-                props: {
-                  style: { display: 'flex', width: '200px', height: '12px', backgroundColor: '#e45325', borderRadius: '9999px' },
-                },
-              },
-            ],
-          },
-        },
-      ],
+  const element = el(
+    {
+      width: '1200px',
+      height: '630px',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      padding: '80px',
+      backgroundColor: '#faf6f3',
+      fontFamily: 'Roboto',
     },
-  };
+    [
+      el({ display: 'flex' }, [
+        el({
+          display: 'flex',
+          backgroundColor: '#4e352e',
+          color: '#ffffff',
+          fontSize: '28px',
+          fontWeight: 700,
+          letterSpacing: '2px',
+          textTransform: 'uppercase',
+          padding: '10px 26px',
+          borderRadius: '9999px',
+        }, typeLabel),
+      ]),
+      el({ display: 'flex', flexDirection: 'column' }, [
+        el({ fontSize: '92px', fontWeight: 700, color: '#2d1e1c', lineHeight: 1.05 }, label),
+        el({ fontSize: '40px', color: '#6b5d57', marginTop: '28px', maxWidth: '1000px', lineHeight: 1.3 }, tagline),
+      ]),
+      el({ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }, [
+        el({ fontSize: '46px', fontWeight: 700, color: '#4e352e' }, 'rotki'),
+        el({ display: 'flex', width: '200px', height: '12px', backgroundColor: '#e45325', borderRadius: '9999px' }),
+      ]),
+    ],
+  );
 
-  const svg = await satori(element as Parameters<typeof satori>[0], {
+  const svg = await satori(element, {
     width: 1200,
     height: 630,
     fonts: [

--- a/packages/website/shared/content-schemas.ts
+++ b/packages/website/shared/content-schemas.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+
+/**
+ * Canonical frontmatter schemas for the SEO content collections.
+ *
+ * These are the single source of truth shared between:
+ * - `content.config.ts`, where they are registered as `@nuxt/content`
+ *   collection schemas (extended with sitemap/robots metadata), and
+ * - the build-time SEO modules (`modules/{feature,integration,comparison}-seo`),
+ *   which read the same frontmatter directly off disk for OG image generation
+ *   and pick the subset they need.
+ *
+ * Keeping them here prevents the module-side schemas from drifting away from the
+ * collection definitions.
+ */
+
+export const integrationSchema = z.object({
+  slug: z.string(),
+  label: z.string(),
+  type: z.enum(['exchange', 'blockchain', 'protocol']),
+  image: z.string(),
+  tagline: z.string().optional(),
+  intro: z.string(),
+  // SERP/meta description (<160 chars). Kept separate from `intro` so the
+  // visible intro paragraph can stay longer than the meta description allows.
+  metaDescription: z.string(),
+  features: z.array(z.string()).default([]),
+  limitations: z.array(z.string()).default([]),
+  setup: z.array(z.string()).default([]),
+  screenshots: z.array(z.object({
+    src: z.string(),
+    alt: z.string(),
+  })).default([]),
+  faq: z.array(z.object({
+    q: z.string(),
+    a: z.string(),
+  })).default([]),
+  keywords: z.string().optional(),
+  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
+  isExchangeWithKey: z.boolean().optional(),
+});
+
+export const comparisonSchema = z.object({
+  slug: z.string(),
+  competitor: z.string(),
+  competitorUrl: z.string().optional(),
+  image: z.string(),
+  tagline: z.string(),
+  intro: z.string(),
+  // SERP/meta description (<160 chars). Kept separate from `intro` so the
+  // visible intro paragraph can stay longer than the meta description allows.
+  metaDescription: z.string(),
+  keywords: z.string().optional(),
+  // Short, scannable summary bullets shown near the top of the page.
+  keyTakeaways: z.array(z.string()).default([]),
+  // One-paragraph summary shown near the top and reused for the verdict block.
+  verdict: z.string(),
+  // Side-by-side table rows. rotki is always the left column. `highlight` emphasises
+  // the rows that are most relevant to rotki's positioning (privacy, open source, self-custody).
+  dimensions: z.array(z.object({
+    label: z.string(),
+    rotki: z.string(),
+    competitor: z.string(),
+    highlight: z.boolean().optional(),
+  })).default([]),
+  rotkiAdvantages: z.array(z.string()).default([]),
+  // Cases where the competitor may be a better fit. Shown openly so the comparison stays balanced.
+  tradeoffs: z.array(z.string()).default([]),
+  // "Who rotki is for" bullets, to address switcher intent.
+  whoShouldRotki: z.array(z.string()).default([]),
+  // Links to relevant /integrations/<slug> pages.
+  relatedIntegrations: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  faq: z.array(z.object({
+    q: z.string(),
+    a: z.string(),
+  })).default([]),
+  // Freshness stamp shown on the page (e.g. "Updated June 2026").
+  updatedAt: z.string(),
+  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
+});
+
+// Feature pages are concept/use-case landing pages (e.g. "CSV import",
+// "local-first crypto accounting"). Modeled on `comparisonSchema` but reshaped
+// for use-case intent: no competitor/dimensions, plus capabilities/setup/troubleshooting.
+export const featureSchema = z.object({
+  slug: z.string(),
+  // Short label used in nav/cards/breadcrumb, e.g. "CSV import".
+  label: z.string(),
+  // Optional icon in public/img/features (svg). Index cards fall back to a glyph when absent.
+  icon: z.string().optional(),
+  tagline: z.string(),
+  intro: z.string(),
+  // SERP/meta description (<160 chars). Kept separate from `intro` so the visible
+  // intro paragraph can stay longer than the meta description allows.
+  metaDescription: z.string(),
+  keywords: z.string().optional(),
+  // Scannable "why rotki for X" bullets shown near the top.
+  keyTakeaways: z.array(z.string()).default([]),
+  // What rotki actually does for this use-case.
+  capabilities: z.array(z.string()).default([]),
+  // Honest limits / what rotki does NOT do — avoid overclaiming.
+  limitations: z.array(z.string()).default([]),
+  // Ordered setup steps.
+  setup: z.array(z.string()).default([]),
+  // Common problems and their fixes.
+  troubleshooting: z.array(z.object({
+    problem: z.string(),
+    fix: z.string(),
+  })).default([]),
+  // Cross-links to /integrations/<slug>.
+  relatedIntegrations: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  // Cross-links to /compare/<slug>.
+  relatedComparisons: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  // Cross-links to other /features/<slug> pages.
+  relatedFeatures: z.array(z.object({
+    slug: z.string(),
+    label: z.string(),
+  })).default([]),
+  faq: z.array(z.object({
+    q: z.string(),
+    a: z.string(),
+  })).default([]),
+  // Optional deep link into the user docs (docs.rotki.com) for this use-case.
+  // Rendered as a "read the documentation" link in the deep-dive section.
+  docsUrl: z.string().url().optional(),
+  // Freshness stamp shown on the page (e.g. "June 2026").
+  updatedAt: z.string(),
+  ctaPlan: z.enum(['free', 'basic', 'advanced']).default('free'),
+});

--- a/packages/website/tests/setup.ts
+++ b/packages/website/tests/setup.ts
@@ -1,6 +1,6 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { createFetch } from 'ofetch';
-import { afterAll, afterEach } from 'vitest';
+import { afterAll, afterEach, vi } from 'vitest';
 import { server } from '~~/tests/mocks/server';
 
 mockNuxtImport('useRuntimeConfig', () => () => {
@@ -35,7 +35,9 @@ server.listen({ onUnhandledRequest: `error` });
 // Nuxt's auto-imported $fetch uses an internal fetch reference that MSW cannot intercept
 // in Vitest v4's Module Runner context. Replace it with a fresh ofetch instance that uses
 // the MSW-patched globalThis.fetch. See: https://github.com/nuxt/test-utils/issues/775
-globalThis.$fetch = createFetch() as typeof globalThis.$fetch;
+// `vi.stubGlobal`'s value is typed `unknown`, so this avoids casting ofetch's
+// `$Fetch` to Nuxt's route-typed `$Fetch` (which aren't assignable).
+vi.stubGlobal('$fetch', createFetch());
 
 afterAll(() => server.close());
 

--- a/packages/website/tests/unit/composables/use-payment-cards.spec.ts
+++ b/packages/website/tests/unit/composables/use-payment-cards.spec.ts
@@ -50,7 +50,7 @@ describe('usePaymentCards', () => {
       const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
       const { addCard } = usePaymentCards();
 
-      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+      await expect(addCard({ paymentMethodNonce: 'nonce' }))
         .rejects
         .toThrow('home.account.payment_methods.errors.rate_limited_failures');
     });
@@ -63,7 +63,7 @@ describe('usePaymentCards', () => {
       const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
       const { addCard } = usePaymentCards();
 
-      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+      await expect(addCard({ paymentMethodNonce: 'nonce' }))
         .rejects
         .toThrow('home.account.payment_methods.errors.rate_limited');
     });
@@ -75,7 +75,7 @@ describe('usePaymentCards', () => {
       const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
       const { addCard } = usePaymentCards();
 
-      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+      await expect(addCard({ paymentMethodNonce: 'nonce' }))
         .rejects
         .toThrow('home.account.payment_methods.errors.rate_limited');
     });
@@ -93,7 +93,7 @@ describe('usePaymentCards', () => {
       const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
       const { addCard } = usePaymentCards();
 
-      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+      await expect(addCard({ paymentMethodNonce: 'nonce' }))
         .rejects
         .toThrow('home.account.payment_methods.errors.card_declined');
     });
@@ -106,7 +106,7 @@ describe('usePaymentCards', () => {
       const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
       const { addCard } = usePaymentCards();
 
-      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+      await expect(addCard({ paymentMethodNonce: 'nonce' }))
         .rejects
         .toThrow('home.account.payment_methods.errors.card_declined');
     });
@@ -121,7 +121,7 @@ describe('usePaymentCards', () => {
       const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
       const { addCard } = usePaymentCards();
 
-      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+      await expect(addCard({ paymentMethodNonce: 'nonce' }))
         .rejects
         .toThrow('Internal failure');
     });
@@ -129,13 +129,13 @@ describe('usePaymentCards', () => {
     it('falls back to common.error_occurred when no message is available', async () => {
       const error = createFetchError(500, undefined);
       // simulate a totally opaque error object
-      delete (error as any).message;
+      Reflect.deleteProperty(error, 'message');
       mockFetchWithCsrf.mockRejectedValueOnce(error);
 
       const { usePaymentCards } = await import('~/modules/checkout/composables/use-payment-cards');
       const { addCard } = usePaymentCards();
 
-      await expect(addCard({ paymentMethodNonce: 'nonce' } as any))
+      await expect(addCard({ paymentMethodNonce: 'nonce' }))
         .rejects
         .toThrow('common.error_occurred');
     });

--- a/packages/website/tests/unit/composables/use-pricing-comparison.spec.ts
+++ b/packages/website/tests/unit/composables/use-pricing-comparison.spec.ts
@@ -143,7 +143,7 @@ describe('parseTiersInfo', () => {
         monthlyPlan: null,
         yearlyPlan: null,
       },
-    ] as PremiumTiersInfo;
+    ] satisfies PremiumTiersInfo;
 
     const result = parseTiersInfo(tiersData);
 

--- a/packages/website/tests/utils.ts
+++ b/packages/website/tests/utils.ts
@@ -4,7 +4,7 @@ import { FetchError } from 'ofetch';
  * Creates a FetchError with the given status code and optional response data.
  * Useful for simulating API error responses in tests.
  */
-export function createFetchError(status: number, data?: any): FetchError {
+export function createFetchError(status: number, data?: unknown): FetchError {
   const error = new FetchError(`Request failed with status ${status}`);
   error.status = status;
   error.statusCode = status;

--- a/patches/@types__paypal-checkout-components@4.0.8.patch
+++ b/patches/@types__paypal-checkout-components@4.0.8.patch
@@ -1,0 +1,34 @@
+diff --git a/modules/callback-data.d.ts b/modules/callback-data.d.ts
+index ef7ba6eb4ba3b6ba28c08b9e69ee9ad193e822a6..87c3fedba4979ffd7e0d74cb29ded8cfd097b2b6 100644
+--- a/modules/callback-data.d.ts
++++ b/modules/callback-data.d.ts
+@@ -219,17 +219,18 @@ export interface AuthorizationResponse {
+     details: AuthorizationResponseDetails;
+ }
+ 
+-export enum FlowType {
+-    /**
+-     * Used to store the payment method for future use, ie subscriptions
+-     */
+-    Vault = "vault",
+-
+-    /**
+-     * Used for one-time checkout
+-     */
+-    Checkout = "checkout",
+-}
++/**
++ * `FlowType` is declared as a string union rather than an `enum` (patched).
++ *
++ * Upstream `@types/paypal-checkout-components` declares this as an `enum`, but
++ * the package ships no runtime JS, so `FlowType.Vault` is `undefined` at
++ * runtime. A union lets callers pass the literal `"vault"`/`"checkout"` the SDK
++ * actually expects without an `as` cast and without a phantom runtime value.
++ *
++ * - "vault": store the payment method for future use, ie subscriptions
++ * - "checkout": one-time checkout
++ */
++export type FlowType = "vault" | "checkout";
+ 
+ export enum Intent {
+     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ catalogs:
 overrides:
   chokidar: 5.0.0
 
+patchedDependencies:
+  '@types/paypal-checkout-components@4.0.8': 7290bc3f5f016af7404be82d90a79de3311c93c0a8e1506159921421273367ee
+
 importers:
 
   .:
@@ -334,7 +337,7 @@ importers:
         version: 3.96.17
       '@types/paypal-checkout-components':
         specifier: 4.0.8
-        version: 4.0.8
+        version: 4.0.8(patch_hash=7290bc3f5f016af7404be82d90a79de3311c93c0a8e1506159921421273367ee)
       '@types/qrcode':
         specifier: 1.5.6
         version: 1.5.6
@@ -13472,7 +13475,7 @@ snapshots:
   '@types/braintree-web@3.96.17':
     dependencies:
       '@types/googlepay': 0.7.10
-      '@types/paypal-checkout-components': 4.0.8
+      '@types/paypal-checkout-components': 4.0.8(patch_hash=7290bc3f5f016af7404be82d90a79de3311c93c0a8e1506159921421273367ee)
 
   '@types/chai@5.2.3':
     dependencies:
@@ -13530,7 +13533,7 @@ snapshots:
     dependencies:
       parse-path: 7.1.0
 
-  '@types/paypal-checkout-components@4.0.8': {}
+  '@types/paypal-checkout-components@4.0.8(patch_hash=7290bc3f5f016af7404be82d90a79de3311c93c0a8e1506159921421273367ee)': {}
 
   '@types/qrcode@1.5.6':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,3 +59,6 @@ catalog:
   vue: 3.5.34
   vue-tsc: 3.3.1
   zod: 3.25.76
+
+patchedDependencies:
+  '@types/paypal-checkout-components@4.0.8': patches/@types__paypal-checkout-components@4.0.8.patch


### PR DESCRIPTION
## Summary

Sweeps the codebase replacing TypeScript `as` assertions with type guards, zod validation, typed helpers, `satisfies`, and explicit literals. **Zero `as` type-assertion casts remain** afterward (only `import … as` aliases and `as const`). Along the way it uncovered and fixed a latent runtime bug a cast was masking.

## What changed

- **Route params/query** — `getSingleRouteParam` + `parseRouteParam(value, schema)` helpers; `planId` via `z.coerce.number().int().positive()`; tab hash via `z.nativeEnum`.
- **Parse boundaries** validated with zod instead of cast: monerium OAuth state, integration-images manifest, frontmatter readers, JobDetail minimark guard.
- **`as any` SDK casts removed** — patched `@types/paypal-checkout-components` so `FlowType` is a string union; typed 3DS `.status`; web3 `getProvider` + assert.
- **Readonly refs** exposed via `shallowReadonly` instead of `readonly(...) as Readonly<Ref<T>>` (also restores a silently-stripped `| null`).
- **DOM event targets** narrowed with `instanceof`/`typeof` guards.
- **ethers** — typed `transfer.send(...)` instead of casting `Promise<any>`.
- **PayPal** `onInit` actions narrowed with an `isPaypalButtonActions` guard.
- **@nuxt/content afterParse hooks** — narrow the generic `ParsedContentFile` ctx to each collection's view with an `is<Collection>Doc` type-guard predicate (runtime-validated; mutations still write through the reference).
- **sigil** — drop the unused `SnakeCaseKeys` mapped type; build `PaymentServerEvents` as an explicit literal validated with `satisfies` (cast-free, exact per-key literals, compile-time completeness).
- **Tests** — drop `as any`/`as unknown` mock casts; type the fetch mock as `vi.fn<typeof fetch>`; stub `$fetch` via `vi.stubGlobal` (value typed `unknown`) instead of casting ofetch's `$Fetch` to Nuxt's route-typed one.

## Bug fix included

**`fix(tiers)`: make `PremiumTierInfo.description` optional.** It was required in the schema, but `parseTiersInfo` skips tiers without one and the backend may omit it — so `PremiumTiersInfoSchema.safeParse` rejected the **entire** `/webapi/2/tiers/info` response (falling back to an empty default and dropping **all** tiers) whenever any tier lacked a description. The `as PremiumTiersInfo` cast in the test had been masking this.

## Testing

- `pnpm typecheck` + `pnpm lint` clean.
- sigil: 48 tests pass; website: 149 tests pass.
- Manually verified the one real behavioral change — PayPal button enable/disable on terms acceptance — plus the 3DS dialog still renders (type-only change).