### PR TITLE
fix(sponsorship): submit button stuck disabled after a fresh sign-in

### DIFF
--- a/backend/internal/csp/middleware.go
+++ b/backend/internal/csp/middleware.go
@@ -63,9 +63,14 @@ func Middleware(next http.Handler, devConnectSrc ...string) http.Handler {
 			extraHeaders = override.Headers
 		}
 
-		// In dev mode, add extra connect-src sources (e.g. Vite HMR WebSocket)
+		// In dev mode (signalled by dev connect-src being supplied), relax the CSP for
+		// local tooling: Vite HMR sockets (connect-src) plus the Nuxt DevTools iframe,
+		// which frames same-origin URLs like /__nuxt_devtools__/ (frame-src 'self').
 		if len(devConnectSrc) > 0 {
-			policy = Merge(policy, Policy{"connect-src": devConnectSrc})
+			policy = Merge(policy, Policy{
+				"connect-src": devConnectSrc,
+				"frame-src":   {"'self'"},
+			})
 		}
 
 		// Set CSP header with the nonce

--- a/packages/website/app/modules/web3/sponsorship/components/submission/NftSubmissionForm.vue
+++ b/packages/website/app/modules/web3/sponsorship/components/submission/NftSubmissionForm.vue
@@ -38,7 +38,6 @@ const {
   nftIdOptions,
   nftReleaseName,
   nftTier,
-  ownershipBlocksSubmit,
   removeImage,
   shouldDisableFields,
   sponsorshipData,
@@ -186,7 +185,7 @@ const [DefineNftIdOption, ReuseNftIdOption] = createReusableTemplate<{
           size="lg"
           class="w-full"
           :loading="isSubmitting || isAuthenticating"
-          :disabled="!isAuthenticated || v$.$invalid || ownershipBlocksSubmit"
+          :disabled="!isAuthenticated || v$.$invalid"
         >
           {{ editingSubmission || existingSubmission ? t('sponsor.submit_name.update') : t('sponsor.submit_name.submit') }}
         </RuiButton>

--- a/packages/website/app/modules/web3/sponsorship/components/submission/NftSubmissionForm.vue
+++ b/packages/website/app/modules/web3/sponsorship/components/submission/NftSubmissionForm.vue
@@ -71,160 +71,186 @@ const [DefineNftIdOption, ReuseNftIdOption] = createReusableTemplate<{
     </div>
   </DefineNftIdOption>
   <RuiCard class="!p-4">
-    <form
-      class="flex flex-col gap-6"
-      @submit.prevent="handleSubmit()"
+    <Transition
+      mode="out-in"
+      enter-active-class="motion-safe:transition motion-safe:duration-200 ease-out"
+      enter-from-class="opacity-0 motion-safe:translate-y-2"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="motion-safe:transition motion-safe:duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
     >
-      <RuiAutoComplete
-        v-model="modelTokenId"
-        :label="t('sponsor.submit_name.token_id_label')"
-        :hint="t('sponsor.submit_name.token_id_hint')"
-        :error-messages="toMessages(v$.tokenId)"
-        :disabled="shouldDisableFields"
-        :options="nftIdOptions"
-        :loading="isCheckingNft"
-        key-attr="id"
-        text-attr="id"
-        clearable
-        custom-value
-        auto-select-first
-        variant="outlined"
-        color="primary"
+      <form
+        v-if="isAuthenticated"
+        class="flex flex-col gap-6"
+        @submit.prevent="handleSubmit()"
       >
-        <template #item="{ item }">
-          <ReuseNftIdOption :item="item" />
-        </template>
-        <template #selection="{ item }">
-          <ReuseNftIdOption :item="item" />
-        </template>
-      </RuiAutoComplete>
-
-      <RuiAlert
-        v-if="nftCheckError"
-        type="error"
-      >
-        <i18n-t
-          v-if="nftCheckError === 'wrong_release'"
-          keypath="sponsor.submit_name.error.wrong_release"
-          scope="global"
-          tag="span"
-        >
-          <template #nftRelease>
-            <strong>{{ nftReleaseName }}</strong>
-          </template>
-          <template #currentRelease>
-            <strong>{{ sponsorshipData?.releaseName || `Release ${sponsorshipData?.releaseId}` }}</strong>
-          </template>
-        </i18n-t>
-        <template v-else>
-          {{ nftCheckError }}
-        </template>
-      </RuiAlert>
-      <RuiAlert
-        v-else-if="nftTier"
-        type="info"
-      >
-        <i18n-t
-          keypath="sponsor.submit_name.nft_info"
-          scope="global"
-          tag="span"
-        >
-          <template #tokenId>
-            {{ modelTokenId }}
-          </template>
-          <template #tier>
-            <strong class="uppercase">{{ nftTier }} tier</strong>
-          </template>
-          <template #releaseName>
-            <strong>{{ nftReleaseName }}</strong>
-          </template>
-        </i18n-t>
-      </RuiAlert>
-
-      <RuiTextField
-        v-model="modelDisplayName"
-        :label="t('sponsor.submit_name.name_label')"
-        :hint="t('sponsor.submit_name.name_hint')"
-        :error-messages="toMessages(v$.displayName)"
-        :disabled="shouldDisableFields"
-        variant="outlined"
-        color="primary"
-      />
-
-      <div v-if="nftTier === 'silver' || nftTier === 'gold'">
-        <label class="block text-sm font-medium mb-2">
-          {{ t('sponsor.submit_name.image_label') }}
-          <span class="text-rui-text-secondary">({{ t('sponsor.submit_name.optional') }})</span>
-        </label>
-
-        <ImageUploadPreview
-          :image-preview="imagePreview"
+        <RuiAutoComplete
+          v-model="modelTokenId"
+          :label="t('sponsor.submit_name.token_id_label')"
+          :hint="t('sponsor.submit_name.token_id_hint')"
+          :error-messages="toMessages(v$.tokenId)"
           :disabled="shouldDisableFields"
-          :error-messages="toMessages(v$.imageFile)"
-          :hint="nftTier === 'silver' ? t('sponsor.submit_name.image_hint_silver') : t('sponsor.submit_name.image_hint_gold')"
-          @file-selected="handleImageSelected($event)"
-          @remove="removeImage()"
+          :options="nftIdOptions"
+          :loading="isCheckingNft"
+          key-attr="id"
+          text-attr="id"
+          clearable
+          custom-value
+          auto-select-first
+          variant="outlined"
+          color="primary"
+        >
+          <template #item="{ item }">
+            <ReuseNftIdOption :item="item" />
+          </template>
+          <template #selection="{ item }">
+            <ReuseNftIdOption :item="item" />
+          </template>
+        </RuiAutoComplete>
+
+        <RuiAlert
+          v-if="nftCheckError"
+          type="error"
+        >
+          <i18n-t
+            v-if="nftCheckError === 'wrong_release'"
+            keypath="sponsor.submit_name.error.wrong_release"
+            scope="global"
+            tag="span"
+          >
+            <template #nftRelease>
+              <strong>{{ nftReleaseName }}</strong>
+            </template>
+            <template #currentRelease>
+              <strong>{{ sponsorshipData?.releaseName || `Release ${sponsorshipData?.releaseId}` }}</strong>
+            </template>
+          </i18n-t>
+          <template v-else>
+            {{ nftCheckError }}
+          </template>
+        </RuiAlert>
+        <RuiAlert
+          v-else-if="nftTier"
+          type="info"
+        >
+          <i18n-t
+            keypath="sponsor.submit_name.nft_info"
+            scope="global"
+            tag="span"
+          >
+            <template #tokenId>
+              {{ modelTokenId }}
+            </template>
+            <template #tier>
+              <strong class="uppercase">{{ nftTier }} tier</strong>
+            </template>
+            <template #releaseName>
+              <strong>{{ nftReleaseName }}</strong>
+            </template>
+          </i18n-t>
+        </RuiAlert>
+
+        <RuiTextField
+          v-model="modelDisplayName"
+          :label="t('sponsor.submit_name.name_label')"
+          :hint="t('sponsor.submit_name.name_hint')"
+          :error-messages="toMessages(v$.displayName)"
+          :disabled="shouldDisableFields"
+          variant="outlined"
+          color="primary"
         />
-      </div>
 
-      <RuiTextField
-        v-model="modelEmail"
-        :label="t('sponsor.submit_name.email_label')"
-        :hint="t('sponsor.submit_name.email_hint')"
-        :error-messages="toMessages(v$.email)"
-        :disabled="shouldDisableFields"
-        type="email"
-        variant="outlined"
-        color="primary"
-      />
+        <div v-if="nftTier === 'silver' || nftTier === 'gold'">
+          <label class="block text-sm font-medium mb-2">
+            {{ t('sponsor.submit_name.image_label') }}
+            <span class="text-rui-text-secondary">({{ t('sponsor.submit_name.optional') }})</span>
+          </label>
 
-      <div v-if="isConnected">
+          <ImageUploadPreview
+            :image-preview="imagePreview"
+            :disabled="shouldDisableFields"
+            :error-messages="toMessages(v$.imageFile)"
+            :hint="nftTier === 'silver' ? t('sponsor.submit_name.image_hint_silver') : t('sponsor.submit_name.image_hint_gold')"
+            @file-selected="handleImageSelected($event)"
+            @remove="removeImage()"
+          />
+        </div>
+
+        <RuiTextField
+          v-model="modelEmail"
+          :label="t('sponsor.submit_name.email_label')"
+          :hint="t('sponsor.submit_name.email_hint')"
+          :error-messages="toMessages(v$.email)"
+          :disabled="shouldDisableFields"
+          type="email"
+          variant="outlined"
+          color="primary"
+        />
+
         <RuiButton
           type="submit"
           color="primary"
           size="lg"
           class="w-full"
           :loading="isSubmitting || isAuthenticating"
-          :disabled="!isAuthenticated || v$.$invalid"
+          :disabled="v$.$invalid"
         >
           {{ editingSubmission || existingSubmission ? t('sponsor.submit_name.update') : t('sponsor.submit_name.submit') }}
         </RuiButton>
-        <p
-          v-if="!isAuthenticated"
-          class="mt-2 text-sm text-rui-text-secondary text-center"
+
+        <RuiAlert
+          v-if="error"
+          type="error"
         >
-          {{ t('sponsor.submit_name.sign_required') }}
-        </p>
-      </div>
+          {{ error }}
+        </RuiAlert>
 
-      <div v-else>
-        <RuiButton
-          type="submit"
-          color="primary"
-          size="lg"
-          class="w-full"
-          disabled
+        <RuiAlert
+          v-if="success"
+          type="success"
         >
-          {{ editingSubmission || existingSubmission ? t('sponsor.submit_name.update') : t('sponsor.submit_name.submit') }}
-        </RuiButton>
-        <p class="mt-2 text-sm text-rui-text-secondary">
-          {{ t('sponsor.submit_name.connect_to_submit') }}
+          {{ t('sponsor.submit_name.success') }}
+        </RuiAlert>
+      </form>
+
+      <!-- Signed out: guide the user to the wallet card above instead of a dead, greyed form. -->
+      <div
+        v-else
+        class="flex flex-col items-center gap-4 py-6 text-center"
+      >
+        <div class="rounded-full bg-rui-primary/10 p-4">
+          <RuiIcon
+            name="lu-wallet"
+            size="28"
+            class="text-rui-primary"
+          />
+        </div>
+        <p class="max-w-xs text-balance font-medium text-rui-text">
+          {{ isConnected ? t('sponsor.submit_name.gate_sign') : t('sponsor.submit_name.gate_connect') }}
         </p>
+        <RuiAlert
+          v-if="nftTier"
+          type="info"
+          class="w-full text-left"
+        >
+          <i18n-t
+            keypath="sponsor.submit_name.nft_info"
+            scope="global"
+            tag="span"
+          >
+            <template #tokenId>
+              {{ modelTokenId }}
+            </template>
+            <template #tier>
+              <strong class="uppercase">{{ nftTier }} tier</strong>
+            </template>
+            <template #releaseName>
+              <strong>{{ nftReleaseName }}</strong>
+            </template>
+          </i18n-t>
+        </RuiAlert>
       </div>
-
-      <RuiAlert
-        v-if="error"
-        type="error"
-      >
-        {{ error }}
-      </RuiAlert>
-
-      <RuiAlert
-        v-if="success"
-        type="success"
-      >
-        {{ t('sponsor.submit_name.success') }}
-      </RuiAlert>
-    </form>
+    </Transition>
   </RuiCard>
 </template>

--- a/packages/website/app/modules/web3/sponsorship/submission-state.ts
+++ b/packages/website/app/modules/web3/sponsorship/submission-state.ts
@@ -61,19 +61,6 @@ export function buildSubmissionFormData(input: SubmissionFormInput): FormData {
 }
 
 /**
- * Whether the live on-chain NFT ownership re-check should block submitting.
- *
- * A brand-new submission must pass the owner/release check. Editing an existing
- * submission must NOT: ownership was already proven when it was first accepted,
- * the NFT may now belong to a past release, and the backend re-verifies on
- * submit. Without this carve-out the update button stays disabled for any
- * non-`ok` re-check (e.g. `wrong_release`) until the user re-selects the NFT.
- */
-export function isSubmitBlockedByOwnership(params: { hasCheckedNft: boolean; isNftOwnerValid: boolean; isEditing: boolean }): boolean {
-  return params.hasCheckedNft && !params.isNftOwnerValid && !params.isEditing;
-}
-
-/**
  * Whether selecting `tokenId` should reset the form up front, before the async
  * NFT/existing-submission checks run. Every selection is a fresh start except
  * re-selecting the submission currently being edited (whose prefill must survive).

--- a/packages/website/app/modules/web3/sponsorship/submission-submit-flow.ts
+++ b/packages/website/app/modules/web3/sponsorship/submission-submit-flow.ts
@@ -1,0 +1,126 @@
+import type { NftMetadataStatus } from '~/modules/web3/sponsorship/submission-state';
+import { pipe } from 'plainfp';
+import { err, ok } from 'plainfp/result';
+import { flatMap, type ResultAsync } from 'plainfp/result-async';
+import { tag, type Tagged } from 'plainfp/tagged';
+
+/**
+ * Ordered, dependency-injected holder-submission flow. Each step runs only after
+ * the previous one succeeds — validate, then verify ownership, then build the
+ * payload, then submit — so the outcome never depends on whether a watcher
+ * happened to set an imperative flag first (the fresh-sign race). Every dependency
+ * is passed in, so the whole flow is unit-testable without Vue or the network.
+ */
+
+/** Tagged failure union for a submit attempt. */
+export type SubmitError =
+  | Tagged<'ValidationFailed', object>
+  | Tagged<'NftNotFound', object>
+  | Tagged<'WrongRelease', object>
+  | Tagged<'NotOwner', object>
+  | Tagged<'OwnershipUnverified', object>
+  | Tagged<'CheckFailed', object>
+  | Tagged<'AuthRequired', object>
+  | Tagged<'SubmitFailed', { message?: string }>;
+
+export interface SubmitFlowDeps {
+  /** Vuelidate `$validate()`; resolves true when the form passes. */
+  validate: () => Promise<boolean>;
+  /** Editing skips the live ownership gate — the backend re-verifies on submit. */
+  isEditing: boolean;
+  /** Runs the on-chain metadata/ownership check and resolves its status. */
+  checkOwnership: () => Promise<NftMetadataStatus | undefined>;
+  /** Assemble the multipart payload (pure). */
+  buildPayload: () => FormData;
+  /** Submit behind a valid SIWE session; rejects on failure. */
+  submit: (payload: FormData) => Promise<void>;
+}
+
+/** Map an ownership status to the matching submit error (undefined status = inconclusive check). */
+export function ownershipStatusToError(status: NftMetadataStatus | undefined): SubmitError | undefined {
+  switch (status) {
+    case 'ok':
+      return undefined;
+    case 'not_found':
+      return tag('NftNotFound')({});
+    case 'wrong_release':
+      return tag('WrongRelease')({});
+    case 'not_owner':
+      return tag('NotOwner')({});
+    case 'unverified':
+      return tag('OwnershipUnverified')({});
+    case undefined:
+      return tag('CheckFailed')({});
+  }
+}
+
+/** Translate a thrown submit error into the tagged union, preserving auth + backend messages. */
+export function mapThrownSubmitError(cause: unknown): SubmitError {
+  const message = cause instanceof Error ? cause.message : undefined;
+  if (message?.includes('Authentication required'))
+    return tag('AuthRequired')({});
+  return tag('SubmitFailed')({ message: backendMessage(cause) ?? message });
+}
+
+/** Pull a `{ data: { message } }` string off a fetch error, if present. */
+function backendMessage(cause: unknown): string | undefined {
+  if (typeof cause !== 'object' || cause === null || !('data' in cause))
+    return undefined;
+  const data = cause.data;
+  if (typeof data !== 'object' || data === null || !('message' in data))
+    return undefined;
+  return typeof data.message === 'string' ? data.message : undefined;
+}
+
+/**
+ * Resolve the top-level error banner text for a failed submit. Validation and NFT
+ * errors already surface inline / via the nftCheckError alert, so they return ''.
+ * `translate` is the i18n `t` — injected so this stays pure and testable.
+ */
+export function submitErrorMessage(error: SubmitError, translate: (key: string) => string): string {
+  switch (error._tag) {
+    case 'ValidationFailed':
+    case 'NftNotFound':
+    case 'WrongRelease':
+    case 'NotOwner':
+    case 'CheckFailed':
+      return '';
+    case 'OwnershipUnverified':
+      return translate('sponsor.submit_name.error.check_failed');
+    case 'AuthRequired':
+      return translate('sponsor.submit_name.error.sign_failed');
+    case 'SubmitFailed':
+      return error.message || translate('sponsor.submit_name.error.submit_failed');
+  }
+}
+
+async function validateStep(validate: () => Promise<boolean>): ResultAsync<void, SubmitError> {
+  return (await validate()) ? ok(undefined) : err(tag('ValidationFailed')({}));
+}
+
+async function ownershipStep(isEditing: boolean, checkOwnership: () => Promise<NftMetadataStatus | undefined>): ResultAsync<void, SubmitError> {
+  if (isEditing)
+    return ok(undefined);
+
+  const error = ownershipStatusToError(await checkOwnership());
+  return error ? err(error) : ok(undefined);
+}
+
+async function submitStep(buildPayload: () => FormData, submit: (payload: FormData) => Promise<void>): ResultAsync<void, SubmitError> {
+  try {
+    await submit(buildPayload());
+    return ok(undefined);
+  }
+  catch (error) {
+    return err(mapThrownSubmitError(error));
+  }
+}
+
+/** Run the whole submit flow, short-circuiting on the first failing step. */
+export async function runSubmitFlow(deps: SubmitFlowDeps): ResultAsync<void, SubmitError> {
+  return pipe(
+    validateStep(deps.validate),
+    flatMap(async () => ownershipStep(deps.isEditing, deps.checkOwnership)),
+    flatMap(async () => submitStep(deps.buildPayload, deps.submit)),
+  );
+}

--- a/packages/website/app/modules/web3/sponsorship/use-nft-submission-form.ts
+++ b/packages/website/app/modules/web3/sponsorship/use-nft-submission-form.ts
@@ -5,7 +5,8 @@ import { useVuelidate, type ValidationArgs } from '@vuelidate/core';
 import { email as emailValidation, helpers, maxLength, minLength, numeric, required } from '@vuelidate/validators';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
-import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, isSubmitBlockedByOwnership, shouldResetFormForToken } from '~/modules/web3/sponsorship/submission-state';
+import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, type NftMetadataStatus, shouldResetFormForToken } from '~/modules/web3/sponsorship/submission-state';
+import { runSubmitFlow, submitErrorMessage } from '~/modules/web3/sponsorship/submission-submit-flow';
 import { useNftMetadata } from '~/modules/web3/sponsorship/use-nft-metadata';
 import { useNftSubmissions } from '~/modules/web3/sponsorship/use-nft-submissions';
 import { useRotkiSponsorshipPayment } from '~/modules/web3/sponsorship/use-payment';
@@ -132,13 +133,6 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
 
   const shouldDisableFields = computed<boolean>(() => get(isSubmitting) || !get(isAuthenticated));
 
-  // Editing an existing submission is never gated by the live ownership re-check.
-  const ownershipBlocksSubmit = computed<boolean>(() => isSubmitBlockedByOwnership({
-    hasCheckedNft: get(hasCheckedNft),
-    isEditing: !!toValue(editingSubmission),
-    isNftOwnerValid: get(isNftOwnerValid),
-  }));
-
   function handleImageSelected(file: File): void {
     set(imageFile, file);
     // Replacing an existing image means we no longer want to delete it.
@@ -214,11 +208,14 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
     }
   }
 
-  async function checkNftMetadata(): Promise<void> {
+  // `checkExisting` prefills/switches to editing when the NFT already has a
+  // submission; the submit flow passes false so re-verifying ownership at submit
+  // never mutates the form the user is filling.
+  async function checkNftMetadata({ checkExisting = true }: { checkExisting?: boolean } = {}): Promise<NftMetadataStatus | undefined> {
     const tokenIdValue = get(modelTokenId);
     if (!tokenIdValue || !Number.isInteger(Number(tokenIdValue))) {
       set(nftCheckError, t('sponsor.submit_name.error.invalid_token_id'));
-      return;
+      return undefined;
     }
 
     try {
@@ -252,14 +249,18 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
           break;
         case 'ok':
           set(isNftOwnerValid, true);
-          await checkExistingSubmission(Number(tokenIdValue));
+          if (checkExisting)
+            await checkExistingSubmission(Number(tokenIdValue));
           break;
         case 'unverified':
           break;
       }
+
+      return evaluation.status;
     }
     catch (error_: any) {
       set(nftCheckError, error_.data?.message || t('sponsor.submit_name.error.check_failed'));
+      return undefined;
     }
     finally {
       set(isCheckingNft, false);
@@ -267,36 +268,40 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
     }
   }
 
+  // Submit behind a valid SIWE session. authenticatedRequest ensures the session and,
+  // if the backend cookie has expired, transparently re-signs and retries once — so
+  // the flow stays auth-agnostic and just calls this. The inner const isolates
+  // fetchWithCsrf's route-typed inference (inlining it overflows the TS route matcher).
+  async function submitHolderSubmission(payload: FormData): Promise<void> {
+    const postSubmission = async () => fetchWithCsrf('/webapi/nfts/holder-submission/', { body: payload, method: 'POST' });
+    await authenticatedRequest(toValue(address) || '', postSubmission);
+  }
+
   async function handleSubmit(): Promise<void> {
-    const isValid = await get(v$).$validate();
-    if (!isValid)
-      return;
-
+    set(error, '');
+    set(isSubmitting, true);
     try {
-      set(error, '');
-      set(isSubmitting, true);
-
-      // Verify NFT ownership before the first submit attempt.
-      if (!get(hasCheckedNft)) {
-        await checkNftMetadata();
-        if (!get(isNftOwnerValid)) {
-          set(isSubmitting, false);
-          return;
-        }
-      }
-
-      const formData = buildSubmissionFormData({
-        address: toValue(address),
-        deleteImage: get(deleteImage),
-        displayName: get(modelDisplayName),
-        email: get(modelEmail),
-        imageFile: get(imageFile),
+      const outcome = await runSubmitFlow({
+        buildPayload: () => buildSubmissionFormData({
+          address: toValue(address),
+          deleteImage: get(deleteImage),
+          displayName: get(modelDisplayName),
+          email: get(modelEmail),
+          imageFile: get(imageFile),
+          isEditing: !!toValue(editingSubmission),
+          tokenId: get(modelTokenId),
+        }),
+        // Re-verify ownership in-order at submit; skip the existing-submission prefill.
+        checkOwnership: async () => checkNftMetadata({ checkExisting: false }),
         isEditing: !!toValue(editingSubmission),
-        tokenId: get(modelTokenId),
+        submit: submitHolderSubmission,
+        validate: async () => get(v$).$validate(),
       });
 
-      const submitFormData = async () => fetchWithCsrf('/webapi/nfts/holder-submission/', { body: formData, method: 'POST' });
-      await authenticatedRequest(toValue(address) || '', submitFormData);
+      if (!outcome.ok) {
+        set(error, submitErrorMessage(outcome.error, t));
+        return;
+      }
 
       set(modelDisplayName, '');
       set(modelTokenId, '');
@@ -311,12 +316,6 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
         get(v$).$reset();
       });
       emit('submission-success');
-    }
-    catch (error_: any) {
-      if (error_.message?.includes('Authentication required'))
-        set(error, t('sponsor.submit_name.error.sign_failed'));
-      else
-        set(error, error_.data?.message || t('sponsor.submit_name.error.submit_failed'));
     }
     finally {
       set(isSubmitting, false);
@@ -390,7 +389,6 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
     nftIdOptions,
     nftReleaseName: shallowReadonly(nftReleaseName),
     nftTier: shallowReadonly(nftTier),
-    ownershipBlocksSubmit,
     removeImage,
     shouldDisableFields,
     sponsorshipData,

--- a/packages/website/app/modules/web3/sponsorship/use-siwe-auth.ts
+++ b/packages/website/app/modules/web3/sponsorship/use-siwe-auth.ts
@@ -1,3 +1,4 @@
+import { createSharedComposable } from '@vueuse/core';
 import { get, set } from '@vueuse/shared';
 import { fromZod } from 'plainfp/interop/zod';
 import { pipe } from 'plainfp/pipe';
@@ -47,7 +48,17 @@ function isSiweCookieError(error: unknown): boolean {
   return statusCode === 403 && typeof detail === 'string' && SIWE_ERROR_KEYS.some(item => detail.includes(item));
 }
 
-export function useSiweAuth() {
+/**
+ * Shared so every consumer (wallet card, submission form, submissions list) reads
+ * one `siwe_session` ref: signing in from the card must flip `isSessionValid` for
+ * the form in the same tick. Separate instances relied on cross-instance storage
+ * events that don't fire same-document, leaving the form disabled after sign-in.
+ * Safe as a shared composable (unlike `useLazyAsyncData`): it only wraps
+ * `useLocalStorage` + a `watch`, so a dispose/re-init just re-reads localStorage.
+ */
+export const useSiweAuth = createSharedComposable(useSiweAuthInternal);
+
+function useSiweAuthInternal() {
   const { fetchWithCsrf } = useFetchWithCsrf();
   const { address, connected, connectedChainId, signMessage: signMessageWeb3 } = useWallet();
   const logger = useLogger();

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -1152,6 +1152,8 @@
       "connect_to_view_submissions": "Connect your wallet to view your NFT submissions",
       "sign_to_continue": "Sign in with Ethereum",
       "sign_required": "Please sign the message to verify your wallet ownership",
+      "gate_connect": "Connect your wallet above, then sign in to set your sponsor display name and image.",
+      "gate_sign": "Sign in above to set your sponsor display name and image.",
       "submit": "Submit Data",
       "update": "Update Submission",
       "success": "Your data has been submitted successfully!",

--- a/packages/website/tests/unit/composables/use-siwe-auth.spec.ts
+++ b/packages/website/tests/unit/composables/use-siwe-auth.spec.ts
@@ -1,6 +1,7 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { get } from '@vueuse/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type EffectScope, effectScope } from 'vue';
 
 const mockFetchWithCsrf = vi.fn();
 const mockSignMessage = vi.fn();
@@ -44,7 +45,19 @@ const TEST_NONCE = 'testnonce123';
 const TEST_SIGNATURE = '0xsignature';
 
 describe('useSiweAuth', () => {
+  // useSiweAuth is a createSharedComposable, so it memoizes one instance. Running
+  // each call inside its own effectScope and stopping it here drops the subscriber
+  // count to 0, disposing the shared state so the next test starts fresh.
+  const scopes: EffectScope[] = [];
+
+  function useInScope<T>(factory: () => T): T {
+    const scope = effectScope();
+    scopes.push(scope);
+    return scope.run(factory)!;
+  }
+
   afterEach(() => {
+    scopes.splice(0).forEach(scope => scope.stop());
     vi.clearAllMocks();
     localStorage.clear();
   });
@@ -60,7 +73,7 @@ describe('useSiweAuth', () => {
     mockSignMessage.mockResolvedValueOnce(okResult(TEST_SIGNATURE));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate, isSessionValid } = useSiweAuth();
+    const { authenticate, isSessionValid } = useInScope(() => useSiweAuth());
 
     const result = await authenticate(TEST_ADDRESS);
 
@@ -86,7 +99,7 @@ describe('useSiweAuth', () => {
     mockSignMessage.mockResolvedValueOnce(errResult('UserRejected', 'User rejected'));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate, authError } = useSiweAuth();
+    const { authenticate, authError } = useInScope(() => useSiweAuth());
 
     const result = await authenticate(TEST_ADDRESS);
 
@@ -99,7 +112,7 @@ describe('useSiweAuth', () => {
     mockSignMessage.mockResolvedValueOnce(errResult('SignFailed', 'Unknown signing error'));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate, authError } = useSiweAuth();
+    const { authenticate, authError } = useInScope(() => useSiweAuth());
 
     const result = await authenticate(TEST_ADDRESS);
 
@@ -111,7 +124,7 @@ describe('useSiweAuth', () => {
     mockFetchWithCsrf.mockRejectedValueOnce(new Error('Network error'));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate, authError } = useSiweAuth();
+    const { authenticate, authError } = useInScope(() => useSiweAuth());
 
     const result = await authenticate(TEST_ADDRESS);
 
@@ -126,7 +139,7 @@ describe('useSiweAuth', () => {
     mockSignMessage.mockResolvedValueOnce(okResult(TEST_SIGNATURE));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate, authError } = useSiweAuth();
+    const { authenticate, authError } = useInScope(() => useSiweAuth());
 
     const result = await authenticate(TEST_ADDRESS);
 
@@ -145,7 +158,7 @@ describe('useSiweAuth', () => {
     mockSignMessage.mockResolvedValueOnce(okResult(TEST_SIGNATURE));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate, isAuthenticating } = useSiweAuth();
+    const { authenticate, isAuthenticating } = useInScope(() => useSiweAuth());
 
     expect(get(isAuthenticating)).toBe(false);
 
@@ -160,7 +173,7 @@ describe('useSiweAuth', () => {
     mockFetchWithCsrf.mockRejectedValueOnce(new Error('fail'));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate, isAuthenticating } = useSiweAuth();
+    const { authenticate, isAuthenticating } = useInScope(() => useSiweAuth());
 
     await authenticate(TEST_ADDRESS);
 
@@ -175,7 +188,7 @@ describe('useSiweAuth', () => {
     localStorage.setItem('siwe_session', JSON.stringify(session));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { authenticate } = useSiweAuth();
+    const { authenticate } = useInScope(() => useSiweAuth());
 
     const result = await authenticate(TEST_ADDRESS);
 
@@ -192,7 +205,7 @@ describe('useSiweAuth', () => {
     localStorage.setItem('siwe_session', JSON.stringify(session));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { isSessionValid } = useSiweAuth();
+    const { isSessionValid } = useInScope(() => useSiweAuth());
 
     expect(isSessionValid(TEST_ADDRESS)).toBe(false);
   });
@@ -205,8 +218,24 @@ describe('useSiweAuth', () => {
     localStorage.setItem('siwe_session', JSON.stringify(session));
 
     const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
-    const { isSessionValid } = useSiweAuth();
+    const { isSessionValid } = useInScope(() => useSiweAuth());
 
     expect(isSessionValid(TEST_ADDRESS)).toBe(false);
+  });
+
+  it('shares one instance across consumers so sign-in state is not siloed', async () => {
+    // Regression: the wallet card and the submission form each call useSiweAuth.
+    // As a createSharedComposable they must get the SAME reactive refs, so signing
+    // in via the card flips the form's auth state in the same tick. Separate
+    // instances left the form disabled after signing in on first load. (Instance
+    // identity is the reliable check: happy-dom syncs localStorage across separate
+    // instances in-document, which real browsers do not, so a behavioural session
+    // assertion can't distinguish the two here.)
+    const { useSiweAuth } = await import('~/modules/web3/sponsorship/use-siwe-auth');
+    const card = useInScope(() => useSiweAuth());
+    const form = useInScope(() => useSiweAuth());
+
+    expect(form.isAuthenticating).toBe(card.isAuthenticating);
+    expect(form.authError).toBe(card.authError);
   });
 });

--- a/packages/website/tests/unit/modules/web3/sponsorship/submission-state.spec.ts
+++ b/packages/website/tests/unit/modules/web3/sponsorship/submission-state.spec.ts
@@ -1,7 +1,7 @@
 import type { SimpleTokenMetadata, StoredNft } from '~/modules/web3/sponsorship/types';
 import type { NftSubmission } from '~/types/sponsor';
 import { describe, expect, it } from 'vitest';
-import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, isCurrentReleaseSubmission, isSubmitBlockedByOwnership, shouldResetFormForToken } from '~/modules/web3/sponsorship/submission-state';
+import { buildNftIdOptions, buildSubmissionFormData, evaluateNftMetadata, isCurrentReleaseSubmission, shouldResetFormForToken } from '~/modules/web3/sponsorship/submission-state';
 
 function storedNft(partial: Partial<StoredNft> & Pick<StoredNft, 'id'>): StoredNft {
   return { address: '0xowner', releaseId: 1, tier: 0, ...partial };
@@ -138,27 +138,6 @@ describe('evaluateNftMetadata', () => {
 
   it('skips the release check when no current release is known', () => {
     expect(evaluateNftMetadata(metadata({ releaseId: 99 }), '0xowner', undefined)).toMatchObject({ status: 'ok' });
-  });
-});
-
-describe('isSubmitBlockedByOwnership', () => {
-  it('does not block before the NFT has been checked', () => {
-    expect(isSubmitBlockedByOwnership({ hasCheckedNft: false, isNftOwnerValid: false, isEditing: false })).toBe(false);
-  });
-
-  it('does not block once ownership is confirmed', () => {
-    expect(isSubmitBlockedByOwnership({ hasCheckedNft: true, isNftOwnerValid: true, isEditing: false })).toBe(false);
-  });
-
-  it('blocks a new submission when the ownership check failed', () => {
-    expect(isSubmitBlockedByOwnership({ hasCheckedNft: true, isNftOwnerValid: false, isEditing: false })).toBe(true);
-  });
-
-  it('never blocks editing an existing submission, even when the re-check fails', () => {
-    // Regression: editing an NFT from a previous release re-evaluates to
-    // wrong_release (isNftOwnerValid=false), which previously left the update
-    // button disabled until the user re-selected the NFT.
-    expect(isSubmitBlockedByOwnership({ hasCheckedNft: true, isNftOwnerValid: false, isEditing: true })).toBe(false);
   });
 });
 

--- a/packages/website/tests/unit/modules/web3/sponsorship/submission-submit-flow.spec.ts
+++ b/packages/website/tests/unit/modules/web3/sponsorship/submission-submit-flow.spec.ts
@@ -1,0 +1,143 @@
+import type { NftMetadataStatus } from '~/modules/web3/sponsorship/submission-state';
+import { describe, expect, it } from 'vitest';
+import { mapThrownSubmitError, ownershipStatusToError, runSubmitFlow, type SubmitError, type SubmitFlowDeps } from '~/modules/web3/sponsorship/submission-submit-flow';
+
+interface Behaviour {
+  validate?: boolean;
+  ownership?: NftMetadataStatus | undefined;
+  isEditing?: boolean;
+  submit?: () => void;
+}
+
+// Each dependency records its own name in `calls`, so a test can assert the exact
+// execution order and that later steps never run once an earlier one fails.
+function makeDeps(behaviour: Behaviour = {}): { deps: SubmitFlowDeps; calls: string[] } {
+  const calls: string[] = [];
+  const deps: SubmitFlowDeps = {
+    buildPayload: () => {
+      calls.push('build');
+      return new FormData();
+    },
+    checkOwnership: async () => {
+      calls.push('ownership');
+      // `in` so an explicit `ownership: undefined` (inconclusive check) is honoured.
+      return 'ownership' in behaviour ? behaviour.ownership : 'ok';
+    },
+    isEditing: behaviour.isEditing ?? false,
+    submit: async () => {
+      calls.push('submit');
+      behaviour.submit?.();
+    },
+    validate: async () => {
+      calls.push('validate');
+      return behaviour.validate ?? true;
+    },
+  };
+  return { calls, deps };
+}
+
+function tagOf(error: SubmitError): string {
+  return error._tag;
+}
+
+describe('runSubmitFlow', () => {
+  it('runs the steps in order: validate -> ownership -> build -> submit', async () => {
+    const { calls, deps } = makeDeps();
+
+    const result = await runSubmitFlow(deps);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual(['validate', 'ownership', 'build', 'submit']);
+  });
+
+  it('stops at validation and touches nothing else when the form is invalid', async () => {
+    const { calls, deps } = makeDeps({ validate: false });
+
+    const result = await runSubmitFlow(deps);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? undefined : tagOf(result.error)).toBe('ValidationFailed');
+    expect(calls).toEqual(['validate']);
+  });
+
+  it('stops at ownership (never builds or submits) when the wallet is not the owner', async () => {
+    const { calls, deps } = makeDeps({ ownership: 'not_owner' });
+
+    const result = await runSubmitFlow(deps);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? undefined : tagOf(result.error)).toBe('NotOwner');
+    expect(calls).toEqual(['validate', 'ownership']);
+  });
+
+  it('treats an inconclusive ownership check as CheckFailed', async () => {
+    const { deps } = makeDeps({ ownership: undefined });
+
+    const result = await runSubmitFlow(deps);
+
+    expect(result.ok ? undefined : tagOf(result.error)).toBe('CheckFailed');
+  });
+
+  it('skips the ownership check entirely when editing', async () => {
+    const { calls, deps } = makeDeps({ isEditing: true });
+
+    const result = await runSubmitFlow(deps);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual(['validate', 'build', 'submit']);
+  });
+
+  it('maps an authentication failure from submit to AuthRequired', async () => {
+    const { deps } = makeDeps({
+      submit: () => {
+        throw new Error('Authentication required. Please sign the message to continue.');
+      },
+    });
+
+    const result = await runSubmitFlow(deps);
+
+    expect(result.ok ? undefined : tagOf(result.error)).toBe('AuthRequired');
+  });
+
+  it('surfaces a backend error message as SubmitFailed', async () => {
+    const { deps } = makeDeps({
+      submit: () => {
+        throw Object.assign(new Error('500'), { data: { message: 'Name already taken' } });
+      },
+    });
+
+    const result = await runSubmitFlow(deps);
+
+    expect(result).toStrictEqual({ error: { _tag: 'SubmitFailed', message: 'Name already taken' }, ok: false });
+  });
+});
+
+describe('ownershipStatusToError', () => {
+  it.each<[NftMetadataStatus, string | undefined]>([
+    ['ok', undefined],
+    ['not_found', 'NftNotFound'],
+    ['wrong_release', 'WrongRelease'],
+    ['not_owner', 'NotOwner'],
+    ['unverified', 'OwnershipUnverified'],
+  ])('maps %s -> %s', (status, expected) => {
+    expect(ownershipStatusToError(status)?._tag).toBe(expected);
+  });
+
+  it('maps a missing status to CheckFailed', () => {
+    expect(ownershipStatusToError(undefined)?._tag).toBe('CheckFailed');
+  });
+});
+
+describe('mapThrownSubmitError', () => {
+  it('recognises the auth-required sentinel', () => {
+    expect(mapThrownSubmitError(new Error('Authentication required'))._tag).toBe('AuthRequired');
+  });
+
+  it('prefers a backend data.message', () => {
+    expect(mapThrownSubmitError({ data: { message: 'boom' } })).toStrictEqual({ _tag: 'SubmitFailed', message: 'boom' });
+  });
+
+  it('falls back to the Error message', () => {
+    expect(mapThrownSubmitError(new Error('network down'))).toStrictEqual({ _tag: 'SubmitFailed', message: 'network down' });
+  });
+});

--- a/packages/website/tests/unit/modules/web3/sponsorship/use-nft-submission-form.spec.ts
+++ b/packages/website/tests/unit/modules/web3/sponsorship/use-nft-submission-form.spec.ts
@@ -77,7 +77,7 @@ function metadata(tier: TierKey, releaseId = CURRENT_RELEASE_ID): SimpleTokenMet
 }
 
 function submitDisabled(form: Form): boolean {
-  return !get(form.isAuthenticated) || get(form.v$).$invalid || get(form.ownershipBlocksSubmit);
+  return !get(form.isAuthenticated) || get(form.v$).$invalid;
 }
 
 // Let the token-change watcher run fetchNftMetadata and reach (but not resolve)
@@ -181,7 +181,8 @@ describe('useNftSubmissionForm submit-button gating', () => {
 
     expect(get(form.modelTokenId)).toBe('42');
     expect(get(form.modelDisplayName)).toBe('Edited Name');
-    // Editing is never gated on the live ownership re-check.
-    expect(get(form.ownershipBlocksSubmit)).toBe(false);
+    // Editing is never gated on the live ownership re-check: submit stays enabled
+    // for a past-release NFT (the submit flow skips ownership when editing).
+    expect(submitDisabled(form)).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #633. The sponsor submit button could stay disabled right after signing in on first load, needing an NFT re-select to unstick. Root cause was two separate issues, plus a UX cleanup.

## 1. SIWE auth was siloed per consumer (`50dbe8eb`)

The wallet card, submission form, and submissions list each called `useSiweAuth` independently, so each built its own `useLocalStorage('siwe_session')`. Signing in from the card updated only the card's ref, so the form's `isAuthenticated` stayed `false` and the form/button stayed disabled after a fresh sign-in.

Wrapped `useSiweAuth` in `createSharedComposable` (matching `usePendingTx` / `useFetchWithCsrf`) so every consumer reads one session ref. Tests run each call inside its own `effectScope` (stopped in `afterEach`) so the shared instance disposes between cases, plus a regression test that two consumers get the same refs.

## 2. Ownership was gated on a racy imperative flag (`6e183e5e`)

The button was gated on `ownershipBlocksSubmit`, derived from `isNftOwnerValid` — a one-shot flag set by `checkNftMetadata`. On a fresh sign-in the check could run before the wallet address settled, land on the silent `unverified` status, and leave the flag `false` with nothing to re-run it (hence the re-select workaround).

Moved ownership verification into an ordered, dependency-injected submit flow (`submission-submit-flow.ts`, a plainfp `ResultAsync` pipe): validate → verify ownership → build payload → submit, short-circuiting on the first failure. Ownership is re-checked **in order at submit** (skipping the existing-submission prefill), so the outcome no longer depends on watcher timing. The button now reflects only auth + form validity (`!isAuthenticated || v$.$invalid`); a non-owner surfaces as an inline error. Removed `ownershipBlocksSubmit` / `isSubmitBlockedByOwnership`. Full unit coverage of step order, each early-exit, the editing skip, and error mapping.

## 3. Guided signed-out state instead of a disabled form (`4bfcfe99`)

The signed-out form rendered fully greyed-out (reads as broken; the token picker is useless without a connected wallet anyway). Replaced it with a guided state — wallet icon + a message pointing at the connect/sign card above (tailored to connected vs not), preserving any `?tokenId` tier context. The real form fades/rises in on sign-in (`motion-safe`).

## 4. DevTools CSP in dev (`eca0d4a5`)

Dev-only `frame-src 'self'` so the Nuxt DevTools iframe isn't blocked by the Go backend CSP.

## Verification
- Full website unit suite passes (419); typecheck + lint clean; Go builds and CSP tests pass.
- Manually verified the fresh-sign flow: button enables on authenticated + valid form; ownership is checked at submit.