### PR TITLE
fix: sponsor submit button stuck disabled + RPC CORS failures

### DIFF
--- a/backend/internal/csp/csp_test.go
+++ b/backend/internal/csp/csp_test.go
@@ -103,7 +103,7 @@ func TestWalletConnectCSPHasViemRPCEndpoints(t *testing.T) {
 	required := []string{
 		"https://sepolia.gateway.tenderly.co",
 		"https://ethereum-sepolia-rpc.publicnode.com",
-		"https://eth.merkle.io",
+		"https://ethereum-rpc.publicnode.com",
 	}
 	for _, host := range required {
 		if !slices.Contains(connectSrc, host) {

--- a/backend/internal/csp/policies.go
+++ b/backend/internal/csp/policies.go
@@ -91,32 +91,37 @@ var WalletConnectCSP = Policy{
 		// MUST stay in sync with the rpcUrls in app/modules/web3/core/chains.ts —
 		// a host missing here is blocked by CSP and the read silently returns empty.
 		// Production: Ethereum
-		"https://eth.merkle.io",
-		"https://eth.llamarpc.com",
 		"https://ethereum-rpc.publicnode.com",
 		"https://rpc.mevblocker.io",
+		"https://eth.drpc.org",
 		// Production: Arbitrum One
 		"https://arbitrum-one-rpc.publicnode.com",
-		"https://arbitrum.llamarpc.com",
+		"https://arb1.arbitrum.io/rpc",
+		"https://arbitrum.drpc.org",
 		// Production: Base
 		"https://base-rpc.publicnode.com",
-		"https://base.llamarpc.com",
+		"https://mainnet.base.org",
+		"https://base.drpc.org",
 		// Production: OP Mainnet
 		"https://optimism-rpc.publicnode.com",
-		"https://optimism.llamarpc.com",
+		"https://mainnet.optimism.io",
+		"https://optimism.drpc.org",
 		// Production: Gnosis
 		"https://gnosis-rpc.publicnode.com",
 		"https://rpc.gnosischain.com",
+		"https://gnosis.drpc.org",
 		// Testnets: Ethereum / Arbitrum / Base / Optimism Sepolia
 		"https://sepolia.gateway.tenderly.co",
 		"https://sepolia.drpc.org",
 		"https://ethereum-sepolia-rpc.publicnode.com",
 		"https://arbitrum-sepolia-rpc.publicnode.com",
-		"https://sepolia-rollup.arbitrum.io",
+		"https://arbitrum-sepolia.drpc.org",
 		"https://base-sepolia-rpc.publicnode.com",
 		"https://sepolia.base.org",
+		"https://base-sepolia.drpc.org",
 		"https://optimism-sepolia-rpc.publicnode.com",
 		"https://sepolia.optimism.io",
+		"https://optimism-sepolia.drpc.org",
 	},
 	"frame-src": {
 		"https://verify.walletconnect.com",

--- a/packages/website/app/modules/web3/core/chains.ts
+++ b/packages/website/app/modules/web3/core/chains.ts
@@ -40,30 +40,33 @@ export interface ChainMeta {
 // hosts — ENS is mainnet-only, so it can't rely on the wagmi config, which omits
 // mainnet in testnet mode.
 export const ETHEREUM_RPCS = [
-  'https://eth.merkle.io',
-  'https://eth.llamarpc.com',
   'https://ethereum-rpc.publicnode.com',
   'https://rpc.mevblocker.io',
+  'https://eth.drpc.org',
 ];
 
 const ARBITRUM_RPCS = [
   'https://arbitrum-one-rpc.publicnode.com',
-  'https://arbitrum.llamarpc.com',
+  'https://arb1.arbitrum.io/rpc',
+  'https://arbitrum.drpc.org',
 ];
 
 const BASE_RPCS = [
   'https://base-rpc.publicnode.com',
-  'https://base.llamarpc.com',
+  'https://mainnet.base.org',
+  'https://base.drpc.org',
 ];
 
 const OPTIMISM_RPCS = [
   'https://optimism-rpc.publicnode.com',
-  'https://optimism.llamarpc.com',
+  'https://mainnet.optimism.io',
+  'https://optimism.drpc.org',
 ];
 
 const GNOSIS_RPCS = [
   'https://gnosis-rpc.publicnode.com',
   'https://rpc.gnosischain.com',
+  'https://gnosis.drpc.org',
 ];
 
 const SEPOLIA_RPCS = [
@@ -74,17 +77,19 @@ const SEPOLIA_RPCS = [
 
 const ARBITRUM_SEPOLIA_RPCS = [
   'https://arbitrum-sepolia-rpc.publicnode.com',
-  'https://sepolia-rollup.arbitrum.io',
+  'https://arbitrum-sepolia.drpc.org',
 ];
 
 const BASE_SEPOLIA_RPCS = [
   'https://base-sepolia-rpc.publicnode.com',
   'https://sepolia.base.org',
+  'https://base-sepolia.drpc.org',
 ];
 
 const OPTIMISM_SEPOLIA_RPCS = [
   'https://optimism-sepolia-rpc.publicnode.com',
   'https://sepolia.optimism.io',
+  'https://optimism-sepolia.drpc.org',
 ];
 
 const PRODUCTION_CHAINS: readonly ChainMeta[] = [

--- a/packages/website/app/modules/web3/sponsorship/submission-state.ts
+++ b/packages/website/app/modules/web3/sponsorship/submission-state.ts
@@ -74,6 +74,20 @@ export function isSubmitBlockedByOwnership(params: { hasCheckedNft: boolean; isN
 }
 
 /**
+ * Whether selecting `tokenId` should reset the form up front, before the async
+ * NFT/existing-submission checks run. Every selection is a fresh start except
+ * re-selecting the submission currently being edited (whose prefill must survive).
+ *
+ * Clearing synchronously here is what stops the deferred existing-submission check
+ * from wiping the name/image a user types once the fields appear: the image field
+ * only shows after the tier resolves mid-check, so silver/gold users routinely
+ * typed into that window and lost their input, leaving submit stuck disabled.
+ */
+export function shouldResetFormForToken(editingSubmission: NftSubmission | undefined, tokenId: string): boolean {
+  return !editingSubmission || editingSubmission.nftId.toString() !== tokenId;
+}
+
+/**
  * Normalize a release tag for comparison: trim, lowercase and drop a leading
  * `v` when it precedes a digit (so `v0.9.0` and `0.9.0` match). The `v` is only
  * stripped before a digit to avoid mangling word-like names.

--- a/packages/website/app/modules/web3/sponsorship/use-nft-submission-form.ts
+++ b/packages/website/app/modules/web3/sponsorship/use-nft-submission-form.ts
@@ -5,7 +5,7 @@ import { useVuelidate, type ValidationArgs } from '@vuelidate/core';
 import { email as emailValidation, helpers, maxLength, minLength, numeric, required } from '@vuelidate/validators';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
-import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, isSubmitBlockedByOwnership } from '~/modules/web3/sponsorship/submission-state';
+import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, isSubmitBlockedByOwnership, shouldResetFormForToken } from '~/modules/web3/sponsorship/submission-state';
 import { useNftMetadata } from '~/modules/web3/sponsorship/use-nft-metadata';
 import { useNftSubmissions } from '~/modules/web3/sponsorship/use-nft-submissions';
 import { useRotkiSponsorshipPayment } from '~/modules/web3/sponsorship/use-payment';
@@ -202,9 +202,7 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
         // Switch the page into editing mode for this submission.
         emit('edit-submission', submission);
       }
-      else {
-        clearFormForNewSubmission();
-      }
+      // No else-clear: the form is reset synchronously on token change (modelTokenId watcher).
     }
     catch (error_: any) {
       // Auth failures surface later on submit; ignore them here.
@@ -348,6 +346,8 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
       emit('cancel-edit');
     }
     else if (newTokenId !== oldTokenId && Number.isInteger(Number(newTokenId)) && toValue(isConnected)) {
+      if (shouldResetFormForToken(toValue(editingSubmission), newTokenId))
+        clearFormForNewSubmission();
       await checkNftMetadata();
     }
   });

--- a/packages/website/modules/integration-images/module.ts
+++ b/packages/website/modules/integration-images/module.ts
@@ -143,7 +143,9 @@ async function removeOrphanFiles(manifest: Manifest, urls: Set<string>, outputDi
 export default defineNuxtModule({
   meta: { name: 'integration-images' },
   async setup(_options, nuxt) {
-    if (nuxt.options.dev)
+    // Skip in dev and under test: the module fetches ~138 remote images on init,
+    // which is pointless (and rate-limited/flaky) when booting Nuxt for Vitest.
+    if (nuxt.options.dev || nuxt.options.test)
       return;
 
     const rootDir = nuxt.options.rootDir;

--- a/packages/website/tests/unit/modules/web3/sponsorship/submission-state.spec.ts
+++ b/packages/website/tests/unit/modules/web3/sponsorship/submission-state.spec.ts
@@ -1,7 +1,7 @@
 import type { SimpleTokenMetadata, StoredNft } from '~/modules/web3/sponsorship/types';
 import type { NftSubmission } from '~/types/sponsor';
 import { describe, expect, it } from 'vitest';
-import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, isCurrentReleaseSubmission, isSubmitBlockedByOwnership } from '~/modules/web3/sponsorship/submission-state';
+import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, isCurrentReleaseSubmission, isSubmitBlockedByOwnership, shouldResetFormForToken } from '~/modules/web3/sponsorship/submission-state';
 
 function storedNft(partial: Partial<StoredNft> & Pick<StoredNft, 'id'>): StoredNft {
   return { address: '0xowner', releaseId: 1, tier: 0, ...partial };
@@ -159,6 +159,22 @@ describe('isSubmitBlockedByOwnership', () => {
     // wrong_release (isNftOwnerValid=false), which previously left the update
     // button disabled until the user re-selected the NFT.
     expect(isSubmitBlockedByOwnership({ hasCheckedNft: true, isNftOwnerValid: false, isEditing: true })).toBe(false);
+  });
+});
+
+describe('shouldResetFormForToken', () => {
+  const editing = submission({ nftId: 5 });
+
+  it('resets for a fresh selection when not editing', () => {
+    expect(shouldResetFormForToken(undefined, '9')).toBe(true);
+  });
+
+  it('does not reset when re-selecting the submission being edited', () => {
+    expect(shouldResetFormForToken(editing, '5')).toBe(false);
+  });
+
+  it('resets when editing but switching to a different token', () => {
+    expect(shouldResetFormForToken(editing, '9')).toBe(true);
   });
 });
 

--- a/packages/website/tests/unit/modules/web3/sponsorship/use-nft-submission-form.spec.ts
+++ b/packages/website/tests/unit/modules/web3/sponsorship/use-nft-submission-form.spec.ts
@@ -1,0 +1,187 @@
+import type { SimpleTokenMetadata, TierKey } from '~/modules/web3/sponsorship/types';
+import type { NftSubmission } from '~/types/sponsor';
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { get, set } from '@vueuse/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, nextTick, ref } from 'vue';
+import { type NftSubmissionFormContext, useNftSubmissionForm } from '~/modules/web3/sponsorship/use-nft-submission-form';
+
+const TEST_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+const CURRENT_RELEASE_ID = 1;
+
+// The two on-chain-adjacent lookups the form performs on token change. Both are
+// controllable per-test so we can hold `checkExistingSubmission` open and drive
+// the race where the user types while it is still pending.
+const mockMetadata = ref<SimpleTokenMetadata | undefined>();
+let existingSubmission: NftSubmission | undefined;
+let deferredCheck: { promise: Promise<NftSubmission | undefined>; resolve: () => void };
+
+function deferCheck(): void {
+  let resolve!: () => void;
+  const promise = new Promise<NftSubmission | undefined>((res) => {
+    resolve = () => res(existingSubmission);
+  });
+  deferredCheck = { promise, resolve };
+}
+
+vi.mock('~/composables/use-fetch-with-csrf', () => ({
+  useFetchWithCsrf: () => ({ fetchWithCsrf: vi.fn(), setHooks: vi.fn() }),
+}));
+vi.mock('~/modules/web3/sponsorship/use-nft-metadata', () => ({
+  useNftMetadata: () => ({ fetchNftMetadata: async () => get(mockMetadata) }),
+}));
+vi.mock('~/modules/web3/sponsorship/use-nft-submissions', () => ({
+  useNftSubmissions: () => ({ checkSubmissionByNftId: async () => deferredCheck.promise }),
+}));
+vi.mock('~/modules/web3/sponsorship/use-payment', () => ({
+  useRotkiSponsorshipPayment: () => ({ currentAddressNfts: ref([]) }),
+}));
+vi.mock('~/modules/web3/sponsorship/use-siwe-auth', () => ({
+  useSiweAuth: () => ({
+    authenticatedRequest: vi.fn(),
+    isAuthenticating: ref(false),
+    isSessionValid: () => true,
+  }),
+}));
+vi.mock('~/modules/web3/sponsorship/use-sponsorship', () => ({
+  useSponsorshipData: () => ({ data: ref({ releaseId: CURRENT_RELEASE_ID, releaseName: 'v1' }) }),
+}));
+vi.mock('~/utils/use-logger', () => ({
+  useLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+type Form = ReturnType<typeof useNftSubmissionForm>;
+
+async function setupForm(editing?: NftSubmission): Promise<Form> {
+  let api: Form | undefined;
+  const editingRef = ref<NftSubmission | undefined>(editing);
+  const context: NftSubmissionFormContext = {
+    address: () => TEST_ADDRESS,
+    editingSubmission: () => get(editingRef),
+    emit: () => {},
+    isConnected: () => true,
+  };
+  const Wrapper = defineComponent({
+    setup() {
+      api = useNftSubmissionForm(context);
+      return () => h('div');
+    },
+  });
+  await mountSuspended(Wrapper);
+  await nextTick();
+  return api!;
+}
+
+function metadata(tier: TierKey, releaseId = CURRENT_RELEASE_ID): SimpleTokenMetadata {
+  return { owner: TEST_ADDRESS, releaseId, releaseName: 'v1', tier };
+}
+
+function submitDisabled(form: Form): boolean {
+  return !get(form.isAuthenticated) || get(form.v$).$invalid || get(form.ownershipBlocksSubmit);
+}
+
+// Let the token-change watcher run fetchNftMetadata and reach (but not resolve)
+// checkExistingSubmission.
+async function flushMicrotasks(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+describe('useNftSubmissionForm submit-button gating', () => {
+  beforeEach(() => {
+    set(mockMetadata, undefined);
+    existingSubmission = undefined;
+    deferCheck();
+  });
+
+  it('keeps name + image the user typed while the existing-submission check is still in flight (gold)', async () => {
+    // Regression: the image field only appears after the tier resolves, so silver/gold
+    // users fill the form while checkExistingSubmission is pending. The deferred
+    // no-submission branch used to wipe that input, leaving submit stuck disabled.
+    set(mockMetadata, metadata('gold'));
+    const form = await setupForm();
+
+    set(form.modelTokenId, '5');
+    await flushMicrotasks(); // tier resolved, image field visible, check still pending
+
+    expect(get(form.nftTier)).toBe('gold');
+
+    set(form.modelDisplayName, 'Alice');
+    form.handleImageSelected(new File(['x'], 'a.png', { type: 'image/png' }));
+    await nextTick();
+    expect(submitDisabled(form)).toBe(false);
+
+    deferredCheck.resolve(); // no existing submission
+    await flushMicrotasks();
+
+    expect(get(form.modelDisplayName)).toBe('Alice');
+    expect(submitDisabled(form)).toBe(false);
+  });
+
+  it('enables submit for a bronze NFT once a name is entered', async () => {
+    set(mockMetadata, metadata('bronze'));
+    const form = await setupForm();
+
+    set(form.modelTokenId, '7');
+    deferredCheck.resolve();
+    await flushMicrotasks();
+
+    set(form.modelDisplayName, 'Bob');
+    await nextTick();
+
+    expect(submitDisabled(form)).toBe(false);
+  });
+
+  it('clears leftover prefill when switching from a submitted NFT to a fresh one', async () => {
+    // First token has a submission -> form prefills. Switching to a fresh token must
+    // drop that stale prefill instead of carrying it over.
+    existingSubmission = {
+      createdAt: '2026-01-01',
+      displayName: 'Old Name',
+      email: null,
+      imageUrl: null,
+      nftId: 5,
+      updatedAt: '2026-01-01',
+    };
+    set(mockMetadata, metadata('gold'));
+    const form = await setupForm();
+
+    set(form.modelTokenId, '5');
+    deferredCheck.resolve();
+    await flushMicrotasks();
+    expect(get(form.modelDisplayName)).toBe('Old Name');
+
+    // Switch to a different, submission-free NFT.
+    existingSubmission = undefined;
+    deferCheck();
+    set(form.modelTokenId, '9');
+    await nextTick(); // synchronous reset happens before the async check
+    expect(get(form.modelDisplayName)).toBe('');
+
+    deferredCheck.resolve();
+    await flushMicrotasks();
+    expect(get(form.modelDisplayName)).toBe('');
+  });
+
+  it('preserves an edited submission prefill for a past-release NFT (no ok re-check)', async () => {
+    // Guards the earlier edit fix: editing an NFT from a previous release never reaches
+    // the ok branch, so the synchronous reset must skip the token being edited.
+    const editing: NftSubmission = {
+      createdAt: '2026-01-01',
+      displayName: 'Edited Name',
+      email: null,
+      imageUrl: null,
+      nftId: 42,
+      releaseVersion: 'v0',
+      updatedAt: '2026-01-01',
+    };
+    set(mockMetadata, metadata('silver', CURRENT_RELEASE_ID + 1)); // wrong_release
+    const form = await setupForm(editing);
+    await flushMicrotasks();
+
+    expect(get(form.modelTokenId)).toBe('42');
+    expect(get(form.modelDisplayName)).toBe('Edited Name');
+    // Editing is never gated on the live ownership re-check.
+    expect(get(form.ownershipBlocksSubmit)).toBe(false);
+  });
+});


### PR DESCRIPTION
Three frontend-facing fixes, each in its own commit.

## 1. Sponsor submit button stuck disabled on silver/gold NFTs (`845aabdb`)

Selecting an NFT runs `fetchNftMetadata` then `checkExistingSubmission` in sequence. The image field only appears once the tier resolves (after the first call), so silver/gold users type a name and upload an image while the second call is still pending. Its deferred no-submission branch then wiped that input via `clearFormForNewSubmission`, leaving `atLeastOne` invalid and submit disabled until the NFT was re-selected. Bronze has no image field, so users rarely hit the window.

Fix: reset the form **synchronously** on token change (before the async checks), gated by a new pure `shouldResetFormForToken` helper that skips the submission being edited (preserving its prefill, including past-release NFTs that never reach the `ok` re-check). Drop the deferred `else`-clear so it can no longer clobber freshly-typed input. This does not regress the earlier edit-case fix (`e5e6a2cb`).

Adds `use-nft-submission-form.spec.ts` (race case, bronze happy path, prefill-cleared-on-switch, edit-preservation guard) and helper unit tests. All new tests fail on the pre-fix code.

## 2. RPC endpoints that fail browser CORS (`fec91002`)

`eth.merkle.io` and the `*.llamarpc.com` hosts don't answer the CORS preflight, so viem reads from the browser were blocked (`No 'Access-Control-Allow-Origin' header`). Reverse-ENS runs on mainnet on every page, so the two Ethereum entries surfaced the error constantly.

Dropped every CORS-failing host (`merkle`, all `*.llamarpc.com`, `sepolia-rollup.arbitrum.io`) and gave each chain a 3-deep, CORS-verified fallback: kept publicnode/mevblocker/tenderly, added the official L2 endpoints (`arb1.arbitrum.io`, `mainnet.base.org`, `mainnet.optimism.io`) and a per-chain dRPC endpoint. Backend CSP `connect-src` kept in sync; Go test that hardcoded `eth.merkle.io` updated. The server-side RPC list in `backend/internal/nft/types.go` is left as-is (node-to-node, no CORS).

## 3. `integration-images` module skipped under test (`0042cf05`)

The module fetches ~138 remote protocol images on Nuxt init. Booting Nuxt for Vitest triggered that on every run (pointless, rate-limited into noisy `HTTP 429` warnings). Now skips when `nuxt.options.test` is set, alongside the existing dev guard.

## Verification
- Frontend unit suite passes (incl. new sponsorship + chains specs); typecheck + lint clean.
- Go CSP tests pass.