### PR TITLE
refactor: reduce in-app complexity (tests-first, safe tier)

### DIFF
--- a/packages/website/app/composables/use-fetch-with-csrf.ts
+++ b/packages/website/app/composables/use-fetch-with-csrf.ts
@@ -9,10 +9,43 @@ export const useAuthHintCookie = () => useCookie('auth_hint');
 
 export const useEmailConfirmedCookie = () => useCookie<boolean>('email_confirmed');
 
-export const useFetchWithCsrf = createSharedComposable(() => {
-  const CSRF_HEADER = 'X-CSRFToken';
-  const CSRF_COOKIE = 'csrftoken';
+const CSRF_HEADER = 'X-CSRFToken';
+const CSRF_COOKIE = 'csrftoken';
 
+const MUTATION_METHODS = ['post', 'delete', 'put', 'patch'];
+
+// CSRF is only refreshed for state-changing verbs.
+export function isMutationMethod(method: string | undefined): boolean {
+  return MUTATION_METHODS.includes(method?.toLowerCase() ?? '');
+}
+
+/**
+ * Builds normalised outgoing headers via the Headers API so names are
+ * canonicalised and set() overwrites instead of appends. ofetch reuses the same
+ * `options` object across retries and re-runs the request hook over the previous
+ * attempt's headers; a plain-object merge would mix `X-CSRFToken` with the
+ * lowercased `x-csrftoken` and collapse them into a duplicated "abcd, abcd" value.
+ */
+export function buildRequestHeaders(callerHeaders: HeadersInit | undefined, token: string | null | undefined, isFormData: boolean): Headers {
+  const headers = new Headers();
+  headers.set('accept', 'application/json');
+  // FormData sets its own multipart boundary, so don't force a JSON content-type.
+  if (!isFormData)
+    headers.set('content-type', 'application/json');
+
+  // Merge any caller-provided headers, normalising case via the Headers API.
+  for (const [key, value] of new Headers(callerHeaders))
+    headers.set(key, value);
+
+  // Set the CSRF token last so the freshly resolved token always wins, even
+  // when this hook re-runs over a retried request's existing headers.
+  if (token)
+    headers.set(CSRF_HEADER, token);
+
+  return headers;
+}
+
+export const useFetchWithCsrf = createSharedComposable(() => {
   const FETCH_CONFIG = {
     RETRIES: 1,
     RETRY_DELAY_MS: 500,
@@ -56,6 +89,34 @@ export const useFetchWithCsrf = createSharedComposable(() => {
     return get(csrfToken) ?? undefined;
   }
 
+  // On the server (and in tests) requests carry the user's cookies/referer
+  // explicitly, since there's no browser to attach them.
+  function applyServerHeaders(headers: Headers, event: ReturnType<typeof useEvent> | null, token: string | null | undefined): void {
+    let cookieString = event?.headers.get('cookie') ?? undefined;
+
+    // Only try useRequestHeaders if we have a valid Nuxt context
+    const nuxtApp = tryUseNuxtApp();
+    if (nuxtApp) {
+      try {
+        cookieString = useRequestHeaders(['cookie']).cookie;
+      }
+      catch (error: any) {
+        logger.error(error);
+      }
+    }
+
+    // Fallback to session cookie if no cookie string from request headers
+    if (!cookieString) {
+      const session = get(sessionId);
+      if (session && token)
+        cookieString = `${CSRF_COOKIE}=${token}; sessionid=${session}`;
+    }
+
+    if (cookieString)
+      headers.set('cookie', cookieString);
+    headers.set('referer', baseUrl);
+  }
+
   const fetchWithCsrf = $fetch.create({
     credentials: 'include',
     async onRequest({ options }): Promise<void> {
@@ -65,61 +126,14 @@ export const useFetchWithCsrf = createSharedComposable(() => {
         ? parseCookies(event)[CSRF_COOKIE]
         : get(csrfToken);
 
-      if (import.meta.client && ['post', 'delete', 'put', 'patch'].includes(options?.method?.toLowerCase() ?? ''))
+      if (import.meta.client && isMutationMethod(options?.method))
         token = await initCsrf();
 
-      // Check if the body is FormData
       const isFormData = options.body instanceof FormData;
+      const headers = buildRequestHeaders(options.headers, token, isFormData);
 
-      // Build the outgoing headers via the Headers API so names are normalised
-      // and set() overwrites (instead of appends). ofetch reuses the same
-      // `options` object across retries and re-runs this hook over the previous
-      // attempt's headers; a plain-object merge would mix `X-CSRFToken` with the
-      // lowercased `x-csrftoken` and the Headers constructor would then collapse
-      // them into a duplicated "abcd, abcd" value.
-      const headers = new Headers();
-      headers.set('accept', 'application/json');
-      // Only set content-type for non-FormData requests; FormData sets its own
-      // boundary parameter for multipart/form-data.
-      if (!isFormData)
-        headers.set('content-type', 'application/json');
-
-      // Merge any caller-provided headers, normalising case via the Headers API.
-      for (const [key, value] of new Headers(options.headers))
-        headers.set(key, value);
-
-      // Set the CSRF token last so the freshly resolved token always wins, even
-      // when this hook re-runs over a retried request's existing headers.
-      if (token)
-        headers.set(CSRF_HEADER, token);
-
-      if (import.meta.server || import.meta.env.NODE_ENV === 'test') {
-        let cookieString = event?.headers.get('cookie');
-
-        // Only try useRequestHeaders if we have a valid Nuxt context
-        const nuxtApp = tryUseNuxtApp();
-        if (nuxtApp) {
-          try {
-            const requestHeaders = useRequestHeaders(['cookie']);
-            cookieString = requestHeaders.cookie;
-          }
-          catch (error: any) {
-            logger.error(error);
-          }
-        }
-
-        // Fallback to session cookie if no cookie string from request headers
-        if (!cookieString) {
-          const session = get(sessionId);
-          if (session && token) {
-            cookieString = `${CSRF_COOKIE}=${token}; sessionid=${session}`;
-          }
-        }
-
-        if (cookieString)
-          headers.set('cookie', cookieString);
-        headers.set('referer', baseUrl);
-      }
+      if (import.meta.server || import.meta.env.NODE_ENV === 'test')
+        applyServerHeaders(headers, event, token);
 
       options.headers = headers;
       options.baseURL = baseUrl;

--- a/packages/website/app/composables/use-pricing-comparison.ts
+++ b/packages/website/app/composables/use-pricing-comparison.ts
@@ -1,4 +1,4 @@
-import type { AvailablePlans } from '@rotki/card-payment-common/schemas/plans';
+import type { AvailablePlan, AvailablePlans } from '@rotki/card-payment-common/schemas/plans';
 import type { MaybeRefOrGetter } from 'vue';
 import type { FeatureDescriptionMap, FeatureValue, MappedPlan, PlanBase } from '~/components/pricings/type';
 import { get, set } from '@vueuse/shared';
@@ -155,6 +155,65 @@ interface UsePricingComparisonOptions {
   compact: MaybeRefOrGetter<boolean | undefined>;
 }
 
+type TranslateFn = (key: string, named?: Record<string, unknown>) => string;
+
+function toRegularPlan(
+  availablePlan: AvailablePlan,
+  targetPlan: NonNullable<AvailablePlan['monthlyPlan']>,
+  yearly: boolean,
+  price: number,
+  t: TranslateFn,
+): PlanBase {
+  const formattedPrice = formatCurrency(price);
+  return {
+    id: targetPlan.planId,
+    name: availablePlan.tierName,
+    displayedName: t('pricing.plans.plan', { plan: toTitleCase(availablePlan.tierName) }),
+    mainPriceDisplay: yearly ? `${formatCurrency(price / 12)}€` : `${formattedPrice}€`,
+    secondaryPriceDisplay: yearly
+      ? t('pricing.billed_annually', { price: formattedPrice })
+      : t('pricing.billed_monthly'),
+    type: 'regular',
+    hidden: availablePlan.isCustom || false,
+    isMostPopular: availablePlan.isMostPopular || false,
+    isEntryTier: false,
+  };
+}
+
+/**
+ * Builds the regular (non-free, non-custom) plan rows for the selected billing
+ * period, skipping plans without a matching plan for that period, and marks the
+ * cheapest non-custom plan as the entry tier.
+ */
+export function buildRegularPlans(availablePlans: AvailablePlans, yearly: boolean, t: TranslateFn): PlanBase[] {
+  const plans: PlanBase[] = [];
+  let minPrice = Number.POSITIVE_INFINITY;
+  let minPriceIndex = -1;
+
+  for (const availablePlan of availablePlans) {
+    const targetPlan = yearly ? availablePlan.yearlyPlan : availablePlan.monthlyPlan;
+    if (!targetPlan) {
+      continue;
+    }
+
+    const price = Number.parseFloat(targetPlan.price);
+    if (price < minPrice && !availablePlan.isCustom) {
+      minPrice = price;
+      minPriceIndex = plans.length;
+    }
+
+    plans.push(toRegularPlan(availablePlan, targetPlan, yearly, price, t));
+  }
+
+  // Mark the cheapest non-custom plan as entry tier
+  const entryPlan = minPriceIndex >= 0 && plans.length > 1 ? plans[minPriceIndex] : undefined;
+  if (entryPlan) {
+    entryPlan.isEntryTier = true;
+  }
+
+  return plans;
+}
+
 export function usePricingComparison(options: UsePricingComparisonOptions) {
   const { t } = useI18n({ useScope: 'global' });
   const rawFreePlanFeatures = useFreePlanFeatures();
@@ -173,49 +232,7 @@ export function usePricingComparison(options: UsePricingComparisonOptions) {
 
   const tiersInfo = computed<TiersInfo>(() => parseTiersInfo(toValue(options.tiersData)));
 
-  const regularPlans = computed<PlanBase[]>(() => {
-    const yearly = get(isYearly);
-    const plans: PlanBase[] = [];
-    let minPrice = Number.POSITIVE_INFINITY;
-    let minPriceIndex = -1;
-
-    for (const availablePlan of toValue(options.availablePlans)) {
-      const targetPlan = yearly ? availablePlan.yearlyPlan : availablePlan.monthlyPlan;
-      if (!targetPlan) {
-        continue;
-      }
-
-      const price = Number.parseFloat(targetPlan.price);
-      const formattedPrice = formatCurrency(price);
-
-      if (price < minPrice && !availablePlan.isCustom) {
-        minPrice = price;
-        minPriceIndex = plans.length;
-      }
-
-      plans.push({
-        id: targetPlan.planId,
-        name: availablePlan.tierName,
-        displayedName: t('pricing.plans.plan', { plan: toTitleCase(availablePlan.tierName) }),
-        mainPriceDisplay: yearly ? `${formatCurrency(price / 12)}€` : `${formattedPrice}€`,
-        secondaryPriceDisplay: yearly
-          ? t('pricing.billed_annually', { price: formattedPrice })
-          : t('pricing.billed_monthly'),
-        type: 'regular',
-        hidden: availablePlan.isCustom || false,
-        isMostPopular: availablePlan.isMostPopular || false,
-        isEntryTier: false,
-      });
-    }
-
-    // Mark the cheapest non-custom plan as entry tier
-    const entryPlan = minPriceIndex >= 0 && plans.length > 1 ? plans[minPriceIndex] : undefined;
-    if (entryPlan) {
-      entryPlan.isEntryTier = true;
-    }
-
-    return plans;
-  });
+  const regularPlans = computed<PlanBase[]>(() => buildRegularPlans(toValue(options.availablePlans), get(isYearly), t));
 
   const plans = computed<MappedPlan[]>(() => {
     const availPlans = toValue(options.availablePlans);

--- a/packages/website/app/modules/checkout/composables/use-payment-cards.ts
+++ b/packages/website/app/modules/checkout/composables/use-payment-cards.ts
@@ -29,21 +29,25 @@ export function usePaymentCards(): UsePaymentCardsReturn {
   const emailConfirmed = useEmailConfirmedCookie();
   const { t } = useI18n();
 
+  function rateLimitMessage(backendMessage: string): string {
+    return backendMessage.toLowerCase().includes('failed')
+      ? t('home.account.payment_methods.errors.rate_limited_failures')
+      : t('home.account.payment_methods.errors.rate_limited');
+  }
+
   function buildAddCardError(error: any): Error {
-    if (error?.statusCode === 429) {
-      const backendMessage: string = error?.data?.message ?? '';
-      const message = backendMessage.toLowerCase().includes('failed')
-        ? t('home.account.payment_methods.errors.rate_limited_failures')
-        : t('home.account.payment_methods.errors.rate_limited');
-      return new Error(message);
-    }
+    const { statusCode, data, message } = error ?? {};
+
+    if (statusCode === 429)
+      return new Error(rateLimitMessage(data?.message ?? ''));
+
     // 400s on this endpoint are either schema/JSON-decode errors (frontend bugs the user
     // can't act on) or Braintree gateway errors (raw "Do Not Honor"-style dumps that read
     // like a stack trace). Substitute a friendly message; raw cause is kept in the logs.
-    if (error?.statusCode === 400) {
+    if (statusCode === 400)
       return new Error(t('home.account.payment_methods.errors.card_declined'));
-    }
-    return new Error(error?.data?.message || error?.message || t('common.error_occurred'));
+
+    return new Error(data?.message || message || t('common.error_occurred'));
   }
 
   const { data, pending, refresh } = useAsyncData<SavedCard[]>(

--- a/packages/website/app/utils/api-error-handling.ts
+++ b/packages/website/app/utils/api-error-handling.ts
@@ -14,19 +14,24 @@ export function isUnauthorizedError(error: unknown): boolean {
 }
 
 /**
+ * Extract the message from a 400 response body, preferring the parsed
+ * ActionResult message and falling back to the raw payload/error message.
+ */
+function extractBadRequestMessage(error: FetchError): string {
+  const parsed = ActionResultResponseSchema.safeParse(error.data);
+  if (parsed.success)
+    return parsed.data.message || 'Unknown error';
+
+  return error.data?.message || error.message || 'Unknown error';
+}
+
+/**
  * Extract error message from various error types
  */
 export function getErrorMessage(error: any): string {
-  if (error instanceof FetchError) {
-    const status = error?.status || -1;
-    if (status === 400 && error.response) {
-      const parsed = ActionResultResponseSchema.safeParse(error.data);
-      if (parsed.success) {
-        return parsed.data.message || 'Unknown error';
-      }
-      return error.data?.message || error.message || 'Unknown error';
-    }
-  }
+  if (error instanceof FetchError && (error.status || -1) === 400 && error.response)
+    return extractBadRequestMessage(error);
+
   return error.message || 'An unknown error occurred';
 }
 

--- a/packages/website/app/utils/redirect.ts
+++ b/packages/website/app/utils/redirect.ts
@@ -15,27 +15,29 @@ export function getSafeRedirectUrl(url: string, fallback: string = '/home/subscr
     if (decoded.startsWith('/') && !decoded.startsWith('//'))
       return decoded;
 
-    // Reject URLs that don't start with a known scheme — prevents relative-URL
-    // resolution of malformed strings like "ht tp://..." into same-origin paths
-    if (!/^https?:\/\//i.test(decoded))
-      return fallback;
-
-    const target = new URL(decoded, window.location.origin);
-    const currentHostname = window.location.hostname;
-
-    // Reject non-http(s) protocols
-    if (target.protocol !== 'http:' && target.protocol !== 'https:')
-      return fallback;
-
-    // Allow exact match or subdomain match
-    if (target.hostname === currentHostname || isSubdomainOf(target.hostname, currentHostname))
-      return decoded;
-
-    return fallback;
+    return isSameOriginAbsoluteUrl(decoded) ? decoded : fallback;
   }
   catch {
     return fallback;
   }
+}
+
+// Validates an absolute URL is http(s) on the current host (or a subdomain of it).
+function isSameOriginAbsoluteUrl(decoded: string): boolean {
+  // Reject URLs that don't start with a known scheme — prevents relative-URL
+  // resolution of malformed strings like "ht tp://..." into same-origin paths
+  if (!/^https?:\/\//i.test(decoded))
+    return false;
+
+  const target = new URL(decoded, window.location.origin);
+  const currentHostname = window.location.hostname;
+
+  // Reject non-http(s) protocols
+  if (target.protocol !== 'http:' && target.protocol !== 'https:')
+    return false;
+
+  // Allow exact match or subdomain match
+  return target.hostname === currentHostname || isSubdomainOf(target.hostname, currentHostname);
 }
 
 function isSubdomainOf(hostname: string, parentHostname: string): boolean {

--- a/packages/website/tests/unit/composables/use-fetch-with-csrf-helpers.spec.ts
+++ b/packages/website/tests/unit/composables/use-fetch-with-csrf-helpers.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequestHeaders, isMutationMethod } from '~/composables/use-fetch-with-csrf';
+
+describe('isMutationMethod', () => {
+  it.each(['post', 'POST', 'put', 'PUT', 'delete', 'patch'])('treats %s as a mutation', (method) => {
+    expect(isMutationMethod(method)).toBe(true);
+  });
+
+  it.each(['get', 'GET', 'head', 'options', ''])('treats %s as a non-mutation', (method) => {
+    expect(isMutationMethod(method)).toBe(false);
+  });
+
+  it('treats an undefined method as a non-mutation', () => {
+    expect(isMutationMethod(undefined)).toBe(false);
+  });
+});
+
+describe('buildRequestHeaders', () => {
+  it('sets JSON accept and content-type by default', () => {
+    const headers = buildRequestHeaders(undefined, undefined, false);
+    expect(headers.get('accept')).toBe('application/json');
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+
+  it('omits content-type for FormData bodies so the multipart boundary is preserved', () => {
+    const headers = buildRequestHeaders(undefined, undefined, true);
+    expect(headers.get('content-type')).toBeNull();
+    expect(headers.get('accept')).toBe('application/json');
+  });
+
+  it('attaches the CSRF token when provided', () => {
+    expect(buildRequestHeaders(undefined, 'tok-123', false).get('X-CSRFToken')).toBe('tok-123');
+  });
+
+  it('omits the CSRF header when no token is available', () => {
+    expect(buildRequestHeaders(undefined, undefined, false).get('X-CSRFToken')).toBeNull();
+  });
+
+  it('merges caller-provided headers case-insensitively', () => {
+    expect(buildRequestHeaders({ 'X-Custom': 'value' }, undefined, false).get('x-custom')).toBe('value');
+  });
+
+  it('lets the resolved token win over a caller-provided CSRF header', () => {
+    const headers = buildRequestHeaders({ 'x-csrftoken': 'stale' }, 'fresh', false);
+    expect(headers.get('X-CSRFToken')).toBe('fresh');
+  });
+
+  it('does not duplicate the CSRF header when re-run over previously-built headers (retry path)', () => {
+    const first = buildRequestHeaders(undefined, 'tok', false);
+    const retried = buildRequestHeaders(first, 'tok', false);
+    // A naive merge would collapse X-CSRFToken + x-csrftoken into "tok, tok".
+    expect(retried.get('X-CSRFToken')).toBe('tok');
+  });
+});

--- a/packages/website/tests/unit/composables/use-pricing-comparison.spec.ts
+++ b/packages/website/tests/unit/composables/use-pricing-comparison.spec.ts
@@ -1,7 +1,23 @@
+import type { AvailablePlan } from '@rotki/card-payment-common/schemas/plans';
 import type { FeatureDescriptionMap, FeatureValue, PlanBase } from '~/components/pricings/type';
 import type { PremiumTiersInfo } from '~/types/tiers';
 import { describe, expect, it } from 'vitest';
-import { parseTiersInfo, resolveFeatureValue } from '~/composables/use-pricing-comparison';
+import { buildRegularPlans, parseTiersInfo, resolveFeatureValue } from '~/composables/use-pricing-comparison';
+import { formatCurrency } from '~/utils/text';
+
+// Translation stub returns the key so tests can assert which key was chosen.
+const tStub = (key: string): string => key;
+
+function availablePlan(overrides: Partial<AvailablePlan> = {}): AvailablePlan {
+  return {
+    tierName: 'pro',
+    isCustom: false,
+    isMostPopular: false,
+    monthlyPlan: { planId: 1, price: '10' },
+    yearlyPlan: { planId: 2, price: '96' },
+    ...overrides,
+  };
+}
 
 const CUSTOM_LABELS = { support: 'Bespoke support', negotiable: 'Negotiable' };
 
@@ -295,5 +311,60 @@ describe('resolveFeatureValue', () => {
 
       expect(result).toBeUndefined();
     });
+  });
+});
+
+describe('buildRegularPlans', () => {
+  it('uses the monthly plan and monthly billing label for the monthly period', () => {
+    const [plan] = buildRegularPlans([availablePlan()], false, tStub);
+    expect(plan?.id).toBe(1);
+    expect(plan?.type).toBe('regular');
+    expect(plan?.mainPriceDisplay).toBe(`${formatCurrency(10)}€`);
+    expect(plan?.secondaryPriceDisplay).toBe('pricing.billed_monthly');
+  });
+
+  it('uses the yearly plan, divides by 12, and uses the annual billing label for the yearly period', () => {
+    const [plan] = buildRegularPlans([availablePlan()], true, tStub);
+    expect(plan?.id).toBe(2);
+    expect(plan?.mainPriceDisplay).toBe(`${formatCurrency(96 / 12)}€`);
+    expect(plan?.secondaryPriceDisplay).toBe('pricing.billed_annually');
+  });
+
+  it('marks the cheapest non-custom plan as the entry tier', () => {
+    const pricey = availablePlan({ tierName: 'pricey', monthlyPlan: { planId: 2, price: '20' } });
+    const cheap = availablePlan({ tierName: 'cheap', monthlyPlan: { planId: 1, price: '10' } });
+
+    const result = buildRegularPlans([pricey, cheap], false, tStub);
+
+    expect(result.find(p => p.name === 'cheap')?.isEntryTier).toBe(true);
+    expect(result.find(p => p.name === 'pricey')?.isEntryTier).toBe(false);
+  });
+
+  it('does not mark an entry tier when there is only one plan', () => {
+    const [plan] = buildRegularPlans([availablePlan()], false, tStub);
+    expect(plan?.isEntryTier).toBe(false);
+  });
+
+  it('excludes custom plans from the entry-tier calculation and hides them', () => {
+    const custom = availablePlan({ tierName: 'custom', isCustom: true, monthlyPlan: { planId: 9, price: '1' } });
+    const regular = availablePlan({ tierName: 'pro', monthlyPlan: { planId: 1, price: '10' } });
+
+    const result = buildRegularPlans([custom, regular], false, tStub);
+
+    expect(result.find(p => p.name === 'custom')?.hidden).toBe(true);
+    expect(result.find(p => p.name === 'custom')?.isEntryTier).toBe(false);
+    expect(result.find(p => p.name === 'pro')?.isEntryTier).toBe(true);
+  });
+
+  it('skips plans without a plan for the selected period', () => {
+    const noMonthly = availablePlan({ tierName: 'no-monthly', monthlyPlan: null });
+    const result = buildRegularPlans([noMonthly, availablePlan()], false, tStub);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('pro');
+  });
+
+  it('passes through the most-popular flag', () => {
+    const [plan] = buildRegularPlans([availablePlan({ isMostPopular: true })], false, tStub);
+    expect(plan?.isMostPopular).toBe(true);
   });
 });

--- a/packages/website/tests/unit/utils/api-error-handling.spec.ts
+++ b/packages/website/tests/unit/utils/api-error-handling.spec.ts
@@ -1,9 +1,17 @@
 import { assert, describe, expect, it } from 'vitest';
 
 import { PaymentError } from '~/types/codes';
-import { handlePaymentError } from '~/utils/api-error-handling';
+import { getErrorMessage, handlePaymentError } from '~/utils/api-error-handling';
 
 import { createFetchError } from '../../utils';
+
+// `getErrorMessage` only inspects `error.data` for 400s when `error.response` is
+// also set, so attach a real Response to exercise that branch.
+function fetchError400(data: unknown): ReturnType<typeof createFetchError> {
+  const error = createFetchError(400, data);
+  error.response = new Response(null, { status: 400 });
+  return error;
+}
 
 describe('handlePaymentError', () => {
   it('should return error with parsed message for 400 status', () => {
@@ -65,5 +73,43 @@ describe('handlePaymentError', () => {
     assert(result.isError);
     expect(result.code).toBeUndefined();
     expect(result.error).toBe(error);
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('returns the message of a plain Error', () => {
+    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('falls back to a generic message when none is present', () => {
+    expect(getErrorMessage({})).toBe('An unknown error occurred');
+  });
+
+  it('uses the parsed ActionResult message for a 400 with response', () => {
+    expect(getErrorMessage(fetchError400({ message: 'parsed message', result: false }))).toBe('parsed message');
+  });
+
+  it('returns "Unknown error" when the parsed 400 body has no message', () => {
+    expect(getErrorMessage(fetchError400({ result: false }))).toBe('Unknown error');
+  });
+
+  it('falls back to raw data.message when the 400 body fails schema parsing', () => {
+    // `result` is not a boolean, so the schema parse fails and the raw message is used.
+    expect(getErrorMessage(fetchError400({ message: 'raw message', result: 'not-a-boolean' }))).toBe('raw message');
+  });
+
+  it('falls back to error.message when an unparsable 400 body has no message', () => {
+    const error = fetchError400({ result: 'not-a-boolean' });
+    expect(getErrorMessage(error)).toBe(error.message);
+  });
+
+  it('uses error.message for a 400 without a response object', () => {
+    const error = createFetchError(400, { message: 'ignored without response' });
+    expect(getErrorMessage(error)).toBe(error.message);
+  });
+
+  it('uses error.message for non-400 FetchErrors', () => {
+    const error = createFetchError(500, { message: 'ignored for 500' });
+    expect(getErrorMessage(error)).toBe(error.message);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #623. Reduces the `complexity` lint warnings in the **low-risk, unit-testable** production functions, using a tests-first approach. The `complexity` warning count drops from **15 → 10**; unit tests grow **149 → 183**.

Each function is its own commit. Where the logic was already covered (or previously inline and only testable after extraction), tests and refactor land together; for `getErrorMessage` the characterization tests were committed first (passing on the old code) before the refactor.

## Changes
- **`getSafeRedirectUrl`** (`utils/redirect.ts`) — extracted `isSameOriginAbsoluteUrl`. Already comprehensively covered.
- **`getErrorMessage`** (`utils/api-error-handling.ts`) — added 8 characterization tests first, then extracted `extractBadRequestMessage`.
- **`buildAddCardError`** (`use-payment-cards.ts`) — precompute fields + `rateLimitMessage` helper. Existing spec already covered all branches.
- **`regularPlans`** (`use-pricing-comparison.ts`) — extracted a pure, exported `buildRegularPlans(availablePlans, yearly, t)` (+ `toRegularPlan`); added 7 direct tests.
- **`onRequest`** (`use-fetch-with-csrf.ts`) — extracted pure exported `isMutationMethod` + `buildRequestHeaders`, moved the SSR-cookie block into `applyServerHeaders`; added 19 unit tests. The existing nuxt integration spec still guards the retry header-dedup path.

## Verification
Every commit: `pnpm lint` (0 errors), `pnpm typecheck`, full `pnpm test` (**183 passing**).

## Out of scope (intentionally deferred)
The remaining 10 `complexity` warnings are left for a dedicated effort:
- **Sponsorship / crypto-pay / SIWE** (`mintSponsorshipNFT`, `use-crypto-payment`, `NftSubmissionForm`, `use-siwe-auth`) — slated for an independent rewrite/cleanup.
- **PayPal flow** (`submitPayment`, `handleSubmitPayment`) — deferred with the payment rewrite.
- **Middleware** (`02.auth.global`, `pending-payment`) and **`UpgradePlanDialog.submitUpgrade`** — left at threshold for now.

Also untouched: `vue/max-template-depth` (74) and `vue/max-props` (9), which are accept-the-threshold.