### PR TITLE
fix(sponsor): align tier price decimals for readable rendering

### DIFF
--- a/packages/website/app/modules/web3/core/format.ts
+++ b/packages/website/app/modules/web3/core/format.ts
@@ -16,6 +16,60 @@ export function formatTokenBalance(value: string, maxDecimals = 6): string {
 }
 
 /**
+ * How many fractional digits `value` needs to display without losing information:
+ * trailing zeros dropped, capped at `maxDecimals`. Operates on the string directly.
+ * @example significantDecimals('200.000000000') // 0
+ * @example significantDecimals('300.10000000')  // 1
+ */
+export function significantDecimals(value: string, maxDecimals = 6): number {
+  const dotIndex = value.indexOf('.');
+  if (dotIndex === -1)
+    return 0;
+
+  return value.slice(dotIndex + 1, dotIndex + 1 + maxDecimals).replace(/0+$/, '').length;
+}
+
+/**
+ * The common number of fractional digits a set of amounts should be displayed with
+ * so they line up: the max any single value needs (trailing zeros dropped), capped
+ * at `maxDecimals`. Returns 0 for an empty set.
+ * @example alignmentDecimals(['200.000', '300.000']) // 0
+ * @example alignmentDecimals(['200', '300.1'])       // 1
+ */
+export function alignmentDecimals(values: string[], maxDecimals = 6): number {
+  return Math.max(0, ...values.map(value => significantDecimals(value, maxDecimals)));
+}
+
+/**
+ * Formats `value` to exactly `decimals` fractional digits, padding with trailing
+ * zeros or truncating extra digits (no rounding). Operates on the string directly
+ * so the integer part stays exact.
+ * @example toFixedDecimals('200', 1)          // '200.0'
+ * @example toFixedDecimals('300.10000000', 1) // '300.1'
+ */
+export function toFixedDecimals(value: string, decimals: number): string {
+  const dotIndex = value.indexOf('.');
+  const whole = dotIndex === -1 ? value : value.slice(0, dotIndex);
+  if (decimals === 0)
+    return whole;
+
+  const frac = dotIndex === -1 ? '' : value.slice(dotIndex + 1, dotIndex + 1 + decimals);
+  return `${whole}.${frac.padEnd(decimals, '0')}`;
+}
+
+/**
+ * Aligns a set of decimal amount strings to a common number of fractional digits
+ * (see {@link alignmentDecimals}), so a column of amounts lines up while dropping
+ * trailing zeros that every value shares.
+ * @example alignAmounts(['200.000', '300.000']) // ['200', '300']
+ * @example alignAmounts(['200', '300.1'])       // ['200.0', '300.1']
+ */
+export function alignAmounts(values: string[], maxDecimals = 6): string[] {
+  const decimals = alignmentDecimals(values, maxDecimals);
+  return values.map(value => toFixedDecimals(value, decimals));
+}
+
+/**
  * Truncates blockchain hashes (addresses / txs) retaining `truncLength+2` characters
  * from the beginning and `truncLength` characters from the end of the string.
  * @param address

--- a/packages/website/app/modules/web3/sponsorship/mint-state.ts
+++ b/packages/website/app/modules/web3/sponsorship/mint-state.ts
@@ -1,5 +1,6 @@
 import { flatMap, fromNullable, map, type Result } from 'plainfp/result';
 import { isNativeToken } from '~/modules/web3/core/erc20';
+import { alignmentDecimals, toFixedDecimals } from '~/modules/web3/core/format';
 import { type PaymentToken, SPONSORSHIP_TIERS, type SponsorshipTier, type TierKey } from '~/modules/web3/sponsorship/types';
 
 /** Reads the price of a tier for a given currency (mirrors `usePaymentTokens().getPriceForTier`). */
@@ -51,6 +52,10 @@ export function filterVisibleTiers(currency: string, getPriceForTier: PriceGette
 /**
  * Per-tier price label for the selected currency. While loading every tier gets
  * `loadingLabel`; otherwise `"<price> <currency>"` or `"0"` when unpriced.
+ *
+ * Priced tiers are aligned to a common number of decimals: shared trailing zeros
+ * are dropped, but as soon as one tier needs a decimal every tier shows it, so the
+ * column lines up (e.g. `200`/`300`, or `200.0`/`300.1`).
  */
 export function buildTierPriceDisplay(currency: string, getPriceForTier: PriceGetter, isLoading: boolean, loadingLabel: string): Record<string, string> {
   const result: Record<string, string> = {};
@@ -61,9 +66,12 @@ export function buildTierPriceDisplay(currency: string, getPriceForTier: PriceGe
     return result;
   }
 
-  for (const tier of SPONSORSHIP_TIERS) {
-    const price = getPriceForTier(currency, tier.key);
-    result[tier.key] = price ? `${price} ${currency}` : '0';
+  const prices = SPONSORSHIP_TIERS.map(tier => getPriceForTier(currency, tier.key));
+  const decimals = alignmentDecimals(prices.filter((price): price is string => !!price));
+
+  for (const [index, tier] of SPONSORSHIP_TIERS.entries()) {
+    const price = prices[index];
+    result[tier.key] = price ? `${toFixedDecimals(price, decimals)} ${currency}` : '0';
   }
   return result;
 }

--- a/packages/website/tests/unit/modules/web3/core/format.spec.ts
+++ b/packages/website/tests/unit/modules/web3/core/format.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatTokenBalance, truncateAddress } from '~/modules/web3/core/format';
+import { alignAmounts, alignmentDecimals, formatTokenBalance, significantDecimals, toFixedDecimals, truncateAddress } from '~/modules/web3/core/format';
 
 describe('web3 core/format', () => {
   describe('formatTokenBalance', () => {
@@ -29,6 +29,78 @@ describe('web3 core/format', () => {
 
     it('returns an empty string unchanged', () => {
       expect(formatTokenBalance('')).toBe('');
+    });
+  });
+
+  describe('significantDecimals', () => {
+    it('is 0 for an integer without a decimal point', () => {
+      expect(significantDecimals('200')).toBe(0);
+    });
+
+    it('is 0 when every fractional digit is a trailing zero', () => {
+      expect(significantDecimals('200.000000000')).toBe(0);
+    });
+
+    it('counts only up to the last non-zero digit', () => {
+      expect(significantDecimals('300.10000000')).toBe(1);
+    });
+
+    it('caps at maxDecimals', () => {
+      expect(significantDecimals('0.188476330975533262')).toBe(6);
+    });
+
+    it('honours a custom cap', () => {
+      expect(significantDecimals('0.123456789', 2)).toBe(2);
+    });
+  });
+
+  describe('alignmentDecimals', () => {
+    it('is 0 when all values are whole', () => {
+      expect(alignmentDecimals(['200.000000000', '300.000000000', '250'])).toBe(0);
+    });
+
+    it('takes the max any single value needs', () => {
+      expect(alignmentDecimals(['200.000000', '300.1', '250'])).toBe(1);
+    });
+
+    it('is 0 for an empty set', () => {
+      expect(alignmentDecimals([])).toBe(0);
+    });
+  });
+
+  describe('toFixedDecimals', () => {
+    it('drops the decimal point entirely at 0 decimals', () => {
+      expect(toFixedDecimals('300.10000000', 0)).toBe('300');
+    });
+
+    it('pads an integer with trailing zeros', () => {
+      expect(toFixedDecimals('200', 1)).toBe('200.0');
+    });
+
+    it('truncates extra digits without rounding', () => {
+      expect(toFixedDecimals('300.16', 1)).toBe('300.1');
+    });
+
+    it('keeps the integer part exact for large values', () => {
+      expect(toFixedDecimals('123456789', 2)).toBe('123456789.00');
+    });
+  });
+
+  describe('alignAmounts', () => {
+    it('trims shared trailing zeros to whole numbers', () => {
+      expect(alignAmounts(['200.000000000', '300.000000000'])).toEqual(['200', '300']);
+    });
+
+    it('pads every value once one needs a decimal', () => {
+      expect(alignAmounts(['200.000000', '300.1'])).toEqual(['200.0', '300.1']);
+    });
+
+    it('aligns to the widest fractional value, capped at maxDecimals', () => {
+      expect(alignAmounts(['1', '0.188476330975533262'])).toEqual(['1.000000', '0.188476']);
+    });
+
+    it('returns an empty list unchanged', () => {
+      expect(alignAmounts([])).toEqual([]);
     });
   });
 

--- a/packages/website/tests/unit/modules/web3/sponsorship/mint-state.spec.ts
+++ b/packages/website/tests/unit/modules/web3/sponsorship/mint-state.spec.ts
@@ -77,6 +77,24 @@ describe('buildTierPriceDisplay', () => {
     const result = buildTierPriceDisplay('USDC', priceGetterFor(tokens), false, 'Loading…');
     expect(result).toEqual({ bronze: '10 USDC', gold: '0', silver: '20 USDC' });
   });
+
+  it('drops shared trailing zeros when every tier is a whole number', () => {
+    const tokens = [token({ prices: { bronze: '200.000000000', gold: '250.0', silver: '300.000000000' }, symbol: 'EURe' })];
+    const result = buildTierPriceDisplay('EURe', priceGetterFor(tokens), false, 'Loading…');
+    expect(result).toEqual({ bronze: '200 EURe', gold: '250 EURe', silver: '300 EURe' });
+  });
+
+  it('aligns every tier to the decimals of the most precise one', () => {
+    const tokens = [token({ prices: { bronze: '200.000000', gold: '250', silver: '300.1' }, symbol: 'EURe' })];
+    const result = buildTierPriceDisplay('EURe', priceGetterFor(tokens), false, 'Loading…');
+    expect(result).toEqual({ bronze: '200.0 EURe', gold: '250.0 EURe', silver: '300.1 EURe' });
+  });
+
+  it('ignores unpriced tiers when computing the shared decimals', () => {
+    const tokens = [token({ prices: { bronze: '200.000000', gold: '', silver: '300.000000' }, symbol: 'EURe' })];
+    const result = buildTierPriceDisplay('EURe', priceGetterFor(tokens), false, 'Loading…');
+    expect(result).toEqual({ bronze: '200 EURe', gold: '0', silver: '300 EURe' });
+  });
 });
 
 describe('computeNeedsApproval', () => {


### PR DESCRIPTION
## Summary

Sponsorship tier prices (bronze / silver / gold) were rendered straight from the API string, so a price like `200.000000000000000000` showed all its trailing zeros. This aligns the decimals per currency so the price column reads cleanly.

For a given currency, all priced tiers share a common decimal count: the max number of *significant* decimals any single tier needs (trailing zeros dropped, capped at 6). Shared trailing zeros collapse, but the moment one tier needs a decimal every tier shows it, so the column lines up.

- `200.000…`, `300.000…`, `250.0` → `200`, `300`, `250`
- `200.000000`, `300.1`, `250` → `200.0`, `300.1`, `250.0`

## Changes

- `app/modules/web3/core/format.ts` — four pure, string-based helpers (no `Number` round-trip, truncate not round, matching the existing `formatTokenBalance` style):
  - `significantDecimals(value, max=6)`
  - `alignmentDecimals(values, max=6)`
  - `toFixedDecimals(value, decimals)`
  - `alignAmounts(values)` (the above composed)
- `app/modules/web3/sponsorship/mint-state.ts` — `buildTierPriceDisplay` computes `alignmentDecimals` over the present prices, then renders each with `toFixedDecimals`. Unpriced tiers still fall back to `'0'` and don't affect alignment.

## Notes

- Decimals are capped at 6, consistent with the existing balance display.
- The rendering component (`MintTierSelection.vue`) is unchanged: it just prints the string.

## Tests

- `tests/unit/modules/web3/core/format.spec.ts` — coverage for each helper (cap, empty set, integer padding, no-rounding truncation).
- `tests/unit/modules/web3/sponsorship/mint-state.spec.ts` — whole-number trimming, align-to-most-precise, and unpriced tiers excluded. The pre-existing `10`/`20 USDC` case is unchanged (no regression).

All unit tests, `typecheck`, and `eslint` pass.
