### PR TITLE
fix(seo): add semantic <h1> to pages missing a top-level heading

### DIFF
--- a/packages/website/app/components/documents/MarkdownContent.vue
+++ b/packages/website/app/components/documents/MarkdownContent.vue
@@ -18,17 +18,17 @@ if (!document) {
         >
           {{ document.title }}
         </div>
-        <div
+        <h1
           v-if="document?.subtitle"
           class="text-h4"
         >
           {{ document.subtitle }}
-        </div>
+        </h1>
       </div>
       <div v-else-if="document?.title">
-        <div class="text-h4">
+        <h1 class="text-h4">
           {{ document.title }}
-        </div>
+        </h1>
       </div>
       <div
         v-if="document?.address"

--- a/packages/website/app/components/download/DownloadHeading.vue
+++ b/packages/website/app/components/download/DownloadHeading.vue
@@ -67,9 +67,9 @@ function onDownloadClick(platform: string): void {
         <h6 class="text-rui-light-primary text-h6 font-medium">
           {{ t('download.heading.download_rotki') }}
         </h6>
-        <h3 class="text-rui-text text-h4">
+        <h1 class="text-rui-text text-h4">
           {{ t('download.heading.description') }}
-        </h3>
+        </h1>
         <div class="flex flex-col items-center gap-3 pt-2 min-h-[106px]">
           <div class="flex gap-2 flex-wrap justify-center min-h-[42px] items-center">
             <RuiButton

--- a/packages/website/app/components/pricings/PricingHeading.vue
+++ b/packages/website/app/components/pricings/PricingHeading.vue
@@ -7,7 +7,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <div class="mb-6">
-    <CheckoutTitle>
+    <CheckoutTitle as="h1">
       {{ t('home.plans.tiers.step_1.title') }}
     </CheckoutTitle>
     <CheckoutDescription>

--- a/packages/website/app/components/products/ProductsHeading.vue
+++ b/packages/website/app/components/products/ProductsHeading.vue
@@ -11,9 +11,9 @@ const { t } = useI18n({ useScope: 'global' });
         <div class="text-rui-light-primary text-h6 font-medium">
           {{ t('products.heading') }}
         </div>
-        <h4 class="text-h4 !font-bold">
+        <h1 class="text-h4 !font-bold">
           {{ t('products.title') }}
-        </h4>
+        </h1>
         <div class="max-w-[768px] text-body-1 text-rui-text-secondary">
           {{ t('products.description') }}
         </div>

--- a/packages/website/app/components/values/ValueHeading.vue
+++ b/packages/website/app/components/values/ValueHeading.vue
@@ -8,9 +8,9 @@ const { t } = useI18n({ useScope: 'global' });
       <div class="text-h6 text-rui-primary">
         {{ t('values.title') }}
       </div>
-      <div class="text-h5 md:text-h3 mt-4">
+      <h1 class="text-h5 md:text-h3 mt-4">
         {{ t('values.subtitle') }}
-      </div>
+      </h1>
     </div>
   </div>
 </template>

--- a/packages/website/app/layouts/jobs.vue
+++ b/packages/website/app/layouts/jobs.vue
@@ -26,9 +26,9 @@ const { t } = useI18n({ useScope: 'global' });
               {{ t('jobs.title') }}
             </ButtonLink>
           </div>
-          <div class="text-h4">
+          <h1 class="text-h4">
             <slot name="title" />
-          </div>
+          </h1>
           <div
             v-if="$slots.description"
             class="mt-5 body-1"

--- a/packages/website/app/modules/checkout/components/common/CheckoutTitle.vue
+++ b/packages/website/app/modules/checkout/components/common/CheckoutTitle.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
+const { as = 'h4' } = defineProps<{
+  as?: 'h1' | 'h4';
+}>();
+
 defineSlots<{
   default: () => void;
 }>();
 </script>
 
 <template>
-  <h4 class="font-bold text-h4 text-rui-text mb-3">
+  <component
+    :is="as"
+    class="font-bold text-h4 text-rui-text mb-3"
+  >
     <slot />
-  </h4>
+  </component>
 </template>

--- a/packages/website/app/pages/sponsor/mint.vue
+++ b/packages/website/app/pages/sponsor/mint.vue
@@ -121,9 +121,9 @@ const {
       <div class="lg:w-1/2">
         <div class="space-y-6">
           <div>
-            <h5 class="text-h4 font-bold mb-2">
+            <h1 class="text-h4 font-bold mb-2">
               {{ t('sponsor.sponsor_page.title') }}
-            </h5>
+            </h1>
             <p class="text-rui-text-secondary mb-6">
               {{ t('sponsor.sponsor_page.description').replace('{leaderboard_link}', '') }}<ButtonLink
                 to="/sponsor/leaderboard"

--- a/packages/website/tests/e2e/specs/pages/index.spec.ts
+++ b/packages/website/tests/e2e/specs/pages/index.spec.ts
@@ -98,7 +98,7 @@ test.describe('download page', () => {
 
     await expect(
       page
-        .locator('h3')
+        .locator('h1')
         .filter({
           hasText:
             'Download now and start using across all major Operating Systems',


### PR DESCRIPTION
## Summary

The SEO audit (`pnpm seo:audit`) flagged `missing-h1` on several indexable pages. This promotes each page's existing styled lead element to a semantic `<h1>`, **keeping all styling classes** so there is no visual change.

Pages fixed:
- `/products`, `/download`, `/jobs` (+ `/jobs/[id]` via the shared `layouts/jobs.vue`)
- `/values`, `/tos`, `/privacy-policy`, `/impressum`, `/refund-policy` (the legal pages share `MarkdownContent.vue` — one change covers all four; both the subtitle and title-only branches updated)
- `/sponsor/mint`

`CheckoutTitle` gains an `as?: 'h1' | 'h4'` prop (default `'h4'`, rendered via `<component :is>`) so `PricingHeading` can render the `/checkout/pay` step-1 title as `<h1>` **without** affecting the other step contexts (`PaymentMethodSelection`, `PaymentLayout`, `3d-secure`) that reuse `CheckoutTitle`.

`/integrations` and `/integrations/[slug]` already had a proper `<h1>`, so no change was needed there.

## Verification
- `pnpm seo:audit` (after `pnpm generate`) now reports **zero** `missing-h1` warnings (was 6).
- Each affected page has exactly one `<h1>`; visually verified in-browser that the lead headings render identically.
- `pnpm lint` (0 errors) and `pnpm typecheck` pass.

Remaining audit items are pre-existing and out of scope: `relative-canonical` (a local-generate artifact — `NUXT_PUBLIC_BASE_URL` is unset locally) and `non-crawlable-anchor` on the sponsor `RuiTabs`.