### PR TITLE
chore(card-payment): resolve easy lint warnings

### DIFF
--- a/packages/card-payment/src/App.vue
+++ b/packages/card-payment/src/App.vue
@@ -218,7 +218,6 @@ onMounted(async () => {
     <CheckoutLayout
       v-else-if="planData && selectedPlan"
       :steps="steps"
-      :current-step="3"
     >
       <CardPayment
         v-model:selected-card="selectedCard"

--- a/packages/card-payment/src/components/BaseButton.vue
+++ b/packages/card-payment/src/components/BaseButton.vue
@@ -22,6 +22,10 @@ const emit = defineEmits<{
   click: [];
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const buttonClasses = computed<string>(() => {
   const baseClasses = 'relative flex items-center justify-center gap-2 font-medium outline-1 outline-offset-[-1px] outline-transparent rounded border-0 transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed';
 

--- a/packages/card-payment/src/components/BaseDialog.vue
+++ b/packages/card-payment/src/components/BaseDialog.vue
@@ -8,6 +8,11 @@ const { title, maxWidth = 'md' } = defineProps<{
   maxWidth?: 'sm' | 'md' | 'lg' | 'xl';
 }>();
 
+defineSlots<{
+  default: () => any;
+  actions: () => any;
+}>();
+
 const maxWidthClass = computed<string>(() => {
   const widths = {
     sm: 'max-w-sm',

--- a/packages/card-payment/src/components/CheckoutLayout.vue
+++ b/packages/card-payment/src/components/CheckoutLayout.vue
@@ -11,10 +11,13 @@ interface Step {
 
 interface Props {
   steps: Step[];
-  currentStep?: number;
 }
 
 defineProps<Props>();
+
+defineSlots<{
+  default: () => any;
+}>();
 </script>
 
 <template>

--- a/packages/card-payment/src/components/DiscountCodeInput.vue
+++ b/packages/card-payment/src/components/DiscountCodeInput.vue
@@ -6,7 +6,7 @@ import { computed, ref, watch } from 'vue';
 
 const model = defineModel<string>({ required: true });
 
-const props = defineProps<{
+const { discountInfo } = defineProps<{
   discountInfo?: PaymentBreakdownDiscount;
   loading?: boolean;
 }>();
@@ -23,17 +23,17 @@ function isInvalidDiscount(info: PaymentBreakdownDiscount | undefined): info is 
   return !!(info && !info.isValid);
 }
 
-const isApplied = computed<boolean>(() => isValidDiscount(props.discountInfo));
+const isApplied = computed<boolean>(() => isValidDiscount(discountInfo));
 
-const hasError = computed<boolean>(() => isInvalidDiscount(props.discountInfo));
+const hasError = computed<boolean>(() => isInvalidDiscount(discountInfo));
 
 const errorMessage = computed<string>(() => {
-  const info = props.discountInfo;
+  const info = discountInfo;
   return isInvalidDiscount(info) ? info.error : '';
 });
 
 const appliedDiscountAmount = computed<string>(() => {
-  const info = props.discountInfo;
+  const info = discountInfo;
   return isValidDiscount(info) && info.discountType === DiscountType.PERCENTAGE && info.discountAmount
     ? `${info.discountAmount}% off`
     : '';

--- a/packages/card-payment/src/components/NewCardForm.vue
+++ b/packages/card-payment/src/components/NewCardForm.vue
@@ -2,21 +2,19 @@
 import type { Client } from 'braintree-web/client';
 import { get, set } from '@vueuse/core';
 import { create as createHostedFields, type HostedFields } from 'braintree-web/hosted-fields';
-import { computed, onMounted, onUnmounted, reactive, ref, toRefs, watch } from 'vue';
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 
 interface Props {
   client: Client;
   disabled?: boolean;
 }
 
-const props = defineProps<Props>();
+const { client, disabled } = defineProps<Props>();
 
 const emit = defineEmits<{
   'validation-change': [isValid: boolean];
   'error': [message: string];
 }>();
-
-const { client, disabled } = toRefs(props);
 
 const hostedFields = ref<HostedFields>();
 const hostedFieldsInitializing = ref<boolean>(false);
@@ -69,7 +67,7 @@ async function initializeHostedFields(): Promise<void> {
 
   try {
     const fieldsInstance = await createHostedFields({
-      client: get(client),
+      client,
       styles: {
         'body': {
           'font-size': '16px',
@@ -142,7 +140,7 @@ function setupHostedFieldsEvents(fieldsInstance: HostedFields): void {
     updateFieldState(event.emittedBy, { hasContent: true });
   });
 
-  watch(disabled, (isDisabled) => {
+  watch(() => disabled, (isDisabled) => {
     const fields = ['number', 'expirationDate', 'cvv'] as const;
 
     fields.forEach((field) => {

--- a/packages/card-payment/src/components/PlanSummary.vue
+++ b/packages/card-payment/src/components/PlanSummary.vue
@@ -3,7 +3,7 @@ import type { PaymentBreakdownResponse, SelectedPlan } from '@rotki/card-payment
 import { formatCreditedAmount } from '@rotki/card-payment-common/utils/checkout';
 import { watchImmediate } from '@vueuse/core';
 import { get, set } from '@vueuse/shared';
-import { computed, onMounted, ref, toRefs, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { getPaymentBreakdown } from '@/utils/api';
 import { formatDate } from '@/utils/date';
 
@@ -15,33 +15,31 @@ interface Props {
 
 const breakdown = defineModel<PaymentBreakdownResponse | undefined>('breakdown', { required: false });
 
-const props = defineProps<Props>();
-
-const { upgrade, selectedPlan, discountCode } = toRefs(props);
+const { upgrade, selectedPlan, discountCode } = defineProps<Props>();
 
 const isLoadingBreakdown = ref<boolean>(false);
 
-const name = computed<string>(() => getPlanNameFor(get(selectedPlan)));
+const name = computed<string>(() => getPlanNameFor(selectedPlan));
 
 const date = computed<string>(() => formatDate(new Date()));
 
 const durationDescription = computed<string>(() => {
-  if (get(selectedPlan).durationInMonths === 12)
+  if (selectedPlan.durationInMonths === 12)
     return '1 year (12 months) recurring subscription';
   return '1 month recurring subscription';
 });
 
 const displayPrice = computed<string>(() => {
   const currentBreakdown = get(breakdown);
-  if (currentBreakdown && !get(upgrade)) {
+  if (currentBreakdown && !upgrade) {
     return currentBreakdown.fullAmount;
   }
-  return get(selectedPlan).price.toString();
+  return selectedPlan.price.toString();
 });
 
 const proratedPrice = computed<string | undefined>(() => {
   const currentBreakdown = get(breakdown);
-  if (!currentBreakdown || !get(upgrade)) {
+  if (!currentBreakdown || !upgrade) {
     return undefined;
   }
   return currentBreakdown.fullAmount;
@@ -67,9 +65,9 @@ function getPlanNameFor(plan: SelectedPlan): string {
 async function loadPaymentBreakdown(): Promise<void> {
   set(isLoadingBreakdown, true);
   try {
-    const code = get(discountCode);
+    const code = discountCode;
     const response = await getPaymentBreakdown({
-      newPlanId: get(selectedPlan).planId,
+      newPlanId: selectedPlan.planId,
       isCryptoPayment: false,
       ...(code ? { discountCode: code } : {}),
     });
@@ -83,14 +81,14 @@ async function loadPaymentBreakdown(): Promise<void> {
   }
 }
 
-watchImmediate(selectedPlan, (newPlan, oldPlan) => {
+watchImmediate(() => selectedPlan, (newPlan, oldPlan) => {
   if (newPlan && newPlan.planId !== oldPlan?.planId) {
     loadPaymentBreakdown();
   }
 });
 
 // Refresh breakdown when discount code changes
-watch(discountCode, () => {
+watch(() => discountCode, () => {
   loadPaymentBreakdown();
 });
 

--- a/packages/card-payment/src/layouts/default.vue
+++ b/packages/card-payment/src/layouts/default.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import Footer from '@/components/Footer.vue';
 import Header from '@/components/Header.vue';
+
+defineSlots<{
+  default: () => any;
+}>();
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Clears the low-risk, mechanical lint warnings in the `card-payment` package (**11 → 2 warnings**). The remaining 2 are `complexity` warnings (`load`, `processPayment`), which are a larger refactor and intentionally left for a follow-up.

## Changes

- **`vue/require-explicit-slots`** (5): add explicit `defineSlots` to `BaseButton`, `BaseDialog`, `CheckoutLayout`, and the default layout.
- **`vue/define-props-destructuring`** (3): destructure props directly from `defineProps` in `DiscountCodeInput`, `NewCardForm`, and `PlanSummary` (drops the `toRefs`/`props.` indirection — matches the preferred Vue 3.5 style in CLAUDE.md).
- **`vue/no-unused-properties`** (1): remove the unused `currentStep` prop from `CheckoutLayout` and its `:current-step` pass-site in `App.vue`.

## Verification

- `vue-tsc --noEmit` passes.
- `eslint` clean on the package except the 2 pre-existing `complexity` warnings.

No behavioral changes — these are declarative slot/prop refactors verified by typecheck.