### PR TITLE
fix(sponsorship): load an existing submission for editing after sign-in

### DIFF
--- a/packages/website/app/modules/web3/sponsorship/use-nft-submission-form.ts
+++ b/packages/website/app/modules/web3/sponsorship/use-nft-submission-form.ts
@@ -208,9 +208,7 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
     }
   }
 
-  // `checkExisting` prefills/switches to editing when the NFT already has a
-  // submission; the submit flow passes false so re-verifying ownership at submit
-  // never mutates the form the user is filling.
+  // `checkExisting` runs the existing-submission prefill (authenticated only); submit passes false.
   async function checkNftMetadata({ checkExisting = true }: { checkExisting?: boolean } = {}): Promise<NftMetadataStatus | undefined> {
     const tokenIdValue = get(modelTokenId);
     if (!tokenIdValue || !Number.isInteger(Number(tokenIdValue))) {
@@ -249,7 +247,7 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
           break;
         case 'ok':
           set(isNftOwnerValid, true);
-          if (checkExisting)
+          if (checkExisting && get(isAuthenticated))
             await checkExistingSubmission(Number(tokenIdValue));
           break;
         case 'unverified':
@@ -268,10 +266,8 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
     }
   }
 
-  // Submit behind a valid SIWE session. authenticatedRequest ensures the session and,
-  // if the backend cookie has expired, transparently re-signs and retries once — so
-  // the flow stays auth-agnostic and just calls this. The inner const isolates
-  // fetchWithCsrf's route-typed inference (inlining it overflows the TS route matcher).
+  // Submit behind a valid SIWE session; authenticatedRequest re-signs + retries once if
+  // the backend cookie expired. Inner const isolates fetchWithCsrf's route-typed inference.
   async function submitHolderSubmission(payload: FormData): Promise<void> {
     const postSubmission = async () => fetchWithCsrf('/webapi/nfts/holder-submission/', { body: payload, method: 'POST' });
     await authenticatedRequest(toValue(address) || '', postSubmission);
@@ -355,12 +351,18 @@ export function useNftSubmissionForm(context: NftSubmissionFormContext) {
     if (submission && get(modelTokenId) !== submission.nftId.toString()) {
       set(modelTokenId, submission.nftId.toString());
       prefillFromSubmission(submission);
-      // Ownership was already proven when this submission was first accepted, so
-      // editing is not re-gated on the live owner/release check — see
-      // `ownershipBlocksSubmit`. (Setting modelTokenId above still refreshes the
-      // tier/release info via the modelTokenId watcher.)
+      // Editing is never re-gated on the live owner/release check (the submit flow skips
+      // ownership when editing). Setting modelTokenId refreshes tier/release via the watcher.
     }
   }, { immediate: true });
+
+  // checkNftMetadata defers the existing-submission lookup until authenticated; re-run it on
+  // sign-in so a prior submission loads to edit (e.g. a ?tokenId deep-link resolved pre-auth).
+  watch(isAuthenticated, async (authed) => {
+    const tokenId = get(modelTokenId);
+    if (authed && tokenId && Number.isInteger(Number(tokenId)) && !get(existingSubmission) && !toValue(editingSubmission))
+      await checkExistingSubmission(Number(tokenId));
+  });
 
   onMounted(async () => {
     const tokenIdParam = getSingleRouteParam(route.query.tokenId);

--- a/packages/website/tests/unit/modules/web3/sponsorship/use-nft-submission-form.spec.ts
+++ b/packages/website/tests/unit/modules/web3/sponsorship/use-nft-submission-form.spec.ts
@@ -13,6 +13,9 @@ const CURRENT_RELEASE_ID = 1;
 // controllable per-test so we can hold `checkExistingSubmission` open and drive
 // the race where the user types while it is still pending.
 const mockMetadata = ref<SimpleTokenMetadata | undefined>();
+// Drives isAuthenticated (isConnected && address && isSessionValid) so tests can
+// select a token while signed out and then sign in.
+const authValid = ref<boolean>(true);
 let existingSubmission: NftSubmission | undefined;
 let deferredCheck: { promise: Promise<NftSubmission | undefined>; resolve: () => void };
 
@@ -40,7 +43,7 @@ vi.mock('~/modules/web3/sponsorship/use-siwe-auth', () => ({
   useSiweAuth: () => ({
     authenticatedRequest: vi.fn(),
     isAuthenticating: ref(false),
-    isSessionValid: () => true,
+    isSessionValid: () => get(authValid),
   }),
 }));
 vi.mock('~/modules/web3/sponsorship/use-sponsorship', () => ({
@@ -90,6 +93,7 @@ async function flushMicrotasks(): Promise<void> {
 describe('useNftSubmissionForm submit-button gating', () => {
   beforeEach(() => {
     set(mockMetadata, undefined);
+    set(authValid, true);
     existingSubmission = undefined;
     deferCheck();
   });
@@ -184,5 +188,34 @@ describe('useNftSubmissionForm submit-button gating', () => {
     // Editing is never gated on the live ownership re-check: submit stays enabled
     // for a past-release NFT (the submit flow skips ownership when editing).
     expect(submitDisabled(form)).toBe(false);
+  });
+
+  it('prefills an existing submission after signing in when the token was selected while signed out', async () => {
+    // A ?tokenId deep-link resolves the NFT before sign-in. The lookup is auth-gated,
+    // so nothing prefills until the user signs in, then the isAuthenticated watcher
+    // loads the prior submission for editing instead of leaving a blank form.
+    set(authValid, false);
+    existingSubmission = {
+      createdAt: '2026-01-01',
+      displayName: 'Prior Name',
+      email: null,
+      imageUrl: null,
+      nftId: 5,
+      updatedAt: '2026-01-01',
+    };
+    set(mockMetadata, metadata('gold'));
+    const form = await setupForm();
+
+    set(form.modelTokenId, '5');
+    deferredCheck.resolve();
+    await flushMicrotasks();
+    // Signed out: ownership/tier resolved, but the submission is not loaded yet.
+    expect(get(form.isAuthenticated)).toBe(false);
+    expect(get(form.modelDisplayName)).toBe('');
+
+    set(authValid, true);
+    await flushMicrotasks();
+    expect(get(form.isAuthenticated)).toBe(true);
+    expect(get(form.modelDisplayName)).toBe('Prior Name');
   });
 });


### PR DESCRIPTION
Follow-up to #634. If you already have a submission for an NFT and you connect + sign in, the form loaded **blank** instead of prefilled — you had to open the submissions list and hit Edit to load it.

## Cause

`checkExistingSubmission` (the prefill lookup) goes through `authenticatedRequest`. When a token resolves **before** sign-in — e.g. a `?tokenId` deep-link handled in `onMounted` — the lookup throws `Authentication required`, which the code silently swallows, and nothing re-runs it once the user signs in. Same class of bug as the ownership one in #634: an auth-dependent check runs too early and never self-heals.

## Fix

- **Gate the lookup on auth** — `checkNftMetadata` only runs `checkExistingSubmission` while authenticated, so there's no doomed pre-auth call.
- **Re-run on sign-in** — an `isAuthenticated` watcher runs the lookup for the selected, non-editing token once the SIWE session is valid, so a prior submission loads for editing.

The public ownership/tier check still runs signed out (tier badge shows on a deep-link), and submit still re-verifies ownership. The list → Edit path is unchanged.

Adds a regression test: select a token while signed out (no prefill), then sign in → the prior submission loads. Verified it fails without the watcher.

## Verification
Sponsorship + SIWE suites pass (109); typecheck + lint clean.