### PR TITLE
feat(siwe): build EIP-4361 messages for smart-account sign-in

### DIFF
--- a/packages/website/app/modules/web3/sponsorship/use-siwe-auth.ts
+++ b/packages/website/app/modules/web3/sponsorship/use-siwe-auth.ts
@@ -4,6 +4,8 @@ import { pipe } from 'plainfp/pipe';
 import { flatMap, fromThrowable, getOr, map, mapError, ok, type Result } from 'plainfp/result';
 import * as RA from 'plainfp/result-async';
 import { tag, type Tagged } from 'plainfp/tagged';
+import { getAddress } from 'viem';
+import { createSiweMessage } from 'viem/siwe';
 import { z } from 'zod';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { useWallet } from '~/modules/web3/composables/use-wallet';
@@ -47,7 +49,7 @@ function isSiweCookieError(error: unknown): boolean {
 
 export function useSiweAuth() {
   const { fetchWithCsrf } = useFetchWithCsrf();
-  const { address, connected, signMessage: signMessageWeb3 } = useWallet();
+  const { address, connected, connectedChainId, signMessage: signMessageWeb3 } = useWallet();
   const logger = useLogger();
 
   const sessionStorage = useLocalStorage<SiweSession | undefined>('siwe_session', undefined, {
@@ -87,20 +89,39 @@ export function useSiweAuth() {
     );
   }
 
-  /** Step 2 — sign the ownership message, translating wallet errors to {@link AuthError}. */
-  async function signNonce(address: string, nonce: string): Promise<Result<string, AuthError>> {
-    const message = `I am the owner of address ${address}. Nonce: ${nonce}`;
-    return mapError(await signMessageWeb3(message), (error): AuthError => error._tag === 'UserRejected'
-      ? tag('UserRejected')({ message: 'Signature rejected. Please try again.' })
-      : tag('SignFailed')({ message: 'Failed to sign message. Please try again.' }));
+  /** Build an EIP-4361 (Sign-In With Ethereum) message bound to this origin + nonce. */
+  function buildSiweMessage(address: string, nonce: string): string {
+    // Only ever called client-side (behind a user-triggered wallet signature).
+    const host = typeof window !== 'undefined' ? window.location.host : '';
+    const uri = typeof window !== 'undefined' ? window.location.origin : '';
+    return createSiweMessage({
+      address: getAddress(address),
+      chainId: get(connectedChainId) ?? 1,
+      domain: host,
+      nonce,
+      statement: 'Sign in with Ethereum to rotki.',
+      uri,
+      version: '1',
+    });
   }
 
-  /** Step 3 — verify the signature with the backend, yielding the persisted session. */
-  async function verifySignature(address: string, nonce: string, signature: string): RA.ResultAsync<SiweSession, AuthError> {
+  /** Step 2 — build + sign the EIP-4361 message, translating wallet errors to {@link AuthError}. */
+  async function signSiweMessage(address: string, nonce: string): Promise<Result<{ message: string; signature: string }, AuthError>> {
+    const message = buildSiweMessage(address, nonce);
+    return map(
+      mapError(await signMessageWeb3(message), (error): AuthError => error._tag === 'UserRejected'
+        ? tag('UserRejected')({ message: 'Signature rejected. Please try again.' })
+        : tag('SignFailed')({ message: 'Failed to sign message. Please try again.' })),
+      (signature): { message: string; signature: string } => ({ message, signature }),
+    );
+  }
+
+  /** Step 3 — verify the signed message with the backend, yielding the persisted session. */
+  async function verifySignature(message: string, signature: string): RA.ResultAsync<SiweSession, AuthError> {
     return pipe(
       RA.fromPromise(
         fetchWithCsrf<SiweSession & { ok: boolean }>('/webapi/nfts/siwe/verify', {
-          body: { evmAddress: address, nonce, signature },
+          body: { message, signature },
           method: 'POST',
         }),
         (cause): AuthError => tag('VerifyFailed')({ cause, message: messageOf(cause) }),
@@ -121,8 +142,8 @@ export function useSiweAuth() {
       const outcome = await pipe(
         fetchNonce(),
         RA.flatMap(async nonce => pipe(
-          signNonce(address, nonce),
-          RA.flatMap(async signature => verifySignature(address, nonce, signature)),
+          signSiweMessage(address, nonce),
+          RA.flatMap(async ({ message, signature }) => verifySignature(message, signature)),
         )),
         RA.tap((session) => { set(sessionStorage, session); }),
       );

--- a/packages/website/tests/unit/composables/use-siwe-auth.spec.ts
+++ b/packages/website/tests/unit/composables/use-siwe-auth.spec.ts
@@ -29,6 +29,7 @@ vi.mock('~/modules/web3/composables/use-wallet', () => ({
   useWallet: () => ({
     address: ref<string>('0x1234567890abcdef1234567890abcdef12345678'),
     connected: ref<boolean>(true),
+    connectedChainId: ref<number>(1),
     signMessage: mockSignMessage,
   }),
 }));
@@ -38,7 +39,8 @@ const okResult = (value: string) => ({ ok: true, value });
 const errResult = (tag: string, message: string) => ({ error: { _tag: tag, message }, ok: false });
 
 const TEST_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
-const TEST_NONCE = 'test-nonce-123';
+// EIP-4361 requires an alphanumeric nonce of at least 8 characters.
+const TEST_NONCE = 'testnonce123';
 const TEST_SIGNATURE = '0xsignature';
 
 describe('useSiweAuth', () => {
@@ -66,9 +68,17 @@ describe('useSiweAuth', () => {
     expect(isSessionValid(TEST_ADDRESS)).toBe(true);
 
     expect(mockFetchWithCsrf).toHaveBeenCalledTimes(2);
-    expect(mockSignMessage).toHaveBeenCalledWith(
-      `I am the owner of address ${TEST_ADDRESS}. Nonce: ${TEST_NONCE}`,
-    );
+    // Signs a proper EIP-4361 message that embeds the nonce.
+    expect(mockSignMessage).toHaveBeenCalledTimes(1);
+    const signedMessage = String(mockSignMessage.mock.calls[0]?.[0] ?? '');
+    expect(signedMessage).toContain('wants you to sign in with your Ethereum account:');
+    expect(signedMessage).toContain(`Nonce: ${TEST_NONCE}`);
+
+    // Verify is posted with the message + signature (not the legacy fields).
+    expect(mockFetchWithCsrf).toHaveBeenLastCalledWith('/webapi/nfts/siwe/verify', {
+      body: { message: signedMessage, signature: TEST_SIGNATURE },
+      method: 'POST',
+    });
   });
 
   it('should set authError when signature is rejected', async () => {


### PR DESCRIPTION
## Problem

The sponsorship SIWE handshake signed a plain ownership string
(`I am the owner of address ... Nonce: ...`), which the backend could only
verify for EOAs. Smart-contract wallets (Safe, Ambire, Coinbase Smart Wallet)
could not sign in.

## What changed

- Build a proper **EIP-4361** message with viem's `createSiweMessage` (domain,
  uri, chainId, nonce, issuedAt), bound to the current origin.
- Post `{message, signature}` to the verify endpoint and forward the signature
  bytes unchanged, so smart-account (**EIP-1271 / EIP-6492**) signatures returned
  over WalletConnect pass straight through to the backend validator.

## Testing

- 10 composable unit tests pass; `pnpm typecheck` and eslint clean.
- Manual sign-in confirmed with Rabby (EOA) and a smart-contract account.

## Deploy coordination

The verify request contract changed, so this requires the matching backend PR
**rotki/rotki-web#262** and must be deployed together with it.
