### PR TITLE
Expectations adjustments

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -63,6 +63,10 @@ PORT=3000 \
 | `SPONSORSHIP_ENABLED`    | `false`                    |                         | Expose sponsorship as enabled via `/api/config` (frontend feature flag)    |
 | `MAINTENANCE`            | `false`                    |                         | Expose maintenance mode via `/api/config` (frontend feature flag)          |
 | `TESTING`                | `false`                    |                         | Expose testing mode via `/api/config` (frontend feature flag)              |
+| `CAMPAIGN_CODE`          | _(empty)_                  |                         | Sitewide discount campaign code exposed via `/api/config`                  |
+| `CAMPAIGN_PERCENT`       | `0`                        |                         | Campaign percentage off (1-100, required when `CAMPAIGN_CODE` is set)      |
+| `CAMPAIGN_START`         | _(empty)_                  |                         | Campaign start (RFC 3339, e.g. `2026-07-01T00:00:00Z`; empty = unbounded)  |
+| `CAMPAIGN_END`           | _(empty)_                  |                         | Campaign end (RFC 3339; empty = unbounded)                                 |
 
 ## Architecture
 

--- a/backend/internal/api/appconfig/handler.go
+++ b/backend/internal/api/appconfig/handler.go
@@ -4,28 +4,60 @@ package appconfig
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/rotki/rotki.com/backend/internal/config"
 	"github.com/rotki/rotki.com/backend/internal/validate"
 )
 
-// Response is the JSON shape returned by GET /api/config.
-type Response struct {
-	SponsorshipEnabled bool `json:"sponsorship_enabled"`
-	Maintenance        bool `json:"maintenance"`
-	Testing            bool `json:"testing"`
+// Campaign describes a sitewide discount campaign advertised to the frontend.
+type Campaign struct {
+	Code      string `json:"code"`
+	Percent   int    `json:"percent"`
+	PeriodEnd string `json:"period_end,omitempty"`
 }
 
-// NewHandler returns a handler that serves runtime config as JSON.
-func NewHandler(cfg *config.Config, logger *slog.Logger) http.Handler {
-	resp := Response{
-		SponsorshipEnabled: cfg.SponsorshipEnabled,
-		Maintenance:        cfg.Maintenance,
-		Testing:            cfg.Testing,
+// Response is the JSON shape returned by GET /api/config.
+type Response struct {
+	SponsorshipEnabled bool      `json:"sponsorship_enabled"`
+	Maintenance        bool      `json:"maintenance"`
+	Testing            bool      `json:"testing"`
+	ActiveCampaign     *Campaign `json:"active_campaign,omitempty"`
+}
+
+// activeCampaign returns the configured campaign when now falls inside its
+// period, or nil when no campaign is configured or it is not yet/no longer active.
+func activeCampaign(cfg *config.Config, now time.Time) *Campaign {
+	if cfg.CampaignCode == "" {
+		return nil
+	}
+	if !cfg.CampaignStart.IsZero() && now.Before(cfg.CampaignStart) {
+		return nil
+	}
+	if !cfg.CampaignEnd.IsZero() && now.After(cfg.CampaignEnd) {
+		return nil
 	}
 
+	campaign := &Campaign{
+		Code:    cfg.CampaignCode,
+		Percent: cfg.CampaignPercent,
+	}
+	if !cfg.CampaignEnd.IsZero() {
+		campaign.PeriodEnd = cfg.CampaignEnd.Format(time.RFC3339)
+	}
+	return campaign
+}
+
+// NewHandler returns a handler that serves runtime config as JSON. The campaign
+// is evaluated per request so it activates and expires without a restart.
+func NewHandler(cfg *config.Config, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		logger.Debug("serving app config")
-		validate.WriteJSON(w, http.StatusOK, resp)
+		validate.WriteJSON(w, http.StatusOK, Response{
+			SponsorshipEnabled: cfg.SponsorshipEnabled,
+			Maintenance:        cfg.Maintenance,
+			Testing:            cfg.Testing,
+			ActiveCampaign:     activeCampaign(cfg, time.Now()),
+		})
 	})
 }

--- a/backend/internal/api/appconfig/handler_test.go
+++ b/backend/internal/api/appconfig/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/rotki/rotki.com/backend/internal/config"
 )
@@ -49,6 +50,77 @@ func TestHandler(t *testing.T) {
 			if ct != "application/json" {
 				t.Errorf("expected Content-Type application/json, got %q", ct)
 			}
+
+			if resp.ActiveCampaign != nil {
+				t.Errorf("expected no active campaign, got %+v", resp.ActiveCampaign)
+			}
 		})
+	}
+}
+
+func TestActiveCampaign(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name   string
+		cfg    config.Config
+		active bool
+	}{
+		{"no campaign configured", config.Config{}, false},
+		{"unbounded campaign", config.Config{CampaignCode: "SUMMER", CampaignPercent: 20}, true},
+		{
+			"within period",
+			config.Config{CampaignCode: "SUMMER", CampaignPercent: 20, CampaignStart: now.Add(-time.Hour), CampaignEnd: now.Add(time.Hour)},
+			true,
+		},
+		{
+			"not yet started",
+			config.Config{CampaignCode: "SUMMER", CampaignPercent: 20, CampaignStart: now.Add(time.Hour)},
+			false,
+		},
+		{
+			"already ended",
+			config.Config{CampaignCode: "SUMMER", CampaignPercent: 20, CampaignEnd: now.Add(-time.Hour)},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			campaign := activeCampaign(&tt.cfg, now)
+			if tt.active != (campaign != nil) {
+				t.Fatalf("expected active=%v, got %+v", tt.active, campaign)
+			}
+			if !tt.active {
+				return
+			}
+			if campaign.Code != tt.cfg.CampaignCode || campaign.Percent != tt.cfg.CampaignPercent {
+				t.Errorf("expected code=%q percent=%d, got %+v", tt.cfg.CampaignCode, tt.cfg.CampaignPercent, campaign)
+			}
+			if tt.cfg.CampaignEnd.IsZero() != (campaign.PeriodEnd == "") {
+				t.Errorf("period_end mismatch: cfg end %v, got %q", tt.cfg.CampaignEnd, campaign.PeriodEnd)
+			}
+		})
+	}
+}
+
+func TestHandlerServesCampaign(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &config.Config{CampaignCode: "SUMMER", CampaignPercent: 20, CampaignEnd: time.Now().Add(time.Hour)}
+	handler := NewHandler(cfg, logger)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	var resp Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.ActiveCampaign == nil {
+		t.Fatal("expected an active campaign in the response")
+	}
+	if resp.ActiveCampaign.Code != "SUMMER" || resp.ActiveCampaign.Percent != 20 || resp.ActiveCampaign.PeriodEnd == "" {
+		t.Errorf("unexpected campaign payload: %+v", resp.ActiveCampaign)
 	}
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Config holds all server configuration, loaded from environment variables.
@@ -48,6 +49,14 @@ type Config struct {
 	SponsorshipEnabled bool
 	Maintenance        bool
 	Testing            bool
+
+	// Sitewide discount campaign, exposed via /api/config while within its period.
+	// A campaign is configured when CampaignCode is non-empty; the start/end bounds
+	// are optional (zero value = unbounded).
+	CampaignCode    string
+	CampaignPercent int
+	CampaignStart   time.Time
+	CampaignEnd     time.Time
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -65,6 +74,21 @@ func Load() (*Config, error) {
 	port, err := envInt("PORT", portDefault)
 	if err != nil {
 		return nil, fmt.Errorf("invalid PORT: %w", err)
+	}
+
+	campaignPercent, err := envInt("CAMPAIGN_PERCENT", 0)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CAMPAIGN_PERCENT: %w", err)
+	}
+
+	campaignStart, err := envTime("CAMPAIGN_START")
+	if err != nil {
+		return nil, fmt.Errorf("invalid CAMPAIGN_START: %w", err)
+	}
+
+	campaignEnd, err := envTime("CAMPAIGN_END")
+	if err != nil {
+		return nil, fmt.Errorf("invalid CAMPAIGN_END: %w", err)
 	}
 
 	cfg := &Config{
@@ -94,6 +118,11 @@ func Load() (*Config, error) {
 		SponsorshipEnabled: envBool("SPONSORSHIP_ENABLED", false),
 		Maintenance:        envBool("MAINTENANCE", false),
 		Testing:            envBool("TESTING", false),
+
+		CampaignCode:    envStr("CAMPAIGN_CODE", ""),
+		CampaignPercent: campaignPercent,
+		CampaignStart:   campaignStart,
+		CampaignEnd:     campaignEnd,
 	}
 
 	if err := cfg.validate(); err != nil {
@@ -124,6 +153,15 @@ func (c *Config) validate() error {
 		return errors.New("NUXT_DEV_URL and STATIC_DIR are mutually exclusive in dev mode")
 	}
 
+	if c.CampaignCode != "" {
+		if c.CampaignPercent < 1 || c.CampaignPercent > 100 {
+			return fmt.Errorf("CAMPAIGN_PERCENT must be between 1 and 100 when CAMPAIGN_CODE is set, got %d", c.CampaignPercent)
+		}
+		if !c.CampaignStart.IsZero() && !c.CampaignEnd.IsZero() && c.CampaignEnd.Before(c.CampaignStart) {
+			return errors.New("CAMPAIGN_END must be after CAMPAIGN_START")
+		}
+	}
+
 	return nil
 }
 
@@ -140,6 +178,16 @@ func envStrOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// envTime parses an RFC 3339 timestamp from the environment. An unset or empty
+// variable yields the zero time.
+func envTime(key string) (time.Time, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339, v)
 }
 
 func envInt(key string, fallback int) (int, error) {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -267,3 +267,70 @@ func TestEnvLogLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestLoad_Campaign(t *testing.T) {
+	t.Setenv("CAMPAIGN_CODE", "SUMMER")
+	t.Setenv("CAMPAIGN_PERCENT", "20")
+	t.Setenv("CAMPAIGN_START", "2026-07-01T00:00:00Z")
+	t.Setenv("CAMPAIGN_END", "2026-08-01T00:00:00Z")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.CampaignCode != "SUMMER" {
+		t.Errorf("expected CampaignCode SUMMER, got %s", cfg.CampaignCode)
+	}
+	if cfg.CampaignPercent != 20 {
+		t.Errorf("expected CampaignPercent 20, got %d", cfg.CampaignPercent)
+	}
+	if cfg.CampaignStart.IsZero() || cfg.CampaignEnd.IsZero() {
+		t.Error("expected campaign period bounds to be parsed")
+	}
+}
+
+func TestLoad_CampaignValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		envs map[string]string
+	}{
+		{
+			name: "missing percent",
+			envs: map[string]string{"CAMPAIGN_CODE": "SUMMER"},
+		},
+		{
+			name: "percent out of range",
+			envs: map[string]string{"CAMPAIGN_CODE": "SUMMER", "CAMPAIGN_PERCENT": "150"},
+		},
+		{
+			name: "invalid percent",
+			envs: map[string]string{"CAMPAIGN_CODE": "SUMMER", "CAMPAIGN_PERCENT": "twenty"},
+		},
+		{
+			name: "invalid start",
+			envs: map[string]string{"CAMPAIGN_CODE": "SUMMER", "CAMPAIGN_PERCENT": "20", "CAMPAIGN_START": "not-a-date"},
+		},
+		{
+			name: "end before start",
+			envs: map[string]string{
+				"CAMPAIGN_CODE":    "SUMMER",
+				"CAMPAIGN_PERCENT": "20",
+				"CAMPAIGN_START":   "2026-08-01T00:00:00Z",
+				"CAMPAIGN_END":     "2026-07-01T00:00:00Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+			_, err := Load()
+			if err == nil {
+				t.Error("expected error for invalid campaign configuration")
+			}
+		})
+	}
+}

--- a/packages/card-payment/src/components/CardPayment.vue
+++ b/packages/card-payment/src/components/CardPayment.vue
@@ -327,10 +327,12 @@ watch(() => cards, (newCards) => {
 });
 
 onMounted(async () => {
-  // Prefill discount code from referral code query param
-  const referralCodeParam = new URLSearchParams(window.location.search).get('ref');
-  if (referralCodeParam && !get(discountCode)) {
-    set(discountCode, referralCodeParam);
+  // Prefill discount code from the explicit discountCode query param (forwarded by the
+  // website checkout, e.g. for sitewide campaigns), falling back to the referral code.
+  const params = new URLSearchParams(window.location.search);
+  const codeParam = params.get('discountCode') ?? params.get('ref');
+  if (codeParam && !get(discountCode)) {
+    set(discountCode, codeParam);
   }
 
   await initializeBraintreeClient();

--- a/packages/website/app/components/common/CampaignRibbon.vue
+++ b/packages/website/app/components/common/CampaignRibbon.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { get } from '@vueuse/shared';
+import { useAppConfig } from '~/composables/use-app-config';
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { activeCampaign } = useAppConfig();
+
+const message = computed<string>(() => {
+  const campaign = get(activeCampaign);
+  if (!campaign)
+    return '';
+
+  const base = t('campaign.ribbon', { code: campaign.code, percent: campaign.percent });
+  if (!campaign.periodEnd)
+    return base;
+
+  const end = new Date(campaign.periodEnd);
+  if (Number.isNaN(end.getTime()))
+    return base;
+
+  return `${base} ${t('campaign.ribbon_until', {
+    date: end.toLocaleDateString('en-US', { month: 'long', day: 'numeric' }),
+  })}`;
+});
+</script>
+
+<template>
+  <div
+    v-if="activeCampaign"
+    class="px-4 py-2 text-body-2 text-rui-primary text-center font-medium border-b border-default w-full bg-rui-primary/[0.06]"
+  >
+    {{ message }}
+  </div>
+</template>

--- a/packages/website/app/components/integration/IntegrationDetails.vue
+++ b/packages/website/app/components/integration/IntegrationDetails.vue
@@ -2,7 +2,7 @@
 import { get, set } from '@vueuse/shared';
 import { z } from 'zod';
 import { useIntegrationsData } from '~/composables/use-integrations-data';
-import { integrationSlug } from '~/utils/integration-slug';
+import { integrationQualifier, integrationSlug } from '~/utils/integration-slug';
 import { parseRouteParam } from '~/utils/query';
 
 enum TabCategory {
@@ -177,6 +177,12 @@ const { isMdAndUp } = useBreakpoint();
                 </div>
                 <span class="text-xs text-rui-text-secondary text-center leading-tight line-clamp-2">
                   {{ item.label }}
+                </span>
+                <span
+                  v-if="integrationQualifier(item.label)"
+                  class="text-[0.625rem] text-rui-text-disabled text-center leading-tight"
+                >
+                  {{ integrationQualifier(item.label) }}
                 </span>
               </NuxtLink>
             </TransitionGroup>

--- a/packages/website/app/components/pricings/PricingPeriodTab.vue
+++ b/packages/website/app/components/pricings/PricingPeriodTab.vue
@@ -57,8 +57,8 @@ const tabs = [
     </RuiTabs>
 
     <div
+      v-if="maxSavedAnnually > 0"
       class="flex items-start gap-2 text-rui-primary font-medium whitespace-nowrap -mt-8 -ml-4 relative z-1"
-      :class="{ invisible: !maxSavedAnnually }"
     >
       <img
         :alt="t('pricing.max_saved_annually', { months: maxSavedAnnually })"

--- a/packages/website/app/components/pricings/PricingTableButton.vue
+++ b/packages/website/app/components/pricings/PricingTableButton.vue
@@ -4,7 +4,8 @@ import type { MappedPlan } from '~/components/pricings/type';
 import { get } from '@vueuse/shared';
 import ButtonLink from '~/components/common/ButtonLink.vue';
 import { isCustomPlan, isEntryTierPlan, isFreePlan } from '~/components/pricings/utils';
-import { useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
+import { useAppConfig } from '~/composables/use-app-config';
+import { useDiscountCodeParams, useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
 import { buildQueryParams } from '~/utils/query';
 import { toTitleCase } from '~/utils/text';
 
@@ -22,9 +23,13 @@ const {
 } = useRuntimeConfig();
 
 const { referralCode } = useReferralCodeParam();
+const { discountCode } = useDiscountCodeParams();
+const { activeCampaign } = useAppConfig();
 
 const checkoutLink = computed<RouteLocationRaw>(() => {
+  // An explicit code in the URL wins over the sitewide campaign code.
   const query = buildQueryParams({
+    discountCode: get(discountCode) ?? get(activeCampaign)?.code,
     planId: plan.id,
     ref: get(referralCode),
   });

--- a/packages/website/app/components/products/ProductsButtons.vue
+++ b/packages/website/app/components/products/ProductsButtons.vue
@@ -5,8 +5,10 @@ import { isDefined } from '@vueuse/core';
 import { get } from '@vueuse/shared';
 import { storeToRefs } from 'pinia';
 import ButtonLink from '~/components/common/ButtonLink.vue';
+import { useAppConfig } from '~/composables/use-app-config';
 import { useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
 import { useMainStore } from '~/store';
+import { buildQueryParams } from '~/utils/query';
 
 defineProps<{
   color?: ContextColorsType;
@@ -19,6 +21,7 @@ const store = useMainStore();
 const { account } = storeToRefs(store);
 
 const { referralCode } = useReferralCodeParam();
+const { activeCampaign } = useAppConfig();
 
 const allowNavigation = computed<boolean>(() => {
   if (!isDefined(account))
@@ -29,11 +32,15 @@ const allowNavigation = computed<boolean>(() => {
 });
 
 const checkoutLink = computed<RouteLocationRaw>(() => {
-  const ref = get(referralCode);
-  if (ref) {
+  const query = buildQueryParams({
+    discountCode: get(activeCampaign)?.code,
+    ref: get(referralCode),
+  });
+
+  if (Object.keys(query).length > 0) {
     return {
       path: '/checkout/pay',
-      query: { ref },
+      query,
     };
   }
   return '/checkout/pay';

--- a/packages/website/app/components/products/ProductsFooter.vue
+++ b/packages/website/app/components/products/ProductsFooter.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ButtonLink from '~/components/common/ButtonLink.vue';
 import ProductsButtons from '~/components/products/ProductsButtons.vue';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -7,8 +8,26 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <div class="container">
     <div class="bg-rui-primary/[0.08] rounded-xl flex flex-col gap-6 lg:gap-10 lg:flex-row p-6 lg:p-10 justify-between items-start">
-      <div class="text-[#475467] text-body-1 md:text-h6 font-medium max-w-[768px] lg:flex-1">
-        {{ t('products.footer.description') }}
+      <div class="flex flex-col gap-3 max-w-[768px] lg:flex-1">
+        <div class="text-[#475467] text-body-1 md:text-h6 font-medium">
+          {{ t('products.footer.description') }}
+        </div>
+        <div class="text-[#475467] text-body-2">
+          <i18n-t
+            keypath="products.footer.integrations"
+            scope="global"
+          >
+            <template #integrations>
+              <ButtonLink
+                to="/integrations"
+                inline
+                color="primary"
+              >
+                {{ t('products.footer.integrations_link') }}
+              </ButtonLink>
+            </template>
+          </i18n-t>
+        </div>
       </div>
       <ProductsButtons color="primary" />
     </div>

--- a/packages/website/app/composables/use-app-config.ts
+++ b/packages/website/app/composables/use-app-config.ts
@@ -1,14 +1,34 @@
 import { get } from '@vueuse/shared';
 import { z } from 'zod';
 
+const ActiveCampaignResponse = z.object({
+  code: z.string(),
+  percent: z.number(),
+  period_end: z.string().optional(),
+});
+
+export interface ActiveCampaign {
+  code: string;
+  percent: number;
+  periodEnd?: string;
+}
+
 const AppConfigResponse = z.object({
   maintenance: z.boolean().default(false),
   sponsorship_enabled: z.boolean().default(false),
   testing: z.boolean().default(false),
+  active_campaign: ActiveCampaignResponse.nullish(),
 }).transform(data => ({
   maintenance: data.maintenance,
   sponsorshipEnabled: data.sponsorship_enabled,
   testing: data.testing,
+  activeCampaign: data.active_campaign
+    ? {
+      code: data.active_campaign.code,
+      percent: data.active_campaign.percent,
+      periodEnd: data.active_campaign.period_end,
+    } satisfies ActiveCampaign
+    : undefined,
 }));
 
 type AppConfig = z.output<typeof AppConfigResponse>;
@@ -17,6 +37,7 @@ const defaultConfig: AppConfig = {
   maintenance: false,
   sponsorshipEnabled: false,
   testing: false,
+  activeCampaign: undefined,
 };
 
 export function useAppConfig() {
@@ -29,10 +50,12 @@ export function useAppConfig() {
 
   const isMaintenance = computed<boolean>(() => get(data).maintenance);
   const isTesting = computed<boolean>(() => get(data).testing);
+  const activeCampaign = computed<ActiveCampaign | undefined>(() => get(data).activeCampaign);
   const configReady = computed<boolean>(() => get(status) === 'success');
   const contentBranch = computed<string>(() => get(isTesting) ? 'develop' : 'main');
 
   return {
+    activeCampaign,
     config: readonly(data),
     configReady,
     contentBranch,

--- a/packages/website/app/modules/checkout/components/common/DiscountCodeInput.vue
+++ b/packages/website/app/modules/checkout/components/common/DiscountCodeInput.vue
@@ -2,6 +2,7 @@
 import type { PaymentBreakdownDiscount } from '@rotki/card-payment-common/schemas/plans';
 import { DiscountType } from '@rotki/card-payment-common';
 import { get, set } from '@vueuse/shared';
+import { useAppConfig } from '~/composables/use-app-config';
 
 const model = defineModel<string>({ required: true });
 
@@ -32,6 +33,20 @@ const errorMessage = computed<string | undefined>(() => {
   return undefined;
 });
 
+const { activeCampaign } = useAppConfig();
+
+// Campaign-aware hint: advertise the sitewide code while a campaign is running.
+const hint = computed<string>(() => {
+  const campaign = get(activeCampaign);
+  if (campaign) {
+    return t('home.plans.tiers.step_3.discount.campaign_hint', {
+      code: campaign.code,
+      percent: campaign.percent,
+    });
+  }
+  return t('home.plans.tiers.step_3.discount.hint');
+});
+
 function apply(): void {
   set(model, get(value));
   emit('apply');
@@ -60,7 +75,7 @@ watchImmediate(model, (modelValue: string) => {
       variant="outlined"
       :label="t('home.plans.tiers.step_3.discount.label')"
       :error-messages="errorMessage"
-      :hint="errorMessage ? undefined : t('home.plans.tiers.step_3.discount.hint')"
+      :hint="errorMessage ? undefined : hint"
       :disabled="disabled"
       prepend-icon="lu-tag"
     >

--- a/packages/website/app/modules/checkout/components/method/PaymentMethodSelection.vue
+++ b/packages/website/app/modules/checkout/components/method/PaymentMethodSelection.vue
@@ -4,10 +4,11 @@ import { type CheckoutPaymentMethod, SigilEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { storeToRefs } from 'pinia';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
+import { useAppConfig } from '~/composables/use-app-config';
 import CheckoutDescription from '~/modules/checkout/components/common/CheckoutDescription.vue';
 import CheckoutTitle from '~/modules/checkout/components/common/CheckoutTitle.vue';
 import PaymentMethodItem from '~/modules/checkout/components/method/PaymentMethodItem.vue';
-import { usePlanIdParam, useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
+import { useDiscountCodeParams, usePlanIdParam, useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
 import { useMainStore } from '~/store';
 import { PaymentMethod } from '~/types/payment';
 import { assert } from '~/utils/assert';
@@ -41,6 +42,8 @@ const { authenticated } = storeToRefs(store);
 const router = useRouter();
 const { planId } = usePlanIdParam();
 const { referralCode } = useReferralCodeParam();
+const { discountCode } = useDiscountCodeParams();
+const { activeCampaign } = useAppConfig();
 
 const { chronicle } = useSigilEvents();
 
@@ -83,6 +86,9 @@ const queryParams = computed<Record<string, string>>(() => {
   const result: Record<string, string> = {};
   const selectedPlanId = get(planId);
   const ref = get(referralCode);
+  // An explicit code in the URL wins over the sitewide campaign code. Forwarding it
+  // keeps the code across the hop to the payment step (including the card SPA).
+  const code = get(discountCode) ?? get(activeCampaign)?.code;
 
   if (selectedPlanId) {
     result.planId = String(selectedPlanId);
@@ -94,6 +100,10 @@ const queryParams = computed<Record<string, string>>(() => {
 
   if (ref) {
     result.ref = ref;
+  }
+
+  if (code) {
+    result.discountCode = code;
   }
 
   return result;
@@ -121,6 +131,7 @@ function buildNavigationUrl(routeName: string): string {
 
 async function handleBack(): Promise<void> {
   const query = buildQueryParams({
+    discountCode: get(discountCode),
     planId: get(planId),
     ref: get(referralCode),
   });

--- a/packages/website/app/modules/checkout/composables/use-checkout.ts
+++ b/packages/website/app/modules/checkout/composables/use-checkout.ts
@@ -6,6 +6,7 @@ import { get, set } from '@vueuse/shared';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useAvailablePlans } from '~/composables/tiers/use-available-plans';
 import { useTiersApi } from '~/composables/tiers/use-tiers-api';
+import { useAppConfig } from '~/composables/use-app-config';
 import { usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { useReferralCodeParam } from '~/modules/checkout/composables/use-plan-params';
 import { logger } from '~/utils/use-logger';
@@ -54,6 +55,9 @@ export function useCheckout() {
   // useReferralCodeParam) so the code survives navigation that stripped the param.
   const { referralCode } = useReferralCodeParam();
 
+  // Sitewide campaign discount served by /api/config, auto-applied as a fallback.
+  const { activeCampaign } = useAppConfig();
+
   // ===================
   // Derived flags
   // ===================
@@ -86,23 +90,24 @@ export function useCheckout() {
   // ===================
   // Discount code handling
   // ===================
-  // Tracks whether the user dismissed the auto-applied referral discount. Persisted via
-  // useState so it survives client-side navigation through the checkout (the URL cannot
-  // carry it - buildQueryParams strips empty values), and resets on a full reload.
-  const referralDismissed = useState<boolean>('checkout-referral-dismissed', () => false);
+  // Tracks whether the user dismissed an auto-applied discount (referral or campaign).
+  // Persisted via useState so it survives client-side navigation through the checkout
+  // (the URL cannot carry it - buildQueryParams strips empty values), and resets on a
+  // full reload.
+  const autoDiscountDismissed = useState<boolean>('checkout-auto-discount-dismissed', () => false);
 
   // Applied value (source of truth). An explicit discountCode in the URL wins; otherwise
-  // the referral code is auto-applied as a discount (mirroring the card flow) unless the
-  // user dismissed it.
+  // the referral code (mirroring the card flow) and then the sitewide campaign code are
+  // auto-applied as a discount, unless the user dismissed the auto-apply.
   const appliedDiscountCode = computed<string>(() => {
     const code = getCurrentRoute().query.discountCode;
     if (typeof code === 'string' && code)
       return code;
 
-    if (get(referralDismissed))
+    if (get(autoDiscountDismissed))
       return '';
 
-    return get(referralCode) ?? '';
+    return get(referralCode) ?? get(activeCampaign)?.code ?? '';
   });
 
   // Input value (for text field binding), seeded from the applied value.
@@ -152,8 +157,8 @@ export function useCheckout() {
   async function applyDiscount(): Promise<void> {
     const code = get(modelDiscountCode);
     // An empty input clears the discount; remember the dismissal so an auto-applied
-    // referral code is not immediately re-applied (see appliedDiscountCode).
-    set(referralDismissed, !code);
+    // referral or campaign code is not immediately re-applied (see appliedDiscountCode).
+    set(autoDiscountDismissed, !code);
     const currentRoute = getCurrentRoute();
     await navigateTo({
       path: currentRoute.path,
@@ -230,7 +235,7 @@ export function useCheckout() {
     set(planSwitchLoading, false);
     set(loading, false);
     set(error, undefined);
-    set(referralDismissed, false);
+    set(autoDiscountDismissed, false);
   }
 
   // ===================

--- a/packages/website/app/pages/checkout/pay.vue
+++ b/packages/website/app/pages/checkout/pay.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { get } from '@vueuse/shared';
+import CampaignRibbon from '~/components/common/CampaignRibbon.vue';
 import { useRedirectUrl } from '~/composables/use-redirect-url';
 import { CHECKOUT_ROUTE_NAMES, type CheckoutStep } from '~/types';
 
@@ -73,36 +74,39 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <div class="container flex flex-col lg:flex-row h-full grow py-4 lg:py-8 gap-6 lg:gap-8">
-    <div class="flex grow overflow-x-auto min-w-0">
-      <form
-        class="flex flex-col justify-between w-full"
-        @submit.prevent
-      >
-        <NuxtPage />
-        <div class="block py-10 w-full lg:hidden">
-          <RuiFooterStepper
-            :model-value="step"
-            :pages="steps.length"
-            class="mx-auto max-w-7xl"
-            variant="pill"
-          />
-        </div>
-      </form>
-    </div>
+  <div class="flex flex-col h-full grow">
+    <CampaignRibbon />
+    <div class="container flex flex-col lg:flex-row grow py-4 lg:py-8 gap-6 lg:gap-8">
+      <div class="flex grow overflow-x-auto min-w-0">
+        <form
+          class="flex flex-col justify-between w-full"
+          @submit.prevent
+        >
+          <NuxtPage />
+          <div class="block py-10 w-full lg:hidden">
+            <RuiFooterStepper
+              :model-value="step"
+              :pages="steps.length"
+              class="mx-auto max-w-7xl"
+              variant="pill"
+            />
+          </div>
+        </form>
+      </div>
 
-    <div
-      v-if="!isFirstStep"
-      class="hidden lg:block w-48 shrink-0 sticky top-8 self-start"
-    >
-      <RuiStepper
-        :step="step"
-        :steps="steps"
-        custom
-        orientation="vertical"
-        subtitle-class="!text-rui-primary-lighter"
-        title-class="!text-rui-primary"
-      />
+      <div
+        v-if="!isFirstStep"
+        class="hidden lg:block w-48 shrink-0 sticky top-8 self-start"
+      >
+        <RuiStepper
+          :step="step"
+          :steps="steps"
+          custom
+          orientation="vertical"
+          subtitle-class="!text-rui-primary-lighter"
+          title-class="!text-rui-primary"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/packages/website/app/pages/checkout/pay/index.vue
+++ b/packages/website/app/pages/checkout/pay/index.vue
@@ -115,6 +115,22 @@ onMounted(() => {
           >
             {{ line }}
           </PricingFeatureItem>
+          <PricingFeatureItem>
+            <i18n-t
+              keypath="home.plans.tiers.step_1.notes.integrations"
+              scope="global"
+            >
+              <template #integrations>
+                <ButtonLink
+                  to="/integrations"
+                  inline
+                  color="primary"
+                >
+                  {{ t('home.plans.tiers.step_1.notes.integrations_link') }}
+                </ButtonLink>
+              </template>
+            </i18n-t>
+          </PricingFeatureItem>
         </div>
 
         <div

--- a/packages/website/app/pages/integrations/[slug].vue
+++ b/packages/website/app/pages/integrations/[slug].vue
@@ -3,6 +3,7 @@ import { isDefined } from '@vueuse/core';
 import { get } from '@vueuse/shared';
 import ButtonLink from '~/components/common/ButtonLink.vue';
 import { usePageSeo } from '~/composables/use-page-seo';
+import { INTEGRATION_QUALIFIERS } from '~/utils/integration-slug';
 
 const { path } = useRoute();
 const { t } = useI18n({ useScope: 'global' });
@@ -86,6 +87,12 @@ const typeLabel = computed<string>(() => {
   return '';
 });
 
+const qualifierBadge = computed<string | undefined>(() => {
+  if (!isDefined(integration))
+    return undefined;
+  return INTEGRATION_QUALIFIERS[get(integration).slug];
+});
+
 const tierBadge = computed<string | undefined>(() => {
   if (!isDefined(integration))
     return undefined;
@@ -134,6 +141,13 @@ definePageMeta({
                 variant="outlined"
               >
                 {{ typeLabel }}
+              </RuiChip>
+              <RuiChip
+                v-if="qualifierBadge"
+                size="sm"
+                variant="outlined"
+              >
+                {{ qualifierBadge }}
               </RuiChip>
               <RuiChip
                 v-if="tierBadge"

--- a/packages/website/app/pages/products/index.vue
+++ b/packages/website/app/pages/products/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import CampaignRibbon from '~/components/common/CampaignRibbon.vue';
 import ProductsAnalytics from '~/components/products/ProductsAnalytics.vue';
 import ProductsBlocks from '~/components/products/ProductsBlocks.vue';
 import ProductsFooter from '~/components/products/ProductsFooter.vue';
@@ -21,6 +22,7 @@ definePageMeta({
 </script>
 
 <template>
+  <CampaignRibbon />
   <ProductsHeading />
   <ProductsBlocks />
   <ProductsLimits />

--- a/packages/website/app/utils/integration-slug.ts
+++ b/packages/website/app/utils/integration-slug.ts
@@ -25,6 +25,25 @@ export const INTEGRATION_CONSOLIDATIONS: Record<string, { label: string; members
 };
 
 /**
+ * Coverage qualifiers shown next to an integration's name (grid card + detail page).
+ * Keyed by canonical slug. Kept here rather than in `all.json` because the catalog
+ * is regenerated from the rotki backend and hand-added fields would be wiped, and
+ * because the label itself must stay untouched - it drives `integrationSlug()`.
+ */
+export const INTEGRATION_QUALIFIERS: Record<string, string> = {
+  aave: 'v1–v3',
+  solana: 'early support',
+  uniswap: 'v2/v3',
+};
+
+/**
+ * Returns the coverage qualifier for an integration label, if one is defined.
+ */
+export function integrationQualifier(label: string): string | undefined {
+  return INTEGRATION_QUALIFIERS[consolidateSlug(integrationSlug(label))];
+}
+
+/**
  * Maps a raw integration slug to its canonical (consolidated) slug. Returns the slug
  * unchanged when it is not part of a consolidation group.
  */

--- a/packages/website/content/integrations/aave.md
+++ b/packages/website/content/integrations/aave.md
@@ -15,6 +15,8 @@ features:
   - "GHO - Aave's stablecoin decoded with its own dedicated handling."
   - "Multi-chain - Aave v3 across Ethereum, Arbitrum, Optimism, Polygon, Base, Gnosis, Scroll, and BNB Chain."
   - "v2 → v3 migrations - transactions routed through Aave's migration helper on Ethereum and Polygon are decoded as migrations rather than separate v2 exits and v3 entries."
+limitations:
+  - "Aave v4 is not yet supported. rotki currently decodes v1, v2, and v3 activity."
 setup:
   - "In rotki, add your address under the chain where your Aave position lives (Blockchain & Accounts → Ethereum / Arbitrum / etc.)."
   - "rotki will detect your Aave positions automatically; no Aave-specific configuration needed."
@@ -24,6 +26,8 @@ faq:
     a: "No. rotki reads your activity from the RPC nodes you configure directly from your computer."
   - q: "Does rotki support both Aave v2 and v3?"
     a: "Yes. Both versions are decoded, including the v2 → v3 migration flows."
+  - q: "Is Aave v4 supported?"
+    a: "No, Aave v4 is not yet supported. rotki currently decodes Aave v1, v2, and v3 activity."
   - q: "Are Aave liquidations handled for tax purposes?"
     a: "Yes. The debt repayment and collateral seizure are decoded as paired liquidation events, so realised PnL flows into your tax report."
 screenshots: []

--- a/packages/website/content/integrations/solana.md
+++ b/packages/website/content/integrations/solana.md
@@ -13,6 +13,8 @@ features:
   - "Jupiter aggregator swaps decoded as trade events."
   - "Jito tips recognised as fee events."
   - "Jupiter Lend activity (deposits, withdrawals, borrows, repays) decoded as events."
+limitations:
+  - "Solana support is early: balances, staking, and a growing set of protocols (Jupiter, Jito) are covered, but decoding is not yet as extensive as on EVM chains."
 setup:
   - "In rotki, open Blockchain & Accounts → Solana → Add address."
   - "Paste your Solana address. rotki validates the format and rejects invalid addresses."

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -401,6 +401,10 @@
       }
     }
   },
+  "campaign": {
+    "ribbon": "Limited-time offer: {percent}% off your first payment with code {code}",
+    "ribbon_until": "- valid until {date}"
+  },
   "change_plan": {
     "switch_agree": "I confirm that no payment has been sent. {separator}Allow me to switch the plan",
     "switch_warning": "Switching a plan after sending a payment can lead to problems with the activation of your subscription. Please only switch a plan if no payment has been sent.",
@@ -637,6 +641,7 @@
             "applied": "Discount code applied:",
             "referral_applied": "Referral code applied:",
             "apply_code": "Apply code",
+            "campaign_hint": "Campaign code {code} ({percent}% off) is applied automatically. You can enter a different code instead.",
             "first_payment_only": "* Applies to first payment only",
             "hint": "Optional: Enter a discount code to apply savings to your purchase.",
             "you_save": "You save {amount}€",

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -611,6 +611,8 @@
         "step_1": {
           "description": "Select the premium plan that best fits your needs",
           "notes": {
+            "integrations": "Coverage varies per chain and protocol: check the exact chains, exchanges and protocols on the {integrations} before subscribing.",
+            "integrations_link": "Integrations page",
             "line_1": "The full amount will be charged immediately and renew automatically each {period} until you cancel.",
             "line_2": "New billing cycle starts at UTC midnight after the subscription has ran out.",
             "line_3": "An invoice is generated for each payment and you can access it from your account page.",
@@ -1055,7 +1057,9 @@
       }
     },
     "footer": {
-      "description": "Upgrade to rotki premium today and take your financial management to the next level. Enjoy enhanced features, greater flexibility, and exclusive perks designed for the modern investor."
+      "description": "Upgrade to rotki premium today and take your financial management to the next level. Enjoy enhanced features, greater flexibility, and exclusive perks designed for the modern investor.",
+      "integrations": "Coverage varies per chain and protocol: check the exact chains, exchanges and protocols on the {integrations} before subscribing.",
+      "integrations_link": "Integrations page"
     },
     "heading": "Unlock the Full Potential of rotki with Premium Features",
     "title": "Upgrade rotki today",


### PR DESCRIPTION
Doing those from the doc.

  rotki.com website repo
  - Item 9 — one sentence + link on the pricing/products page: "check the exact chains, exchanges and protocols on the Integrations page before subscribing."
  - Item 17 — integrations grid: version qualifiers on the cards ("Aave (v1–v3)", "Uniswap (v2/v3)"), per-chain decoded-protocol counts ("Solana — early support"), and an explicit "v4 is not yet supported" line in the Aave FAQ.
  - Item 18 — an activeCampaign config (code, percent, period) driving: campaign-aware "Get Premium" CTAs that append ?discountCode=, a thin ribbon on /pricing + /products + checkout layout, and a campaign-aware wording of the step-3 discount hint.
  - Item 25 — auto-apply the active sitewide code at checkout (extend the plans/breakdown response, pre-populate discountCode in OrderSummaryCard/CardPayment — the invalid-code fallback logic already exists). The only remaining item touching the Go backend.
  - Item 26 — fix the "Save 0 months vs monthly" SSR placeholder on /pricing.