### PR TITLE
refactor(leaderboard): extract sponsor leaderboard into a testable module

### DIFF
--- a/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardCallToAction.vue
+++ b/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardCallToAction.vue
@@ -1,0 +1,27 @@
+<script lang="ts" setup>
+import ButtonLink from '~/components/common/ButtonLink.vue';
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="text-center mt-6 border-t border-default">
+    <div class="bg-white/10 backdrop-blur-md rounded-xl p-8 max-w-md mx-auto">
+      <h2 class="text-2xl font-bold mb-1">
+        {{ t('sponsor.leaderboard.call_to_action.title') }}
+      </h2>
+      <p class="text-rui-text-secondary text-sm mb-4">
+        {{ t('sponsor.leaderboard.call_to_action.description') }}
+      </p>
+      <ButtonLink
+        variant="outlined"
+        to="/sponsor/mint"
+        size="lg"
+        color="primary"
+        class="mx-auto"
+      >
+        {{ t('sponsor.leaderboard.call_to_action.button') }}
+      </ButtonLink>
+    </div>
+  </div>
+</template>

--- a/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardEmptyState.vue
+++ b/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardEmptyState.vue
@@ -1,0 +1,35 @@
+<script lang="ts" setup>
+import ButtonLink from '~/components/common/ButtonLink.vue';
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="text-center py-12">
+    <img
+      :alt="t('sponsor.leaderboard.empty_state')"
+      class="w-24 mx-auto"
+      src="/img/no_data_placeholder.svg"
+      width="96"
+      height="96"
+      loading="lazy"
+    />
+    <p class="text-rui-text-secondary">
+      {{ t('sponsor.leaderboard.empty_state') }}
+    </p>
+    <i18n-t
+      keypath="sponsor.leaderboard.be_the_first"
+      scope="global"
+    >
+      <template #mint>
+        <ButtonLink
+          color="primary"
+          inline
+          to="/sponsor/mint"
+        >
+          {{ t('sponsor.leaderboard.mint') }}
+        </ButtonLink>
+      </template>
+    </i18n-t>
+  </div>
+</template>

--- a/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardEntryRow.vue
+++ b/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardEntryRow.vue
@@ -1,0 +1,101 @@
+<script lang="ts" setup>
+import type { AddressDisplay, LeaderboardEntry } from '~/modules/sponsor/leaderboard/types';
+import AddressAvatar from '~/components/common/AddressAvatar.vue';
+import { buildAddressDisplay, getDisplayRank, getRankClass } from '~/modules/sponsor/leaderboard/utils';
+import { getTierMedal } from '~/utils/nft-tiers';
+
+const { entry, index, page, limit, shorten = false } = defineProps<{
+  entry: LeaderboardEntry;
+  index: number;
+  page: number;
+  limit: number;
+  shorten?: boolean;
+}>();
+
+const emit = defineEmits<{
+  copy: [address: string];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const addressDisplay = computed<AddressDisplay>(() => buildAddressDisplay(entry, shorten));
+
+const displayRank = computed<number>(() => getDisplayRank(entry, index, page, limit));
+
+const rankClass = computed<string | Record<string, boolean>>(() => getRankClass(page, index));
+</script>
+
+<template>
+  <div class="flex items-center space-x-4 flex-1 min-h-[74px]">
+    <!-- Avatar (ENS or Blockie) -->
+    <AddressAvatar
+      :ens-name="entry.ensName"
+      :address="entry.address"
+    />
+
+    <div class="flex-1">
+      <div class="space-y-1">
+        <RuiTooltip
+          v-if="addressDisplay.showTooltip"
+          :open-delay="400"
+        >
+          <template #activator>
+            <p
+              class="text-sm font-bold cursor-pointer hover:opacity-75 transition-opacity text-primary"
+              @click="emit('copy', entry.address)"
+            >
+              {{ addressDisplay.primary }}
+            </p>
+          </template>
+          <div class="text-center">
+            <div class="font-mono text-xs">
+              {{ entry.address }}
+            </div>
+            <div class="text-xs text-rui-dark-text-secondary mt-1">
+              {{ t('sponsor.leaderboard.tooltip.copy_address') }}
+            </div>
+          </div>
+        </RuiTooltip>
+        <p
+          v-else
+          class="text-sm font-bold font-mono cursor-pointer hover:opacity-75 transition-opacity"
+          @click="emit('copy', entry.address)"
+        >
+          {{ addressDisplay.primary }}
+        </p>
+      </div>
+      <div class="text-rui-text-secondary text-sm space-y-1">
+        <div class="flex flex-wrap gap-x-3 gap-y-0.5">
+          <span class="whitespace-nowrap">{{ t('sponsor.leaderboard.nft_counts', { medal: getTierMedal('gold'), count: entry.goldCount }, entry.goldCount) }}</span>
+          <span class="whitespace-nowrap">{{ t('sponsor.leaderboard.nft_counts', { medal: getTierMedal('silver'), count: entry.silverCount }, entry.silverCount) }}</span>
+          <span class="whitespace-nowrap">{{ t('sponsor.leaderboard.nft_counts', { medal: getTierMedal('bronze'), count: entry.bronzeCount }, entry.bronzeCount) }}</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <RuiTooltip :open-delay="400">
+            <template #activator>
+              <RuiChip
+                color="primary"
+                size="sm"
+              >
+                {{ t('sponsor.leaderboard.points', { points: entry.points }) }}
+              </RuiChip>
+            </template>
+            <div>
+              <div>{{ t('sponsor.leaderboard.tooltip.points_breakdown.gold') }}</div>
+              <div>{{ t('sponsor.leaderboard.tooltip.points_breakdown.silver') }}</div>
+              <div>{{ t('sponsor.leaderboard.tooltip.points_breakdown.bronze') }}</div>
+            </div>
+          </RuiTooltip>
+        </div>
+      </div>
+    </div>
+    <div class="text-right">
+      <div
+        class="text-2xl font-bold"
+        :class="[rankClass]"
+      >
+        #{{ displayRank }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardEntrySkeleton.vue
+++ b/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardEntrySkeleton.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="flex items-center space-x-4 flex-1 min-h-[74px]">
+    <RuiSkeletonLoader
+      class="w-10 h-10 shrink-0"
+      rounded="full"
+    />
+    <div class="flex-1 space-y-2">
+      <RuiSkeletonLoader class="w-48 h-4" />
+      <RuiSkeletonLoader class="w-32 h-3" />
+      <RuiSkeletonLoader class="w-16 h-5" />
+    </div>
+    <RuiSkeletonLoader class="w-8 h-7" />
+  </div>
+</template>

--- a/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardHeader.vue
+++ b/packages/website/app/modules/sponsor/leaderboard/components/LeaderboardHeader.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="text-center py-6 mb-6 bg-gradient-to-b from-rui-primary/[0.06] to-transparent rounded-xl">
+    <h1 class="text-h4 font-bold mb-2">
+      {{ t('sponsor.leaderboard.title') }}
+    </h1>
+    <p class="text-rui-text-secondary">
+      {{ t('sponsor.leaderboard.subtitle') }}
+    </p>
+  </div>
+</template>

--- a/packages/website/app/modules/sponsor/leaderboard/composables/use-leaderboard.ts
+++ b/packages/website/app/modules/sponsor/leaderboard/composables/use-leaderboard.ts
@@ -1,0 +1,130 @@
+import type { Ref } from 'vue';
+import { get, set } from '@vueuse/shared';
+import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
+import {
+  type LeaderboardEntry,
+  LeaderboardMetadataSchema,
+  type LeaderboardResponse,
+  LeaderboardResponseSchema,
+  type PaginationData,
+} from '~/modules/sponsor/leaderboard/types';
+import { calculateOffset, createPlaceholderEntries } from '~/modules/sponsor/leaderboard/utils';
+
+interface UseLeaderboardReturn {
+  paginationData: Readonly<Ref<PaginationData>>;
+  loading: Readonly<Ref<boolean>>;
+  currentLeaderboard: Readonly<Ref<LeaderboardEntry[]>>;
+  displayedEntries: Readonly<Ref<LeaderboardEntry[]>>;
+  hasData: Readonly<Ref<boolean>>;
+  showSkeleton: Readonly<Ref<boolean>>;
+  isEmpty: Readonly<Ref<boolean>>;
+  lastUpdated: Readonly<Ref<string>>;
+  shouldShorten: Readonly<Ref<boolean>>;
+  handlePaginationChange: (newPagination: PaginationData) => Promise<void>;
+  copyToClipboard: (text: string) => Promise<void>;
+}
+
+export function useLeaderboard(): UseLeaderboardReturn {
+  const { fetchWithCsrf } = useFetchWithCsrf();
+
+  // Pagination state
+  const paginationData = ref<PaginationData>({
+    page: 1,
+    total: 0,
+    limit: 10,
+    limits: [10, 25, 50, 100],
+  });
+
+  // Clipboard functionality
+  const clipboardSource = shallowRef<string>('');
+  const { copy } = useClipboard({ source: clipboardSource });
+
+  // Breakpoint detection — addresses are truncated on smaller screens
+  const { isMdAndDown } = useBreakpoint();
+
+  // Leaderboard data
+  const { data: leaderboardData, pending: loading, refresh: refreshLeaderboard } = useAsyncData<LeaderboardResponse>(
+    'leaderboard',
+    async () => {
+      const { page, limit } = get(paginationData);
+      const response = await fetchWithCsrf('/webapi/nfts/leaderboard/', {
+        method: 'GET',
+        query: { offset: calculateOffset(page, limit), limit },
+      });
+      return LeaderboardResponseSchema.parse(response);
+    },
+    {
+      default: (): LeaderboardResponse => ({ count: 0, next: null, previous: null, results: [] }),
+      lazy: true,
+      server: false,
+    },
+  );
+
+  // Metadata
+  const { data: lastUpdated } = useAsyncData<string>(
+    'leaderboard-metadata',
+    async () => {
+      const response = await fetchWithCsrf('/webapi/nfts/leaderboard/metadata', {
+        method: 'GET',
+      });
+      return LeaderboardMetadataSchema.parse(response).lastUpdated ?? '';
+    },
+    {
+      default: () => '',
+      lazy: true,
+      server: false,
+    },
+  );
+
+  const currentLeaderboard = computed<LeaderboardEntry[]>(() => get(leaderboardData)?.results ?? []);
+
+  const placeholderEntries = computed<LeaderboardEntry[]>(() => createPlaceholderEntries());
+
+  const hasData = computed<boolean>(() => get(currentLeaderboard).length > 0);
+
+  const isEmpty = computed<boolean>(() =>
+    !get(loading) && get(currentLeaderboard).length === 0 && get(leaderboardData)?.count === 0,
+  );
+
+  // Skeletons reserve layout only while loading with no data yet — never once an
+  // empty response has loaded (that state renders the empty message instead).
+  const showSkeleton = computed<boolean>(() => !get(hasData) && !get(isEmpty));
+
+  const displayedEntries = computed<LeaderboardEntry[]>(() =>
+    get(showSkeleton) ? get(placeholderEntries) : get(currentLeaderboard),
+  );
+
+  // Sync total from response into pagination state
+  watch(leaderboardData, (data) => {
+    if (data) {
+      set(paginationData, {
+        ...get(paginationData),
+        total: data.count,
+      });
+    }
+  });
+
+  async function copyToClipboard(text: string): Promise<void> {
+    set(clipboardSource, text);
+    await copy();
+  }
+
+  async function handlePaginationChange(newPagination: PaginationData): Promise<void> {
+    set(paginationData, newPagination);
+    await refreshLeaderboard();
+  }
+
+  return {
+    paginationData: shallowReadonly(paginationData),
+    loading: shallowReadonly(loading),
+    currentLeaderboard: shallowReadonly(currentLeaderboard),
+    displayedEntries: shallowReadonly(displayedEntries),
+    hasData: shallowReadonly(hasData),
+    showSkeleton: shallowReadonly(showSkeleton),
+    isEmpty: shallowReadonly(isEmpty),
+    lastUpdated: shallowReadonly(lastUpdated),
+    shouldShorten: shallowReadonly(isMdAndDown),
+    handlePaginationChange,
+    copyToClipboard,
+  };
+}

--- a/packages/website/app/modules/sponsor/leaderboard/types.ts
+++ b/packages/website/app/modules/sponsor/leaderboard/types.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+export const LeaderboardEntrySchema = z.object({
+  rank: z.number().nullable(),
+  address: z.string(),
+  bronzeCount: z.number(),
+  silverCount: z.number(),
+  goldCount: z.number(),
+  totalCount: z.number(),
+  points: z.number(),
+  ensName: z.string().nullable(),
+});
+
+export const LeaderboardResponseSchema = z.object({
+  count: z.number(),
+  next: z.string().nullable(),
+  previous: z.string().nullable(),
+  results: z.array(LeaderboardEntrySchema),
+});
+
+export const LeaderboardMetadataSchema = z.object({
+  lastUpdated: z.string().nullable(),
+});
+
+export type LeaderboardEntry = z.infer<typeof LeaderboardEntrySchema>;
+
+export type LeaderboardResponse = z.infer<typeof LeaderboardResponseSchema>;
+
+export type LeaderboardMetadata = z.infer<typeof LeaderboardMetadataSchema>;
+
+export interface PaginationData {
+  page: number;
+  total: number;
+  limit: number;
+  limits?: number[];
+}
+
+export interface AddressDisplay {
+  primary: string;
+  showTooltip: boolean;
+  isEns: boolean;
+}

--- a/packages/website/app/modules/sponsor/leaderboard/utils.ts
+++ b/packages/website/app/modules/sponsor/leaderboard/utils.ts
@@ -1,0 +1,80 @@
+import type { AddressDisplay, LeaderboardEntry } from '~/modules/sponsor/leaderboard/types';
+import { truncateAddress } from '~/utils/text';
+
+const PLACEHOLDER_ENTRY_COUNT = 5;
+
+/**
+ * Builds placeholder entries shown during the initial load to reserve layout
+ * space before real data arrives.
+ */
+export function createPlaceholderEntries(count = PLACEHOLDER_ENTRY_COUNT): LeaderboardEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    rank: i + 1,
+    address: '',
+    bronzeCount: 0,
+    silverCount: 0,
+    goldCount: 0,
+    totalCount: 0,
+    points: 0,
+    ensName: null,
+  }));
+}
+
+/**
+ * Resolves how a single entry's address should be displayed.
+ * - ENS names are always shown with the truncated address and a tooltip.
+ * - Plain addresses are truncated (with a tooltip) only on smaller screens.
+ */
+export function buildAddressDisplay(
+  entry: Pick<LeaderboardEntry, 'address' | 'ensName'>,
+  shouldShorten: boolean,
+): AddressDisplay {
+  if (entry.ensName) {
+    return {
+      primary: `${entry.ensName} - ${truncateAddress(entry.address)}`,
+      showTooltip: true,
+      isEns: true,
+    };
+  }
+
+  return {
+    primary: shouldShorten ? truncateAddress(entry.address) : entry.address,
+    showTooltip: shouldShorten,
+    isEns: false,
+  };
+}
+
+/**
+ * Offset (number of items to skip) for the given 1-based page and page size.
+ */
+export function calculateOffset(page: number, limit: number): number {
+  return (page - 1) * limit;
+}
+
+/**
+ * Display rank for an entry. Falls back to a computed rank derived from the
+ * page/index when the backend did not provide one.
+ */
+export function getDisplayRank(
+  entry: Pick<LeaderboardEntry, 'rank'>,
+  index: number,
+  page: number,
+  limit: number,
+): number {
+  return entry.rank || (index + 1 + calculateOffset(page, limit));
+}
+
+/**
+ * Colour classes for the rank badge. The top three entries on the first page
+ * get medal colours (gold/silver/bronze); everything else is muted.
+ */
+export function getRankClass(page: number, index: number): string | Record<string, boolean> {
+  if (page === 1 && index <= 2) {
+    return {
+      'text-yellow-400': index === 0,
+      'text-gray-400': index === 1,
+      'text-amber-500': index === 2,
+    };
+  }
+  return 'text-rui-text-secondary';
+}

--- a/packages/website/app/pages/sponsor/leaderboard.vue
+++ b/packages/website/app/pages/sponsor/leaderboard.vue
@@ -1,46 +1,12 @@
 <script lang="ts" setup>
-import { get, set } from '@vueuse/shared';
-import { z } from 'zod';
-import AddressAvatar from '~/components/common/AddressAvatar.vue';
-import ButtonLink from '~/components/common/ButtonLink.vue';
-import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { usePageSeo } from '~/composables/use-page-seo';
+import LeaderboardCallToAction from '~/modules/sponsor/leaderboard/components/LeaderboardCallToAction.vue';
+import LeaderboardEmptyState from '~/modules/sponsor/leaderboard/components/LeaderboardEmptyState.vue';
+import LeaderboardEntryRow from '~/modules/sponsor/leaderboard/components/LeaderboardEntryRow.vue';
+import LeaderboardEntrySkeleton from '~/modules/sponsor/leaderboard/components/LeaderboardEntrySkeleton.vue';
+import LeaderboardHeader from '~/modules/sponsor/leaderboard/components/LeaderboardHeader.vue';
+import { useLeaderboard } from '~/modules/sponsor/leaderboard/composables/use-leaderboard';
 import { formatDate } from '~/utils/date';
-import { getTierMedal } from '~/utils/nft-tiers';
-import { truncateAddress } from '~/utils/text';
-
-interface PaginationData {
-  page: number;
-  total: number;
-  limit: number;
-  limits?: number[];
-}
-
-const LeaderboardEntry = z.object({
-  rank: z.number().nullable(),
-  address: z.string(),
-  bronzeCount: z.number(),
-  silverCount: z.number(),
-  goldCount: z.number(),
-  totalCount: z.number(),
-  points: z.number(),
-  ensName: z.string().nullable(),
-});
-
-const LeaderboardResponse = z.object({
-  count: z.number(),
-  next: z.string().nullable(),
-  previous: z.string().nullable(),
-  results: z.array(LeaderboardEntry),
-});
-
-type LeaderboardResponse = z.infer<typeof LeaderboardResponse>;
-
-type LeaderboardEntry = z.infer<typeof LeaderboardEntry>;
-
-const LeaderboardMetadata = z.object({
-  lastUpdated: z.string().nullable(),
-});
 
 usePageSeo('Sponsor Leaderboard', 'See the top supporters of rotki, an independent open-source privacy-preserving portfolio tracker. Join the leaderboard by sponsoring a release.', '/sponsor/leaderboard', {
   keywords: 'open source sponsorship, open source funding, privacy software, local-first software, rotki sponsor',
@@ -50,330 +16,82 @@ definePageMeta({
   layout: 'sponsor',
 });
 
-// Pagination state
-const paginationData = ref<PaginationData>({
-  page: 1,
-  total: 0,
-  limit: 10,
-  limits: [10, 25, 50, 100],
-});
-
-// Clipboard functionality
-const clipboardSource = ref<string>('');
-const { copy } = useClipboard({ source: clipboardSource });
-
 const { t } = useI18n({ useScope: 'global' });
-const { fetchWithCsrf } = useFetchWithCsrf();
 
-// Breakpoint detection
-const { isMdAndDown } = useBreakpoint();
-
-// Leaderboard data
-const { data: leaderboardData, pending: loading, refresh: refreshLeaderboard } = useAsyncData<LeaderboardResponse>(
-  'leaderboard',
-  async () => {
-    const { page, limit } = get(paginationData);
-    const offset = (page - 1) * limit;
-    const response = await fetchWithCsrf('/webapi/nfts/leaderboard/', {
-      method: 'GET',
-      query: { offset, limit },
-    });
-    return LeaderboardResponse.parse(response);
-  },
-  {
-    default: (): LeaderboardResponse => ({ count: 0, next: null, previous: null, results: [] }),
-    lazy: true,
-    server: false,
-  },
-);
-
-// Metadata
-const { data: lastUpdated } = useAsyncData<string>(
-  'leaderboard-metadata',
-  async () => {
-    const response = await fetchWithCsrf<z.infer<typeof LeaderboardMetadata>>('/webapi/nfts/leaderboard/metadata', {
-      method: 'GET',
-    });
-    return LeaderboardMetadata.parse(response).lastUpdated ?? '';
-  },
-  {
-    default: () => '',
-    lazy: true,
-    server: false,
-  },
-);
-
-const currentLeaderboard = computed<LeaderboardEntry[]>(() => get(leaderboardData)?.results ?? []);
-
-// Placeholder entries shown during initial load to reserve layout space
-const placeholderEntries = computed<LeaderboardEntry[]>(() =>
-  Array.from({ length: 5 }, (_, i) => ({
-    rank: i + 1,
-    address: '',
-    bronzeCount: 0,
-    silverCount: 0,
-    goldCount: 0,
-    totalCount: 0,
-    points: 0,
-    ensName: null,
-  })),
-);
-
-// Sync total from response into pagination state
-watch(leaderboardData, (data) => {
-  if (data) {
-    set(paginationData, {
-      ...get(paginationData),
-      total: data.count,
-    });
-  }
-});
-
-interface AddressDisplay {
-  primary: string;
-  showTooltip: boolean;
-  isEns: boolean;
-}
-
-const addressDisplayMap = computed<Record<string, AddressDisplay>>(() => {
-  const shouldShorten = get(isMdAndDown);
-  const entries = get(currentLeaderboard);
-  const result: Record<string, AddressDisplay> = {};
-
-  for (const holder of entries) {
-    if (holder.ensName) {
-      result[holder.address] = {
-        primary: `${holder.ensName} - ${truncateAddress(holder.address)}`,
-        showTooltip: true,
-        isEns: true,
-      };
-    }
-    else {
-      result[holder.address] = {
-        primary: shouldShorten ? truncateAddress(holder.address) : holder.address,
-        showTooltip: shouldShorten,
-        isEns: false,
-      };
-    }
-  }
-
-  return result;
-});
-
-function copyToClipboard(text: string): void {
-  set(clipboardSource, text);
-  copy();
-}
-
-async function handlePaginationChange(newPagination: PaginationData): Promise<void> {
-  set(paginationData, newPagination);
-  await refreshLeaderboard();
-}
+const {
+  paginationData,
+  loading,
+  hasData,
+  displayedEntries,
+  isEmpty,
+  lastUpdated,
+  shouldShorten,
+  handlePaginationChange,
+  copyToClipboard,
+} = useLeaderboard();
 </script>
 
 <template>
-  <div>
-    <div class="container mx-auto px-4">
-      <div class="text-center py-6 mb-6 bg-gradient-to-b from-transparent to-rui-primary/[0.05] rounded-xl">
-        <h4 class="text-h4 font-bold mb-2">
-          {{ t('sponsor.leaderboard.title') }}
-        </h4>
-        <p class="text-rui-text-secondary">
-          {{ t('sponsor.leaderboard.subtitle') }}
-        </p>
-      </div>
+  <div class="max-w-2xl mx-auto">
+    <LeaderboardHeader />
 
-      <div class="max-w-2xl mx-auto">
-        <RuiCard content-class="min-h-[480px]">
-          <div class="relative flex flex-col">
-            <!-- Loading overlay for pagination -->
-            <div
-              v-if="loading && currentLeaderboard.length > 0"
-              class="absolute inset-0 bg-white/80 dark:bg-rui-grey-900/80 backdrop-blur-sm z-10 flex items-center justify-center rounded-lg"
-            >
-              <RuiProgress
-                variant="indeterminate"
-                size="48"
-                circular
-                color="primary"
-              />
-            </div>
-
-            <template
-              v-for="(entry, index) in (currentLeaderboard.length > 0 ? currentLeaderboard : placeholderEntries)"
-              :key="currentLeaderboard.length > 0 ? entry.rank : index"
-            >
-              <RuiDivider
-                v-if="index > 0"
-                class="mt-4 pt-2 w-full"
-              />
-              <div class="flex items-center space-x-4 flex-1 min-h-[74px]">
-                <template v-if="currentLeaderboard.length > 0">
-                  <!-- Avatar (ENS or Blockie) -->
-                  <AddressAvatar
-                    :ens-name="entry.ensName"
-                    :address="entry.address"
-                  />
-
-                  <div class="flex-1">
-                    <div class="space-y-1">
-                      <RuiTooltip
-                        v-if="addressDisplayMap[entry.address]?.showTooltip"
-                        :open-delay="400"
-                      >
-                        <template #activator>
-                          <h5
-                            class="text-sm font-bold cursor-pointer hover:opacity-75 transition-opacity text-primary"
-                            @click="copyToClipboard(entry.address)"
-                          >
-                            {{ addressDisplayMap[entry.address]?.primary }}
-                          </h5>
-                        </template>
-                        <div class="text-center">
-                          <div class="font-mono text-xs">
-                            {{ entry.address }}
-                          </div>
-                          <div class="text-xs text-rui-dark-text-secondary mt-1">
-                            {{ t('sponsor.leaderboard.tooltip.copy_address') }}
-                          </div>
-                        </div>
-                      </RuiTooltip>
-                      <h5
-                        v-else
-                        class="text-sm font-bold font-mono cursor-pointer hover:opacity-75 transition-opacity"
-                        @click="copyToClipboard(entry.address)"
-                      >
-                        {{ addressDisplayMap[entry.address]?.primary }}
-                      </h5>
-                    </div>
-                    <div class="text-rui-text-secondary text-sm space-y-1">
-                      <div class="flex gap-4">
-                        <span>{{ t('sponsor.leaderboard.nft_counts', { medal: getTierMedal('gold'), count: entry.goldCount }) }}</span>
-                        <span>{{ t('sponsor.leaderboard.nft_counts', { medal: getTierMedal('silver'), count: entry.silverCount }) }}</span>
-                        <span>{{ t('sponsor.leaderboard.nft_counts', { medal: getTierMedal('bronze'), count: entry.bronzeCount }) }}</span>
-                      </div>
-                      <div class="flex items-center gap-2">
-                        <RuiTooltip :open-delay="400">
-                          <template #activator>
-                            <RuiChip
-                              color="primary"
-                              size="sm"
-                            >
-                              {{ t('sponsor.leaderboard.points', { points: entry.points }) }}
-                            </RuiChip>
-                          </template>
-                          <div>
-                            <div>{{ t('sponsor.leaderboard.tooltip.points_breakdown.gold') }}</div>
-                            <div>{{ t('sponsor.leaderboard.tooltip.points_breakdown.silver') }}</div>
-                            <div>{{ t('sponsor.leaderboard.tooltip.points_breakdown.bronze') }}</div>
-                          </div>
-                        </RuiTooltip>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="text-right">
-                    <div
-                      class="text-2xl font-bold"
-                      :class="[
-                        paginationData.page === 1 && index <= 2 ? {
-                          'text-yellow-400': index === 0,
-                          'text-gray-300': index === 1,
-                          'text-amber-500': index === 2,
-                        } : 'text-rui-text-secondary',
-                      ]"
-                    >
-                      #{{ entry.rank || (index + 1 + (paginationData.page - 1) * paginationData.limit) }}
-                    </div>
-                  </div>
-                </template>
-
-                <!-- Skeleton placeholder row -->
-                <template v-else>
-                  <RuiSkeletonLoader
-                    class="w-10 h-10 shrink-0"
-                    rounded="full"
-                  />
-                  <div class="flex-1 space-y-2">
-                    <RuiSkeletonLoader class="w-48 h-4" />
-                    <RuiSkeletonLoader class="w-32 h-3" />
-                    <RuiSkeletonLoader class="w-16 h-5" />
-                  </div>
-                  <RuiSkeletonLoader class="w-8 h-7" />
-                </template>
-              </div>
-            </template>
-          </div>
-
-          <!-- Empty State (only when loaded and truly empty) -->
-          <div
-            v-if="!loading && currentLeaderboard.length === 0 && leaderboardData?.count === 0"
-            class="text-center py-12"
-          >
-            <img
-              :alt="t('sponsor.leaderboard.empty_state')"
-              class="w-24 mx-auto"
-              src="/img/no_data_placeholder.svg"
-              width="96"
-              height="96"
-              loading="lazy"
-            />
-            <p class="text-rui-text-secondary text">
-              {{ t('sponsor.leaderboard.empty_state') }}
-            </p>
-            <i18n-t
-              keypath="sponsor.leaderboard.be_the_first"
-              scope="global"
-            >
-              <template #mint>
-                <ButtonLink
-                  color="primary"
-                  inline
-                  to="/sponsor/mint"
-                >
-                  {{ t('sponsor.leaderboard.mint') }}
-                </ButtonLink>
-              </template>
-            </i18n-t>
-          </div>
-        </RuiCard>
-
-        <p class="text-xs text-rui-text-secondary mt-2 italic">
-          {{ lastUpdated ? t('sponsor.leaderboard.last_updated', { date: formatDate(lastUpdated, 'MMMM DD, YYYY HH:mm z') }) : t('sponsor.leaderboard.updated_every_hour') }}
-        </p>
-
-        <!-- Pagination -->
+    <RuiCard content-class="min-h-[480px]">
+      <div class="relative flex flex-col">
+        <!-- Loading overlay for pagination -->
         <div
-          v-if="paginationData.total > 0"
-          class="mt-4"
+          v-if="loading && hasData"
+          class="absolute inset-0 bg-white/80 dark:bg-rui-grey-900/80 backdrop-blur-sm z-10 flex items-center justify-center rounded-lg"
         >
-          <RuiTablePagination
-            :model-value="paginationData"
-            :loading="loading"
-            @update:model-value="handlePaginationChange($event)"
+          <RuiProgress
+            variant="indeterminate"
+            size="48"
+            circular
+            color="primary"
           />
         </div>
+
+        <template
+          v-for="(entry, index) in displayedEntries"
+          :key="hasData ? entry.rank : index"
+        >
+          <RuiDivider
+            v-if="index > 0"
+            class="mt-4 pt-2 w-full"
+          />
+          <LeaderboardEntryRow
+            v-if="hasData"
+            :entry="entry"
+            :index="index"
+            :page="paginationData.page"
+            :limit="paginationData.limit"
+            :shorten="shouldShorten"
+            @copy="copyToClipboard($event)"
+          />
+          <LeaderboardEntrySkeleton v-else />
+        </template>
       </div>
 
-      <!-- Call to Action -->
-      <div class="text-center mt-6 border-t border-default">
-        <div class="bg-white/10 backdrop-blur-md rounded-xl p-8 max-w-md mx-auto">
-          <h3 class="text-2xl font-bold mb-1">
-            {{ t('sponsor.leaderboard.call_to_action.title') }}
-          </h3>
-          <p class="text-rui-text-secondary text-sm mb-4">
-            {{ t('sponsor.leaderboard.call_to_action.description') }}
-          </p>
-          <ButtonLink
-            variant="outlined"
-            to="/sponsor/mint"
-            size="lg"
-            color="primary"
-            class="mx-auto"
-          >
-            {{ t('sponsor.leaderboard.call_to_action.button') }}
-          </ButtonLink>
-        </div>
-      </div>
+      <!-- Empty State (only when loaded and truly empty) -->
+      <LeaderboardEmptyState v-if="isEmpty" />
+    </RuiCard>
+
+    <p class="text-xs text-rui-text-secondary mt-2 italic">
+      {{ lastUpdated ? t('sponsor.leaderboard.last_updated', { date: formatDate(lastUpdated, 'MMMM DD, YYYY HH:mm z') }) : t('sponsor.leaderboard.updated_every_hour') }}
+    </p>
+
+    <!-- Pagination -->
+    <div
+      v-if="paginationData.total > 0"
+      class="mt-4"
+    >
+      <RuiTablePagination
+        :model-value="paginationData"
+        :loading="loading"
+        @update:model-value="handlePaginationChange($event)"
+      />
     </div>
+
+    <!-- Call to Action -->
+    <LeaderboardCallToAction />
   </div>
 </template>

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -1090,7 +1090,7 @@
       "subtitle": "Recognizing those funding privacy-first, local software",
       "loading": "Loading leaderboard...",
       "empty_state": "Leaderboard data is empty",
-      "nft_counts": "{medal} {count} NFTs",
+      "nft_counts": "{medal} {count} NFT | {medal} {count} NFTs",
       "points": "{points} points",
       "tooltip": {
         "copy_address": "Click to copy full address",

--- a/packages/website/tests/unit/modules/sponsor/leaderboard/LeaderboardCallToAction.spec.ts
+++ b/packages/website/tests/unit/modules/sponsor/leaderboard/LeaderboardCallToAction.spec.ts
@@ -1,0 +1,19 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { describe, expect, it } from 'vitest';
+import LeaderboardCallToAction from '~/modules/sponsor/leaderboard/components/LeaderboardCallToAction.vue';
+
+describe('leaderboardCallToAction', () => {
+  it('renders the call-to-action title and description', async () => {
+    const wrapper = await mountSuspended(LeaderboardCallToAction);
+
+    expect(wrapper.text()).toContain('Support rotki. Get recognized.');
+    expect(wrapper.text()).toContain('Become a Sponsor');
+  });
+
+  it('links the sponsor button to the mint page', async () => {
+    const wrapper = await mountSuspended(LeaderboardCallToAction);
+
+    const link = wrapper.find('a');
+    expect(link.attributes('href')).toBe('/sponsor/mint');
+  });
+});

--- a/packages/website/tests/unit/modules/sponsor/leaderboard/LeaderboardEmptyState.spec.ts
+++ b/packages/website/tests/unit/modules/sponsor/leaderboard/LeaderboardEmptyState.spec.ts
@@ -1,0 +1,21 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { describe, expect, it } from 'vitest';
+import LeaderboardEmptyState from '~/modules/sponsor/leaderboard/components/LeaderboardEmptyState.vue';
+
+describe('leaderboardEmptyState', () => {
+  it('renders the empty-state message and placeholder image', async () => {
+    const wrapper = await mountSuspended(LeaderboardEmptyState);
+
+    expect(wrapper.text()).toContain('Leaderboard data is empty');
+    const img = wrapper.find('img');
+    expect(img.exists()).toBe(true);
+    expect(img.attributes('src')).toBe('/img/no_data_placeholder.svg');
+  });
+
+  it('links to the mint page', async () => {
+    const wrapper = await mountSuspended(LeaderboardEmptyState);
+
+    const mintLink = wrapper.findAll('a').find(a => a.attributes('href') === '/sponsor/mint');
+    expect(mintLink).toBeDefined();
+  });
+});

--- a/packages/website/tests/unit/modules/sponsor/leaderboard/LeaderboardEntryRow.spec.ts
+++ b/packages/website/tests/unit/modules/sponsor/leaderboard/LeaderboardEntryRow.spec.ts
@@ -1,0 +1,80 @@
+import type { LeaderboardEntry } from '~/modules/sponsor/leaderboard/types';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { describe, expect, it } from 'vitest';
+import LeaderboardEntryRow from '~/modules/sponsor/leaderboard/components/LeaderboardEntryRow.vue';
+
+const ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+function entry(overrides: Partial<LeaderboardEntry> = {}): LeaderboardEntry {
+  return {
+    rank: 1,
+    address: ADDRESS,
+    bronzeCount: 1,
+    silverCount: 2,
+    goldCount: 3,
+    totalCount: 6,
+    points: 42,
+    ensName: null,
+    ...overrides,
+  };
+}
+
+async function mountRow(props: Record<string, unknown>) {
+  return mountSuspended(LeaderboardEntryRow, {
+    props: { entry: entry(), index: 0, page: 1, limit: 10, ...props },
+    global: { stubs: { AddressAvatar: true } },
+  });
+}
+
+describe('leaderboardEntryRow', () => {
+  it('renders the full address without a tooltip when not shortening', async () => {
+    const wrapper = await mountRow({ shorten: false });
+
+    const heading = wrapper.find('p.font-mono');
+    expect(heading.text()).toBe(ADDRESS);
+    expect(heading.classes()).toContain('font-mono');
+  });
+
+  it('renders the points and rank', async () => {
+    const wrapper = await mountRow({ entry: entry({ rank: 7, points: 42 }) });
+
+    expect(wrapper.text()).toContain('42 points');
+    expect(wrapper.text()).toContain('#7');
+  });
+
+  it('uses the singular NFT label for a count of one', async () => {
+    const wrapper = await mountRow({ entry: entry({ goldCount: 1, silverCount: 2 }) });
+
+    // Gold has exactly one NFT → singular; silver has two → plural.
+    expect(wrapper.text()).toContain('1 NFT');
+    expect(wrapper.text()).not.toContain('1 NFTs');
+    expect(wrapper.text()).toContain('2 NFTs');
+  });
+
+  it('computes the rank from page/index when rank is missing', async () => {
+    const wrapper = await mountRow({ entry: entry({ rank: null }), index: 2, page: 3, limit: 10 });
+
+    expect(wrapper.text()).toContain('#23');
+  });
+
+  it('applies the gold medal class to the first entry on page 1', async () => {
+    const wrapper = await mountRow({ index: 0, page: 1 });
+
+    expect(wrapper.find('.text-yellow-400').exists()).toBe(true);
+  });
+
+  it('uses the muted rank class on later pages', async () => {
+    const wrapper = await mountRow({ index: 0, page: 2 });
+
+    expect(wrapper.find('.text-rui-text-secondary').exists()).toBe(true);
+    expect(wrapper.find('.text-yellow-400').exists()).toBe(false);
+  });
+
+  it('emits copy with the address when the name is clicked', async () => {
+    const wrapper = await mountRow({ shorten: false });
+
+    await wrapper.find('p.font-mono').trigger('click');
+
+    expect(wrapper.emitted('copy')).toEqual([[ADDRESS]]);
+  });
+});

--- a/packages/website/tests/unit/modules/sponsor/leaderboard/use-leaderboard.nuxt.spec.ts
+++ b/packages/website/tests/unit/modules/sponsor/leaderboard/use-leaderboard.nuxt.spec.ts
@@ -1,0 +1,140 @@
+import type { LeaderboardEntry, LeaderboardResponse, PaginationData } from '~/modules/sponsor/leaderboard/types';
+import { flushPromises } from '@vue/test-utils';
+import { get } from '@vueuse/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockFetchWithCsrf } = vi.hoisted(() => ({ mockFetchWithCsrf: vi.fn() }));
+
+vi.mock('~/composables/use-fetch-with-csrf', () => ({
+  useFetchWithCsrf: () => ({
+    fetchWithCsrf: mockFetchWithCsrf,
+    setHooks: vi.fn(),
+  }),
+}));
+
+const LEADERBOARD_URL = '/webapi/nfts/leaderboard/';
+const METADATA_URL = '/webapi/nfts/leaderboard/metadata';
+
+function entry(overrides: Partial<LeaderboardEntry> = {}): LeaderboardEntry {
+  return {
+    rank: 1,
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+    bronzeCount: 1,
+    silverCount: 2,
+    goldCount: 3,
+    totalCount: 6,
+    points: 42,
+    ensName: null,
+    ...overrides,
+  };
+}
+
+function response(overrides: Partial<LeaderboardResponse> = {}): LeaderboardResponse {
+  return { count: 1, next: null, previous: null, results: [entry()], ...overrides };
+}
+
+/**
+ * Routes each mocked request to the matching payload. The leaderboard endpoint
+ * resolves with `leaderboard`, the metadata endpoint with `{ lastUpdated }`.
+ */
+function mockApi(leaderboard: LeaderboardResponse, lastUpdated: string | null = null): void {
+  mockFetchWithCsrf.mockImplementation(async (url: string) => {
+    if (url === METADATA_URL) {
+      return { lastUpdated };
+    }
+    return leaderboard;
+  });
+}
+
+const firstPage: PaginationData = { page: 1, total: 0, limit: 10, limits: [10, 25, 50, 100] };
+
+describe('useLeaderboard', () => {
+  afterEach(() => {
+    // useAsyncData caches by key in the shared Nuxt instance; clear it so state
+    // does not leak between tests.
+    clearNuxtData();
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('fetches the leaderboard with a zero offset on the first page', async () => {
+    mockApi(response());
+    const { useLeaderboard } = await import('~/modules/sponsor/leaderboard/composables/use-leaderboard');
+
+    const { currentLeaderboard, hasData, handlePaginationChange } = useLeaderboard();
+    await handlePaginationChange(firstPage);
+    await flushPromises();
+
+    expect(mockFetchWithCsrf).toHaveBeenCalledWith(LEADERBOARD_URL, {
+      method: 'GET',
+      query: { offset: 0, limit: 10 },
+    });
+    expect(get(hasData)).toBe(true);
+    expect(get(currentLeaderboard)).toHaveLength(1);
+  });
+
+  it('syncs the total from the response count into pagination state', async () => {
+    mockApi(response({ count: 137 }));
+    const { useLeaderboard } = await import('~/modules/sponsor/leaderboard/composables/use-leaderboard');
+
+    const { paginationData, handlePaginationChange } = useLeaderboard();
+    await handlePaginationChange(firstPage);
+    await flushPromises();
+
+    expect(get(paginationData).total).toBe(137);
+  });
+
+  it('shows skeleton placeholders while loading before any data resolves', async () => {
+    mockApi(response());
+    const { useLeaderboard } = await import('~/modules/sponsor/leaderboard/composables/use-leaderboard');
+
+    // No fetch awaited yet: still loading, no data, not empty → skeletons.
+    const { displayedEntries, hasData, showSkeleton } = useLeaderboard();
+
+    expect(get(hasData)).toBe(false);
+    expect(get(showSkeleton)).toBe(true);
+    expect(get(displayedEntries)).toHaveLength(5);
+  });
+
+  it('renders the fetched entries (not placeholders) once data has loaded', async () => {
+    mockApi(response({ count: 2, results: [entry({ rank: 1 }), entry({ rank: 2 })] }));
+    const { useLeaderboard } = await import('~/modules/sponsor/leaderboard/composables/use-leaderboard');
+
+    const { displayedEntries, hasData, showSkeleton, handlePaginationChange } = useLeaderboard();
+    await handlePaginationChange(firstPage);
+    await flushPromises();
+
+    expect(get(hasData)).toBe(true);
+    expect(get(showSkeleton)).toBe(false);
+    expect(get(displayedEntries)).toHaveLength(2);
+  });
+
+  it('reports an empty leaderboard once an empty response has loaded', async () => {
+    mockApi(response({ count: 0, results: [] }));
+    const { useLeaderboard } = await import('~/modules/sponsor/leaderboard/composables/use-leaderboard');
+
+    const { isEmpty, hasData, handlePaginationChange } = useLeaderboard();
+    await handlePaginationChange(firstPage);
+    await flushPromises();
+
+    expect(get(hasData)).toBe(false);
+    expect(get(isEmpty)).toBe(true);
+  });
+
+  // Regression: skeleton placeholders must NOT render alongside the empty state.
+  // Previously displayedEntries fell back to 5 placeholders whenever there was
+  // no data, so a loaded-but-empty leaderboard showed skeletons *and* the empty
+  // message at the same time.
+  it('does not show skeleton placeholders once an empty response has loaded', async () => {
+    mockApi(response({ count: 0, results: [] }));
+    const { useLeaderboard } = await import('~/modules/sponsor/leaderboard/composables/use-leaderboard');
+
+    const { displayedEntries, showSkeleton, isEmpty, handlePaginationChange } = useLeaderboard();
+    await handlePaginationChange(firstPage);
+    await flushPromises();
+
+    expect(get(isEmpty)).toBe(true);
+    expect(get(showSkeleton)).toBe(false);
+    expect(get(displayedEntries)).toHaveLength(0);
+  });
+});

--- a/packages/website/tests/unit/modules/sponsor/leaderboard/utils.spec.ts
+++ b/packages/website/tests/unit/modules/sponsor/leaderboard/utils.spec.ts
@@ -1,0 +1,134 @@
+import type { LeaderboardEntry } from '~/modules/sponsor/leaderboard/types';
+import { describe, expect, it } from 'vitest';
+import {
+  buildAddressDisplay,
+  calculateOffset,
+  createPlaceholderEntries,
+  getDisplayRank,
+  getRankClass,
+} from '~/modules/sponsor/leaderboard/utils';
+import { truncateAddress } from '~/utils/text';
+
+const ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+function entry(overrides: Partial<LeaderboardEntry> = {}): LeaderboardEntry {
+  return {
+    rank: 1,
+    address: ADDRESS,
+    bronzeCount: 0,
+    silverCount: 0,
+    goldCount: 0,
+    totalCount: 0,
+    points: 0,
+    ensName: null,
+    ...overrides,
+  };
+}
+
+describe('createPlaceholderEntries', () => {
+  it('creates 5 placeholder entries by default', () => {
+    const entries = createPlaceholderEntries();
+
+    expect(entries).toHaveLength(5);
+  });
+
+  it('honours a custom count', () => {
+    expect(createPlaceholderEntries(3)).toHaveLength(3);
+  });
+
+  it('assigns sequential ranks and zeroed counts', () => {
+    const entries = createPlaceholderEntries(2);
+
+    expect(entries[0]).toEqual({
+      rank: 1,
+      address: '',
+      bronzeCount: 0,
+      silverCount: 0,
+      goldCount: 0,
+      totalCount: 0,
+      points: 0,
+      ensName: null,
+    });
+    expect(entries[1]?.rank).toBe(2);
+  });
+});
+
+describe('buildAddressDisplay', () => {
+  it('shows ENS name with truncated address and tooltip', () => {
+    const result = buildAddressDisplay({ address: ADDRESS, ensName: 'rotki.eth' }, false);
+
+    expect(result).toEqual({
+      primary: `rotki.eth - ${truncateAddress(ADDRESS)}`,
+      showTooltip: true,
+      isEns: true,
+    });
+  });
+
+  it('keeps ENS formatting even when shortening is requested', () => {
+    const result = buildAddressDisplay({ address: ADDRESS, ensName: 'rotki.eth' }, true);
+
+    expect(result.isEns).toBe(true);
+    expect(result.primary).toBe(`rotki.eth - ${truncateAddress(ADDRESS)}`);
+  });
+
+  it('shows the full address without tooltip when not shortening', () => {
+    const result = buildAddressDisplay({ address: ADDRESS, ensName: null }, false);
+
+    expect(result).toEqual({
+      primary: ADDRESS,
+      showTooltip: false,
+      isEns: false,
+    });
+  });
+
+  it('truncates the address with a tooltip when shortening', () => {
+    const result = buildAddressDisplay({ address: ADDRESS, ensName: null }, true);
+
+    expect(result).toEqual({
+      primary: truncateAddress(ADDRESS),
+      showTooltip: true,
+      isEns: false,
+    });
+  });
+});
+
+describe('calculateOffset', () => {
+  it('returns 0 for the first page', () => {
+    expect(calculateOffset(1, 10)).toBe(0);
+  });
+
+  it('multiplies the zero-based page index by the limit', () => {
+    expect(calculateOffset(3, 25)).toBe(50);
+  });
+});
+
+describe('getDisplayRank', () => {
+  it('uses the backend-provided rank when present', () => {
+    expect(getDisplayRank(entry({ rank: 7 }), 0, 1, 10)).toBe(7);
+  });
+
+  it('derives the rank from page/index when rank is null', () => {
+    expect(getDisplayRank(entry({ rank: null }), 0, 1, 10)).toBe(1);
+    expect(getDisplayRank(entry({ rank: null }), 2, 3, 10)).toBe(23);
+  });
+
+  it('derives the rank when rank is 0 (falsy)', () => {
+    expect(getDisplayRank(entry({ rank: 0 }), 4, 2, 25)).toBe(30);
+  });
+});
+
+describe('getRankClass', () => {
+  it('returns medal classes for the top three on page 1', () => {
+    expect(getRankClass(1, 0)).toEqual({ 'text-yellow-400': true, 'text-gray-400': false, 'text-amber-500': false });
+    expect(getRankClass(1, 1)).toEqual({ 'text-yellow-400': false, 'text-gray-400': true, 'text-amber-500': false });
+    expect(getRankClass(1, 2)).toEqual({ 'text-yellow-400': false, 'text-gray-400': false, 'text-amber-500': true });
+  });
+
+  it('returns the muted class for entries beyond the top three', () => {
+    expect(getRankClass(1, 3)).toBe('text-rui-text-secondary');
+  });
+
+  it('returns the muted class for all entries on later pages', () => {
+    expect(getRankClass(2, 0)).toBe('text-rui-text-secondary');
+  });
+});


### PR DESCRIPTION
## Summary

Splits the monolithic `app/pages/sponsor/leaderboard.vue` into a modular, testable structure under `app/modules/sponsor/leaderboard/`. The page is now a thin orchestrator.

- **`types.ts`** — zod schemas (`XxxSchema`) + inferred types, `PaginationData`, `AddressDisplay`
- **`utils.ts`** — pure helpers: `createPlaceholderEntries`, `buildAddressDisplay`, `calculateOffset`, `getDisplayRank`, `getRankClass`
- **`composables/use-leaderboard.ts`** — data fetching, pagination, derived state, clipboard
- **`components/`** — `LeaderboardHeader`, `LeaderboardEntryRow`, `LeaderboardEntrySkeleton`, `LeaderboardEmptyState`, `LeaderboardCallToAction`

## Tests

New unit tests (32 total, all green): pure utils, the composable (fetch wiring, total sync, empty/skeleton states), and the content components — including a named regression test for the skeleton-vs-empty bug below.

## UI / a11y polish

- Pluralize NFT counts (`1 NFT` vs `N NFTs`)
- Darken the `#2` silver rank for legibility (`text-gray-300` → `text-gray-400`)
- Flip the hero gradient to a top-down halo behind the title
- Fix heading hierarchy: hero `<h1>`, row addresses `<p>` (were `<h5>`), CTA `<h2>`
- Align header / list / footnote / pagination / CTA to one `max-w-2xl` column (removed a redundant nested container)

## Bug fix

A loaded-but-empty leaderboard rendered **5 skeleton placeholder rows alongside the empty-state message**. Skeletons now show only while loading with no data yet (`showSkeleton = !hasData && !isEmpty`), covered by a regression test.

## Verification

- `pnpm test` (module specs): 32 passing
- `pnpm lint`: 0 warnings/errors in the refactored code
- `pnpm typecheck`: clean
- Verified in-browser on desktop and mobile