### PR TITLE
feat(web3): show reverse-ENS name on the connected-wallet card

### DIFF
--- a/packages/website/app/modules/web3/components/WalletAccountSummary.vue
+++ b/packages/website/app/modules/web3/components/WalletAccountSummary.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core';
+import { get } from '@vueuse/shared';
 import AddressAvatar from '~/components/common/AddressAvatar.vue';
+import { useEnsName } from '~/modules/web3/composables/use-ens-name';
 import { truncateAddress } from '~/modules/web3/core/format';
 
 const { address, ensName } = defineProps<{
@@ -11,22 +13,34 @@ const { address, ensName } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
+const { ensName: resolvedEnsName, loading: ensLoading } = useEnsName(() => address);
+
 const source = computed<string>(() => address);
 const { copy, copied, isSupported } = useClipboard({ copiedDuring: 1500, source });
 
-const display = computed<string>(() => ensName || truncateAddress(address));
+// The `ensName` prop is an explicit override; otherwise use the reverse-resolved name.
+const effectiveEnsName = computed<string | undefined>(() => ensName || get(resolvedEnsName));
+
+const display = computed<string>(() => get(effectiveEnsName) || truncateAddress(address));
 </script>
 
 <template>
   <div class="flex items-center gap-3 p-2.5 rounded-lg border border-rui-grey-200 dark:border-rui-grey-800 bg-rui-grey-50 dark:bg-rui-grey-900/40">
     <AddressAvatar
       :address="address"
-      :ens-name="ensName"
+      :ens-name="effectiveEnsName"
     />
 
     <div class="flex flex-col min-w-0 flex-1">
-      <span class="text-xs text-rui-text-secondary leading-tight">
+      <span class="flex items-center gap-1 text-xs text-rui-text-secondary leading-tight">
         {{ t('sponsor.connected_account.label') }}
+        <RuiIcon
+          v-if="get(ensLoading) && !effectiveEnsName"
+          class="animate-spin text-rui-text-disabled"
+          name="lu-loader-circle"
+          size="12"
+          :aria-label="t('sponsor.connected_account.resolving_ens')"
+        />
       </span>
       <span class="text-sm font-medium font-mono truncate text-rui-text">
         {{ display }}

--- a/packages/website/app/modules/web3/composables/use-ens-name.ts
+++ b/packages/website/app/modules/web3/composables/use-ens-name.ts
@@ -1,0 +1,78 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
+import { set } from '@vueuse/shared';
+import { getOr } from 'plainfp/result';
+import { peekEnsName } from '~/modules/web3/core/ens-cache';
+import { useLogger } from '~/utils/use-logger';
+
+export interface UseEnsNameReturn {
+  /** The connected address' primary ENS name, or `undefined` when none/unresolved. */
+  ensName: Readonly<Ref<string | undefined>>;
+  /** True while a reverse lookup is in flight (incl. the debounce window). */
+  loading: Readonly<Ref<boolean>>;
+}
+
+/**
+ * Best-effort reverse-ENS lookup for a (reactive) address. Errors are swallowed (the
+ * name is a cosmetic enhancement, never a blocker) — the card just keeps showing the
+ * truncated address.
+ *
+ * An already-resolved name is seeded *synchronously* from the session cache (see
+ * `core/ens-cache`, which is viem-free) so the card never flickers to the truncated
+ * address before a known name appears. Only an actual network lookup is debounced (so
+ * rapid address changes don't fan out RPC calls) and stale-guarded (so a slow response
+ * for a previous address never overwrites a newer one). `core/ens` (and viem) is
+ * dynamically imported on that path so it stays in an async chunk, off the initial bundle.
+ */
+export function useEnsName(address: MaybeRefOrGetter<string | undefined>): UseEnsNameReturn {
+  const ensName = shallowRef<string>();
+  const loading = shallowRef<boolean>(false);
+
+  const logger = useLogger('ens-name');
+
+  const lookup = useDebounceFn(async (owner: string): Promise<void> => {
+    try {
+      const { resolveEnsName } = await import('~/modules/web3/core/ens');
+      const result = await resolveEnsName(owner);
+      // A newer address arrived while this lookup was in flight — drop the result.
+      if (toValue(address) !== owner)
+        return;
+      set(ensName, getOr(result, undefined));
+    }
+    catch (error) {
+      logger.error('Failed to resolve ENS name:', error);
+    }
+    finally {
+      // Only the lookup for the current address owns the loading flag.
+      if (toValue(address) === owner)
+        set(loading, false);
+    }
+  }, 300);
+
+  watch(() => toValue(address), (owner) => {
+    if (!owner) {
+      set(ensName, undefined);
+      set(loading, false);
+      return;
+    }
+
+    // Already known — seed in the same tick so the card shows the name immediately.
+    const cached = peekEnsName(owner);
+    if (cached.hit) {
+      set(ensName, cached.name);
+      set(loading, false);
+      return;
+    }
+
+    // Unknown address: blank any previous name and resolve in the background. The
+    // lookup swallows its own errors, so the returned promise never rejects.
+    set(ensName, undefined);
+    set(loading, true);
+    lookup(owner).catch(() => {});
+  }, { immediate: true });
+
+  return {
+    ensName: shallowReadonly(ensName),
+    loading: shallowReadonly(loading),
+  };
+}

--- a/packages/website/app/modules/web3/core/chains.ts
+++ b/packages/website/app/modules/web3/core/chains.ts
@@ -34,7 +34,12 @@ export interface ChainMeta {
 // here MUST also be listed in the backend CSP `connect-src`
 // (backend/internal/csp/policies.go) or the browser blocks the read and balances
 // silently come back empty. Keep the two in sync.
-const ETHEREUM_RPCS = [
+//
+// `ETHEREUM_RPCS` is exported because reverse-ENS resolution (`core/ens.ts`) runs
+// on mainnet via a standalone viem client and reuses these same already-allowed
+// hosts — ENS is mainnet-only, so it can't rely on the wagmi config, which omits
+// mainnet in testnet mode.
+export const ETHEREUM_RPCS = [
   'https://eth.merkle.io',
   'https://eth.llamarpc.com',
   'https://ethereum-rpc.publicnode.com',

--- a/packages/website/app/modules/web3/core/ens-cache.ts
+++ b/packages/website/app/modules/web3/core/ens-cache.ts
@@ -1,0 +1,36 @@
+/**
+ * Session cache for reverse-ENS results, split out from `core/ens` (which statically
+ * pulls in viem and so is only ever dynamically imported). Keeping the cache here, in
+ * a viem-free module, lets the composable peek it *synchronously* on first render and
+ * seed the already-known name without flickering to the truncated address — no
+ * debounce wait, no dynamic import, no RPC.
+ *
+ * Lives for the page session only (module state, no persistence) with no expiry — a
+ * primary name is stable per address and changes rarely enough that a page reload is a
+ * fine refresh point. Keyed by lower-cased address; checksumming is only needed for the
+ * RPC call itself, not for cache identity.
+ */
+const cache = new Map<string, string | undefined>();
+
+export interface CachedEnsName {
+  /** Whether the address has a cached result — distinguishes a cached `undefined` miss from an absent key. */
+  readonly hit: boolean;
+  /** The cached name, or `undefined` for a cached "no primary name" result. */
+  readonly name: string | undefined;
+}
+
+/** Synchronously read the cached name for an address, if any. */
+export function peekEnsName(address: string): CachedEnsName {
+  const key = address.toLowerCase();
+  return { hit: cache.has(key), name: cache.get(key) };
+}
+
+/** Cache a resolved result. Both hits and confirmed misses (`undefined`) are stored. */
+export function cacheEnsName(address: string, name: string | undefined): void {
+  cache.set(address.toLowerCase(), name);
+}
+
+/** Drop all cached names. Intended for tests, which otherwise leak state across cases. */
+export function resetEnsCache(): void {
+  cache.clear();
+}

--- a/packages/website/app/modules/web3/core/ens.ts
+++ b/packages/website/app/modules/web3/core/ens.ts
@@ -1,0 +1,85 @@
+import { ok, type Result, tap } from 'plainfp/result';
+import { fromPromise } from 'plainfp/result-async';
+import { createPublicClient, fallback, getAddress, http, type PublicClient } from 'viem';
+import { mainnet } from 'viem/chains';
+import { ETHEREUM_RPCS } from './chains';
+import { cacheEnsName, peekEnsName, resetEnsCache } from './ens-cache';
+import { fromCause, type Web3Error } from './errors';
+
+/**
+ * Per-request RPC timeout for the reverse-ENS lookup. Kept short — the name is a
+ * best-effort cosmetic enhancement to the connected-wallet card, never a blocker,
+ * so a stalled endpoint should fail fast and let the `fallback` transport advance.
+ */
+const ENS_TIMEOUT_MS = 10_000;
+
+/**
+ * Standalone mainnet viem client, decoupled from the wagmi `Config`. ENS lives on
+ * Ethereum mainnet only, but the wagmi config omits mainnet in testnet mode — so
+ * reverse resolution can't go through `core/actions`. It reuses `ETHEREUM_RPCS`,
+ * whose hosts are already in the backend CSP `connect-src`, so no extra origins.
+ *
+ * Memoized: the first call builds the client (and its `fallback` transport); later
+ * calls reuse it. This module pulls viem statically, so it must only ever be
+ * reached through a dynamic import (see `use-ens-name`) to stay out of the bundle.
+ */
+let client: PublicClient | undefined;
+
+function ensClient(): PublicClient {
+  if (!client) {
+    client = createPublicClient({
+      chain: mainnet,
+      transport: fallback(ETHEREUM_RPCS.map(url => http(url, { timeout: ENS_TIMEOUT_MS }))),
+    });
+  }
+  return client;
+}
+
+/**
+ * In-flight lookups, keyed by checksummed address, so concurrent callers for the same
+ * address share one RPC round-trip instead of fanning out duplicate requests.
+ */
+const inflight = new Map<string, Promise<Result<string | undefined, Web3Error>>>();
+
+/**
+ * Reverse-resolve an address to its primary ENS name. Resolves to `undefined`
+ * when the address has no name set (viem returns `null`); any RPC/transport
+ * failure becomes a typed {@link Web3Error} the caller can swallow.
+ *
+ * Backed by the session cache (see `ens-cache`) and in-flight dedup, so a fresh
+ * lookup only happens on a cache miss with no request already running. Successful
+ * results — including confirmed misses — are cached; errors are not, so a transient
+ * RPC failure retries on the next call.
+ */
+export async function resolveEnsName(address: string): Promise<Result<string | undefined, Web3Error>> {
+  const cached = peekEnsName(address);
+  if (cached.hit)
+    return ok(cached.name);
+
+  const key = getAddress(address);
+  let pending = inflight.get(key);
+  if (!pending) {
+    pending = fromPromise(
+      ensClient().getEnsName({ address: key }).then(name => name ?? undefined),
+      cause => fromCause(cause, 'TxFailed'),
+    )
+      .then(result => tap(result, (name) => {
+        cacheEnsName(address, name);
+      }))
+      .finally(() => {
+        inflight.delete(key);
+      });
+    inflight.set(key, pending);
+  }
+
+  return pending;
+}
+
+/**
+ * Drop all cached names and in-flight lookups. Intended for tests, which share this
+ * module's state across cases and otherwise leak a cached result from one into the next.
+ */
+export function clearEnsCache(): void {
+  resetEnsCache();
+  inflight.clear();
+}

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -1111,7 +1111,8 @@
       "label": "Connected wallet",
       "copy_address": "Copy address",
       "copied": "Copied!",
-      "change": "Change"
+      "change": "Change",
+      "resolving_ens": "Resolving ENS name"
     },
     "leaderboard": {
       "be_the_first": "Be the first to {mint}",

--- a/packages/website/tests/unit/modules/web3/components/WalletAccountSummary.spec.ts
+++ b/packages/website/tests/unit/modules/web3/components/WalletAccountSummary.spec.ts
@@ -18,6 +18,11 @@ vi.mock('@vueuse/core', async () => {
   };
 });
 
+// Stub reverse-ENS resolution so the component never hits the network.
+vi.mock('~/modules/web3/composables/use-ens-name', () => ({
+  useEnsName: () => ({ ensName: ref<string>(), loading: ref<boolean>(false) }),
+}));
+
 async function mountSummary(props: Record<string, unknown> = {}) {
   return mountSuspended(WalletAccountSummary, {
     props: { address: ADDRESS, open: vi.fn(), ...props },

--- a/packages/website/tests/unit/modules/web3/composables/use-ens-name.spec.ts
+++ b/packages/website/tests/unit/modules/web3/composables/use-ens-name.spec.ts
@@ -1,0 +1,161 @@
+import { err, ok } from 'plainfp/result';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import { useEnsName } from '~/modules/web3/composables/use-ens-name';
+import { resolveEnsName } from '~/modules/web3/core/ens';
+import { cacheEnsName, resetEnsCache } from '~/modules/web3/core/ens-cache';
+import { validation } from '~/modules/web3/core/errors';
+
+const ADDRESS_A = '0xaaaa000000000000000000000000000000000000';
+const ADDRESS_B = '0xbbbb000000000000000000000000000000000000';
+
+// The composable dynamically imports core/ens; vi.mock intercepts that too.
+vi.mock('~/modules/web3/core/ens', () => ({
+  resolveEnsName: vi.fn(),
+}));
+
+vi.mock('~/utils/use-logger', () => ({
+  useLogger: () => ({ error: vi.fn() }),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+// Mount the composable inside an effect scope so its watcher is owned/cleanable,
+// then let the 300ms debounce fire and any in-flight resolve settle.
+function mount(address: Parameters<typeof useEnsName>[0]) {
+  const scope = effectScope();
+  const result = scope.run(() => useEnsName(address))!;
+  return { ...result, stop: () => scope.stop() };
+}
+
+describe('useEnsName', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(resolveEnsName).mockReset();
+    resetEnsCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves the name for the initial address once the debounce elapses', async () => {
+    vi.mocked(resolveEnsName).mockResolvedValue(ok('rotki.eth'));
+    const { ensName, stop } = mount(ref(ADDRESS_A));
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(resolveEnsName).toHaveBeenCalledWith(ADDRESS_A);
+    expect(ensName.value).toBe('rotki.eth');
+    stop();
+  });
+
+  it('seeds a cached name synchronously, without a debounce wait or lookup', async () => {
+    cacheEnsName(ADDRESS_A, 'cached.eth');
+    const { ensName, loading, stop } = mount(ref(ADDRESS_A));
+
+    // No timer advance: the name is present on the first synchronous tick.
+    expect(ensName.value).toBe('cached.eth');
+    expect(loading.value).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(resolveEnsName).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('seeds a cached miss (no name) synchronously, without re-querying', async () => {
+    cacheEnsName(ADDRESS_A, undefined);
+    const { ensName, loading, stop } = mount(ref(ADDRESS_A));
+
+    expect(ensName.value).toBeUndefined();
+    expect(loading.value).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(resolveEnsName).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('does not query and clears the name when the address is undefined', async () => {
+    const { ensName, stop } = mount(ref<string>());
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(resolveEnsName).not.toHaveBeenCalled();
+    expect(ensName.value).toBeUndefined();
+    stop();
+  });
+
+  it('debounces rapid address changes into a single lookup', async () => {
+    vi.mocked(resolveEnsName).mockResolvedValue(ok('rotki.eth'));
+    const address = ref<string>(ADDRESS_A);
+    const { stop } = mount(address);
+
+    address.value = ADDRESS_B;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(resolveEnsName).toHaveBeenCalledTimes(1);
+    expect(resolveEnsName).toHaveBeenCalledWith(ADDRESS_B);
+    stop();
+  });
+
+  it('swallows resolution errors and leaves the name undefined', async () => {
+    vi.mocked(resolveEnsName).mockResolvedValue(err(validation('boom')));
+    const { ensName, loading, stop } = mount(ref(ADDRESS_A));
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(ensName.value).toBeUndefined();
+    expect(loading.value).toBe(false);
+    stop();
+  });
+
+  it('toggles loading around an in-flight lookup', async () => {
+    const pending = deferred<ReturnType<typeof ok<string | undefined>>>();
+    vi.mocked(resolveEnsName).mockReturnValue(pending.promise);
+    const { loading, stop } = mount(ref(ADDRESS_A));
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(loading.value).toBe(true);
+
+    pending.resolve(ok('rotki.eth'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(loading.value).toBe(false);
+    stop();
+  });
+
+  it('drops a stale response when a newer address arrives mid-flight', async () => {
+    const first = deferred<ReturnType<typeof ok<string | undefined>>>();
+    const second = deferred<ReturnType<typeof ok<string | undefined>>>();
+    vi.mocked(resolveEnsName)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const address = ref<string>(ADDRESS_A);
+    const { ensName, stop } = mount(address);
+
+    // First lookup (address A) is now in flight.
+    await vi.advanceTimersByTimeAsync(300);
+
+    // Switch to B and let its lookup start before A's response lands.
+    address.value = ADDRESS_B;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(300);
+
+    // A resolves late — must be ignored since B is the current address.
+    first.resolve(ok('stale.eth'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ensName.value).not.toBe('stale.eth');
+
+    second.resolve(ok('fresh.eth'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ensName.value).toBe('fresh.eth');
+    stop();
+  });
+});

--- a/packages/website/tests/unit/modules/web3/core/ens.spec.ts
+++ b/packages/website/tests/unit/modules/web3/core/ens.spec.ts
@@ -1,0 +1,111 @@
+import { isErr, isOk } from 'plainfp/result';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearEnsCache, resolveEnsName } from '~/modules/web3/core/ens';
+
+// vitalik.eth — lowercased input so we can assert the call is checksummed.
+const ADDRESS_LOWER = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+const ADDRESS_CHECKSUMMED = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+
+const getEnsName = vi.hoisted(() => vi.fn());
+
+// Replace the viem client factory so reverse resolution never hits the network.
+// `getAddress` stays real so checksumming is exercised, not stubbed away.
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>();
+  return {
+    ...actual,
+    createPublicClient: () => ({ getEnsName }),
+  };
+});
+
+describe('web3 core/ens', () => {
+  beforeEach(() => {
+    getEnsName.mockReset();
+    clearEnsCache();
+  });
+
+  describe('resolveEnsName', () => {
+    it('resolves to the primary ENS name on success', async () => {
+      getEnsName.mockResolvedValue('vitalik.eth');
+
+      const result = await resolveEnsName(ADDRESS_LOWER);
+
+      expect(isOk(result)).toBe(true);
+      expect(isOk(result) && result.value).toBe('vitalik.eth');
+    });
+
+    it('queries with the checksummed address', async () => {
+      getEnsName.mockResolvedValue('vitalik.eth');
+
+      await resolveEnsName(ADDRESS_LOWER);
+
+      expect(getEnsName).toHaveBeenCalledWith({ address: ADDRESS_CHECKSUMMED });
+    });
+
+    it('maps a missing name (viem null) to undefined', async () => {
+      getEnsName.mockResolvedValue(null);
+
+      const result = await resolveEnsName(ADDRESS_LOWER);
+
+      expect(isOk(result)).toBe(true);
+      expect(isOk(result) && result.value).toBeUndefined();
+    });
+
+    it('turns an RPC/transport failure into a typed Web3Error', async () => {
+      getEnsName.mockRejectedValue(new Error('rpc down'));
+
+      const result = await resolveEnsName(ADDRESS_LOWER);
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error._tag).toBe('TxFailed');
+        expect(result.error.message).toBe('rpc down');
+      }
+    });
+
+    it('serves a repeat lookup from cache without a second RPC call', async () => {
+      getEnsName.mockResolvedValue('vitalik.eth');
+
+      const first = await resolveEnsName(ADDRESS_LOWER);
+      const second = await resolveEnsName(ADDRESS_LOWER);
+
+      expect(isOk(second) && second.value).toBe('vitalik.eth');
+      expect(isOk(first) && first.value).toBe('vitalik.eth');
+      expect(getEnsName).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches a confirmed miss (undefined) so it is not re-queried', async () => {
+      getEnsName.mockResolvedValue(null);
+
+      await resolveEnsName(ADDRESS_LOWER);
+      const result = await resolveEnsName(ADDRESS_LOWER);
+
+      expect(isOk(result) && result.value).toBeUndefined();
+      expect(getEnsName).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failure — a later call retries', async () => {
+      getEnsName.mockRejectedValueOnce(new Error('rpc down')).mockResolvedValue('vitalik.eth');
+
+      const failed = await resolveEnsName(ADDRESS_LOWER);
+      const retried = await resolveEnsName(ADDRESS_LOWER);
+
+      expect(isErr(failed)).toBe(true);
+      expect(isOk(retried) && retried.value).toBe('vitalik.eth');
+      expect(getEnsName).toHaveBeenCalledTimes(2);
+    });
+
+    it('shares one in-flight request between concurrent callers', async () => {
+      getEnsName.mockResolvedValue('vitalik.eth');
+
+      const [a, b] = await Promise.all([
+        resolveEnsName(ADDRESS_LOWER),
+        resolveEnsName(ADDRESS_LOWER),
+      ]);
+
+      expect(isOk(a) && a.value).toBe('vitalik.eth');
+      expect(isOk(b) && b.value).toBe('vitalik.eth');
+      expect(getEnsName).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Reverse-resolve the connected wallet address to its primary ENS name and surface it on the wallet account summary card, falling back to the truncated address when there's no name (or resolution fails).

## Changes

- **`core/ens.ts`** — standalone mainnet viem `PublicClient`, decoupled from the wagmi `Config` (which omits mainnet in testnet mode, so reverse resolution can't go through `core/actions`). Reuses `ETHEREUM_RPCS`, whose hosts are already in the backend CSP `connect-src`, so no new origins are needed. Memoized and only ever reached via a dynamic import, keeping viem out of the initial bundle.
- **`use-ens-name.ts`** — debounced (300ms), stale-guarded, error-swallowing composable. A slow response for a previous address can never overwrite a newer one; errors are swallowed since the name is a cosmetic enhancement, never a blocker.
- **`WalletAccountSummary.vue`** — renders the resolved name and passes it down to the avatar.

## Testing

- `core/ens.spec.ts` — success / `null`→`undefined` / checksummed query / RPC failure → typed `Web3Error`
- `use-ens-name.spec.ts` — debounce, undefined-address clear, error swallow, loading toggle, stale-response drop
- Component spec updated for the ENS display path
- Full web3 unit suite: 168 passing; typecheck clean; lint 0 errors

## Notes

ENS reuses `ETHEREUM_RPCS`, whose mainnet hosts are already covered by the backend CSP `connect-src` — no CSP change required.