### PR TITLE
fix(backend): hard 404 for unmatched routes instead of SPA shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,12 @@ jobs:
       - name: Build 🚧
         run: pnpm run build
 
+      # The Go static handler hard-404s anything not prerendered or listed in
+      # spa-routes.json, so a route missing from the build is a user-visible 404
+      # rather than a silent client-side render. Must run after the build.
+      - name: Check every router route resolves 🧭
+        run: pnpm run check:routes
+
       - name: Run tests with coverage ✅
         run: pnpm run coverage
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -64,7 +64,11 @@ func main() {
 		"git_sha", version.GitSHA,
 	)
 
-	srv, deps := server.New(cfg, logger)
+	srv, deps, srvErr := server.New(cfg, logger)
+	if srvErr != nil {
+		logger.Error("failed to create server", "error", srvErr)
+		os.Exit(1)
+	}
 
 	// Start scheduled tasks
 	deps.Scheduler.Start(5 * time.Second)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -27,7 +27,7 @@ type Deps struct {
 }
 
 // New creates and configures the HTTP server with all routes and middleware.
-func New(cfg *config.Config, logger *slog.Logger) (*http.Server, *Deps) {
+func New(cfg *config.Config, logger *slog.Logger) (*http.Server, *Deps, error) {
 	// Create shared cache infrastructure
 	mem := cache.NewMemory()
 	red := cache.NewRedis(cfg.RedisHost, cfg.RedisPassword, logger)
@@ -73,7 +73,10 @@ func New(cfg *config.Config, logger *slog.Logger) (*http.Server, *Deps) {
 		mux.Handle("/", dev)
 		logger.Info("dev mode: proxying to Nuxt dev server", "url", cfg.NuxtDevURL)
 	} else {
-		static := newStaticHandler(cfg.StaticDir)
+		static, err := newStaticHandler(cfg.StaticDir)
+		if err != nil {
+			return nil, nil, fmt.Errorf("static handler: %w", err)
+		}
 		mux.Handle("/", static)
 	}
 
@@ -96,7 +99,7 @@ func New(cfg *config.Config, logger *slog.Logger) (*http.Server, *Deps) {
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       120 * time.Second,
-	}, deps
+	}, deps, nil
 }
 
 // handleHealth returns a JSON health check response with version info.

--- a/backend/internal/server/server_test.go
+++ b/backend/internal/server/server_test.go
@@ -234,12 +234,51 @@ func setupStaticDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 
+	// not-found/index.html (prerendered 404 body; a nested path, matching what
+	// the real manifest points at)
+	notFoundDir := filepath.Join(dir, "not-found")
+	if err := os.MkdirAll(notFoundDir, 0o755); err != nil { //nolint:gosec // G301: test temp dir, 0755 is fine
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(notFoundDir, "index.html"), []byte("<html>not-found</html>"), 0o644); err != nil { //nolint:gosec // G306: test fixture, 0644 is fine
+		t.Fatal(err)
+	}
+
+	// checkout/pay/card/index.html (nested standalone SPA)
+	cardDir := filepath.Join(dir, "checkout", "pay", "card")
+	if err := os.MkdirAll(cardDir, 0o755); err != nil { //nolint:gosec // G301: test temp dir, 0755 is fine
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cardDir, "index.html"), []byte("<html>card-app</html>"), 0o644); err != nil { //nolint:gosec // G306: test fixture, 0644 is fine
+		t.Fatal(err)
+	}
+
+	// spa-routes.json, mirroring what the Nuxt build hook emits.
+	manifest := `{
+  "spaShell": "200.html",
+  "notFound": "not-found/index.html",
+  "spaRoutes": ["/home/**", "/login", "/oauth/**", "/activate/**", "/checkout/success"],
+  "nestedApps": [{"prefix": "/checkout/pay/card", "index": "checkout/pay/card/index.html"}]
+}`
+	if err := os.WriteFile(filepath.Join(dir, spaManifestFile), []byte(manifest), 0o644); err != nil { //nolint:gosec // G306: test fixture, 0644 is fine
+		t.Fatal(err)
+	}
+
 	return dir
+}
+
+func newTestStaticHandler(t *testing.T, dir string) *staticHandler {
+	t.Helper()
+	h, err := newStaticHandler(dir)
+	if err != nil {
+		t.Fatalf("newStaticHandler: %v", err)
+	}
+	return h
 }
 
 func TestStaticHandler_ServeRootIndex(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -255,7 +294,7 @@ func TestStaticHandler_ServeRootIndex(t *testing.T) {
 
 func TestStaticHandler_ServeHashedAsset(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/_nuxt/app.abc123.js", nil)
 	rec := httptest.NewRecorder()
@@ -272,7 +311,7 @@ func TestStaticHandler_ServeHashedAsset(t *testing.T) {
 
 func TestStaticHandler_SPAFallback(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
 	// /activate/uid123/token456 should fall back to 200.html (SPA shell)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/activate/uid123/token456", nil)
@@ -287,26 +326,155 @@ func TestStaticHandler_SPAFallback(t *testing.T) {
 	}
 }
 
-func TestStaticHandler_RootFallback(t *testing.T) {
+// Unmatched extensionless paths must be a hard 404, not the SPA shell with 200.
+// A soft-404 is an SEO penalty and makes status-code-only vulnerability scanners
+// report phantom findings (e.g. CVE-1999-0610 against /webcart/).
+func TestStaticHandler_UnmatchedRouteHard404(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
-	// /unknown-page should fall back to 200.html (SPA shell)
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/unknown-page", nil)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200 from SPA fallback, got %d", rec.Code)
+	paths := []string{
+		"/unknown-page",
+		"/webcart/",
+		"/webcart/orders/",
+		"/webcart/config/",
+		"/cgi-bin/",
+		"/scripts/",
+		"/cgi-bin/wsisa.dll/WService=wsbroker1/",
+		"/zzz-nonexistent/deeply/nested",
 	}
-	if body := rec.Body.String(); body != "<html>spa-shell</html>" {
-		t.Errorf("expected 200.html SPA shell content, got %q", body)
+
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, p, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("expected 404, got %d", rec.Code)
+			}
+			if body := rec.Body.String(); body != "<html>not-found</html>" {
+				t.Errorf("expected 404.html content, got %q", body)
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+				t.Errorf("Content-Type = %q, want text/html", ct)
+			}
+		})
+	}
+}
+
+// Routes Nuxt deliberately leaves unrendered still need the SPA shell at 200,
+// otherwise auth, OAuth callbacks and checkout break.
+func TestStaticHandler_ManifestRoutesServeShell(t *testing.T) {
+	dir := setupStaticDir(t)
+	h := newTestStaticHandler(t, dir)
+
+	paths := []string{
+		"/home/subscription",
+		"/home",
+		"/login",
+		"/oauth/callback",
+		"/checkout/success",
+	}
+
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, p, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected 200, got %d", rec.Code)
+			}
+			if body := rec.Body.String(); body != "<html>spa-shell</html>" {
+				t.Errorf("expected SPA shell, got %q", body)
+			}
+		})
+	}
+}
+
+// The card-payment app owns its subtree, so deep links inside it must get that
+// app's own index.html rather than the Nuxt shell.
+func TestStaticHandler_NestedAppFallback(t *testing.T) {
+	dir := setupStaticDir(t)
+	h := newTestStaticHandler(t, dir)
+
+	for _, p := range []string{"/checkout/pay/card", "/checkout/pay/card/confirm"} {
+		t.Run(p, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, p, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected 200, got %d", rec.Code)
+			}
+			if body := rec.Body.String(); body != "<html>card-app</html>" {
+				t.Errorf("expected card app index, got %q", body)
+			}
+		})
+	}
+}
+
+// A missing or malformed manifest must fail startup. Falling back to
+// "serve the shell for everything" would silently restore the soft-404.
+func TestNewStaticHandler_ManifestRequired(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := newStaticHandler(dir); err == nil {
+			t.Fatal("expected error when spa-routes.json is absent")
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, spaManifestFile), []byte("{not json"), 0o644); err != nil { //nolint:gosec // G306: test fixture, 0644 is fine
+			t.Fatal(err)
+		}
+		if _, err := newStaticHandler(dir); err == nil {
+			t.Fatal("expected error for malformed manifest")
+		}
+	})
+
+	t.Run("missing required fields", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, spaManifestFile), []byte(`{"spaRoutes":[]}`), 0o644); err != nil { //nolint:gosec // G306: test fixture, 0644 is fine
+			t.Fatal(err)
+		}
+		if _, err := newStaticHandler(dir); err == nil {
+			t.Fatal("expected error when spaShell/notFound are absent")
+		}
+	})
+}
+
+func TestMatchesRoute(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"/login", "/login", true},
+		{"/login", "/login/extra", false},
+		{"/login", "/logins", false},
+		{"/home/**", "/home", true},
+		{"/home/**", "/home/subscription", true},
+		{"/home/**", "/home/a/b/c", true},
+		{"/home/**", "/homepage", false},
+		{"/oauth/**", "/oauth/callback", true},
+		{"/oauth/**", "/webcart/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+" vs "+tt.path, func(t *testing.T) {
+			if got := matchesRoute(tt.pattern, tt.path); got != tt.want {
+				t.Errorf("matchesRoute(%q, %q) = %v, want %v", tt.pattern, tt.path, got, tt.want)
+			}
+		})
 	}
 }
 
 func TestStaticHandler_MissingAsset404(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/missing.css", nil)
 	rec := httptest.NewRecorder()
@@ -317,9 +485,76 @@ func TestStaticHandler_MissingAsset404(t *testing.T) {
 	}
 }
 
+// Missing assets must NOT get the full 404 document. After a deploy, clients
+// re-request stale /_nuxt/<hash>.js chunks, and the HTML page is ~50 KB of
+// content they cannot parse.
+func TestStaticHandler_MissingAssetGetsBareBody(t *testing.T) {
+	dir := setupStaticDir(t)
+	h := newTestStaticHandler(t, dir)
+
+	for _, p := range []string{"/missing.css", "/_nuxt/stale.abc123.js", "/gone.txt"} {
+		t.Run(p, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, p, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("expected 404, got %d", rec.Code)
+			}
+			if strings.Contains(rec.Body.String(), "not-found") {
+				t.Errorf("asset 404 served the full HTML page (%d bytes); want the bare body", rec.Body.Len())
+			}
+		})
+	}
+}
+
+// A manifest naming files that are not on disk must fail startup, otherwise
+// every client-only route silently hard-404s in production.
+func TestNewStaticHandler_ReferencedFilesMustExist(t *testing.T) {
+	write := func(t *testing.T, dir, name, content string) {
+		t.Helper()
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil { //nolint:gosec // G301: test temp dir, 0755 is fine
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil { //nolint:gosec // G306: test fixture, 0644 is fine
+			t.Fatal(err)
+		}
+	}
+
+	manifest := `{
+  "spaShell": "200.html",
+  "notFound": "not-found/index.html",
+  "spaRoutes": ["/login"],
+  "nestedApps": [{"prefix": "/checkout/pay/card", "index": "checkout/pay/card/index.html"}]
+}`
+
+	tests := []struct {
+		name    string
+		present []string
+	}{
+		{"missing spaShell", []string{"not-found/index.html", "checkout/pay/card/index.html"}},
+		{"missing notFound", []string{"200.html", "checkout/pay/card/index.html"}},
+		{"missing nested app index", []string{"200.html", "not-found/index.html"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			write(t, dir, spaManifestFile, manifest)
+			for _, f := range tt.present {
+				write(t, dir, f, "<html></html>")
+			}
+			if _, err := newStaticHandler(dir); err == nil {
+				t.Fatal("expected startup to fail when a manifest-referenced file is absent")
+			}
+		})
+	}
+}
+
 func TestStaticHandler_PathTraversalBlocked(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
 	// path.Clean normalizes /../ to /, so traversal via URL path is blocked
 	// by Go's http library. Verify that even if someone crafts a URL.Path
@@ -343,7 +578,7 @@ func TestStaticHandler_PathTraversalBlocked(t *testing.T) {
 
 func TestStaticHandler_MethodNotAllowed(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
 		req := httptest.NewRequestWithContext(context.Background(), method, "/", nil)
@@ -358,7 +593,7 @@ func TestStaticHandler_MethodNotAllowed(t *testing.T) {
 
 func TestStaticHandler_HeadMethod(t *testing.T) {
 	dir := setupStaticDir(t)
-	h := newStaticHandler(dir)
+	h := newTestStaticHandler(t, dir)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodHead, "/", nil)
 	rec := httptest.NewRecorder()

--- a/backend/internal/server/static.go
+++ b/backend/internal/server/static.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -8,17 +10,111 @@ import (
 	"strings"
 )
 
-// staticHandler serves pre-rendered static files with SPA fallback.
-// For hashed assets (/_nuxt/*), it sets long-lived cache headers.
-// For HTML files, it sets no-cache to allow CSP nonce injection.
-// If a file is not found and the path has no extension, it walks up
-// the directory tree looking for the nearest index.html (SPA fallback).
-type staticHandler struct {
-	root string
+// spaManifestFile is emitted into the static output by the
+// `nitro:build:public-assets` hook in packages/website/nuxt.config.ts.
+const spaManifestFile = "spa-routes.json"
+
+// nestedApp is a standalone SPA copied under the static root that owns its own
+// subtree and serves its own index.html for deep links (e.g. the card-payment
+// app mounted at /checkout/pay/card).
+type nestedApp struct {
+	Prefix string `json:"prefix"`
+	Index  string `json:"index"`
 }
 
-func newStaticHandler(root string) *staticHandler {
-	return &staticHandler{root: root}
+// spaManifest lists the routes Nuxt deliberately leaves unrendered, so the
+// handler knows which unmatched paths deserve the SPA shell and which are
+// genuinely not found.
+type spaManifest struct {
+	SPAShell   string      `json:"spaShell"`
+	NotFound   string      `json:"notFound"`
+	SPARoutes  []string    `json:"spaRoutes"`
+	NestedApps []nestedApp `json:"nestedApps"`
+}
+
+// staticHandler serves pre-rendered static files.
+// For hashed assets (/_nuxt/*), it sets long-lived cache headers.
+// For HTML files, it sets no-cache to allow CSP nonce injection.
+//
+// A path that does not resolve to a file on disk falls back to the SPA shell
+// ONLY if it matches a route in the manifest; anything else gets a real 404.
+// Serving the shell with 200 for every unmatched path makes the site a
+// soft-404, which search engines penalise and which makes status-code-only
+// vulnerability scanners report phantom findings for paths like /webcart/.
+type staticHandler struct {
+	root     string
+	manifest spaManifest
+	// notFoundBody is the prerendered 404 page, read once at startup. It is
+	// tens of kilobytes, so re-reading it per request would put a syscall and
+	// an allocation on every scanner sweep.
+	notFoundBody []byte
+}
+
+func newStaticHandler(root string) (*staticHandler, error) {
+	manifestPath := filepath.Join(root, spaManifestFile)
+	raw, err := os.ReadFile(manifestPath) //nolint:gosec // G304: static root + constant filename, no user input
+	if err != nil {
+		// Fail loudly. Defaulting to "serve the shell for everything" would
+		// silently reintroduce the soft-404 this manifest exists to prevent.
+		return nil, fmt.Errorf("reading %s: %w", manifestPath, err)
+	}
+
+	var m spaManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", manifestPath, err)
+	}
+	if m.SPAShell == "" || m.NotFound == "" {
+		return nil, fmt.Errorf("%s: spaShell and notFound are required", manifestPath)
+	}
+
+	// The manifest naming a file is not enough: if the build dropped 200.html,
+	// every client-only route (/login, /home/**, /oauth/**) would silently hard
+	// 404. Check the referenced files exist rather than discovering it in prod.
+	shellPath := filepath.Join(root, filepath.FromSlash(m.SPAShell))
+	if _, err := os.Stat(shellPath); err != nil { //nolint:gosec // G703: static root + manifest-declared path
+		return nil, fmt.Errorf("spaShell %s: %w", shellPath, err)
+	}
+	for _, app := range m.NestedApps {
+		indexPath := filepath.Join(root, filepath.FromSlash(app.Index))
+		if _, err := os.Stat(indexPath); err != nil { //nolint:gosec // G703: static root + manifest-declared path
+			return nil, fmt.Errorf("nested app %s index %s: %w", app.Prefix, indexPath, err)
+		}
+	}
+
+	body, bodyErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(m.NotFound))) //nolint:gosec // G304: static root + manifest-declared path
+	if bodyErr != nil {
+		return nil, fmt.Errorf("notFound %s: %w", m.NotFound, bodyErr)
+	}
+
+	return &staticHandler{root: root, manifest: m, notFoundBody: body}, nil
+}
+
+// matchesRoute reports whether urlPath matches a manifest pattern. Patterns are
+// either exact ("/login") or prefix wildcards ("/home/**"), covering the subset
+// of Nitro's routeRules syntax that clientOnlyRoutes actually uses.
+func matchesRoute(pattern, urlPath string) bool {
+	if prefix := strings.TrimSuffix(pattern, "/**"); prefix != pattern {
+		return urlPath == prefix || strings.HasPrefix(urlPath, prefix+"/")
+	}
+	return urlPath == pattern
+}
+
+// spaFallbackFor returns the file to serve for an unmatched path, or "" when the
+// path should be a hard 404.
+func (s *staticHandler) spaFallbackFor(urlPath string) string {
+	// Nested apps first: they own their subtree, so a deep link inside one must
+	// get that app's index.html rather than the Nuxt shell.
+	for _, app := range s.manifest.NestedApps {
+		if urlPath == app.Prefix || strings.HasPrefix(urlPath, app.Prefix+"/") {
+			return app.Index
+		}
+	}
+	for _, pattern := range s.manifest.SPARoutes {
+		if matchesRoute(pattern, urlPath) {
+			return s.manifest.SPAShell
+		}
+	}
+	return ""
 }
 
 func (s *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -56,50 +152,62 @@ func (s *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// File not found — if the path has an extension, it's a missing asset
+	// File not found: if the path has an extension, it's a missing asset.
+	// Assets get the bare text 404, not the ~50 KB HTML page. A browser holding
+	// stale markup after a deploy re-requests old /_nuxt/<hash>.js chunks, and
+	// answering each of those with the full 404 document would be a ~2500x
+	// amplification of a response the client cannot parse anyway.
 	if path.Ext(urlPath) != "" {
 		http.NotFound(w, r)
 		return
 	}
 
-	// SPA fallback: serve 200.html (Nuxt SSG SPA shell) for client-side routes.
-	// This handles auth-gated and dynamic routes that are not pre-rendered.
-	spaFallback := filepath.Join(s.root, "200.html")
-	if _, err := os.Stat(spaFallback); err == nil { //nolint:gosec // G703: static root + "200.html", no user input
-		s.serveFile(w, r, spaFallback, urlPath)
-		return
+	// SPA fallback, but only for routes Nuxt intentionally left unrendered.
+	if fallback := s.spaFallbackFor(urlPath); fallback != "" {
+		shellPath := filepath.Join(s.root, filepath.FromSlash(fallback))
+		if _, err := os.Stat(shellPath); err == nil { //nolint:gosec // G703: static root + manifest-declared path
+			s.serveFile(w, r, shellPath, urlPath)
+			return
+		}
 	}
 
-	// Last resort: root index.html
-	rootIndex := filepath.Join(s.root, "index.html")
-	if _, err := os.Stat(rootIndex); err == nil { //nolint:gosec // G703: static root + "index.html", no user input
-		s.serveFile(w, r, rootIndex, urlPath)
-		return
-	}
+	s.serveNotFound(w, r)
+}
 
-	http.NotFound(w, r)
+// serveNotFound writes the pre-rendered 404 page with a real 404 status.
+// http.ServeContent cannot be used here: it always writes 200 and negotiates
+// Range/If-Modified-Since, so the body is written directly instead.
+func (s *staticHandler) serveNotFound(w http.ResponseWriter, r *http.Request) {
+	// Content-Length is left to net/http: the CSP middleware rewrites this body
+	// to inject nonces, so a length set here would be stale.
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.WriteHeader(http.StatusNotFound)
+	if r.Method != http.MethodHead {
+		_, _ = w.Write(s.notFoundBody)
+	}
 }
 
 func (s *staticHandler) serveFile(w http.ResponseWriter, r *http.Request, filePath string, urlPath string) {
 	// Set cache headers based on path
 	if strings.HasPrefix(urlPath, "/_nuxt/") || strings.HasPrefix(urlPath, "/_fonts/") {
-		// Hashed assets — cache for 1 year
+		// Hashed assets: cache for 1 year
 		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 	} else if strings.HasSuffix(filePath, ".html") {
-		// HTML — no cache (allows nonce injection to work properly)
+		// HTML: no cache (allows nonce injection to work properly)
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	}
 
 	f, err := os.Open(filePath) //nolint:gosec // G304: path validated by ServeHTTP (rejects ".." paths)
 	if err != nil {
-		http.NotFound(w, r)
+		s.serveNotFound(w, r)
 		return
 	}
 	defer func() { _ = f.Close() }()
 
 	stat, err := f.Stat()
 	if err != nil {
-		http.NotFound(w, r)
+		s.serveNotFound(w, r)
 		return
 	}
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:e2e": "pnpm --filter @rotki/website test:e2e",
     "test:e2e:ui": "pnpm --filter @rotki/website test:e2e:ui",
     "coverage": "pnpm --filter @rotki/website coverage",
+    "check:routes": "node scripts/check-routes.mjs",
     "i18n:check": "node scripts/check-i18n.mjs",
     "i18n:clean": "node scripts/check-i18n.mjs --delete",
     "prepare": "husky",

--- a/packages/website/app/components/error/NotFoundError.vue
+++ b/packages/website/app/components/error/NotFoundError.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-defineProps<{ statusCode: number }>();
+import ButtonLink from '~/components/common/ButtonLink.vue';
+
+// `linkHome` renders the call to action as a real anchor instead of a
+// click-handler button, so it still works on the statically served 404 body
+// where no JavaScript runs (see app/pages/not-found.vue).
+const { linkHome = false } = defineProps<{ statusCode: number; linkHome?: boolean }>();
 
 const emit = defineEmits<{ 'handle-error': [] }>();
 
@@ -24,7 +29,19 @@ const { t } = useI18n({ useScope: 'global' });
         {{ t('not_found.description.line_two') }}
       </p>
 
+      <ButtonLink
+        v-if="linkHome"
+        class="self-center lg:self-start"
+        to="/"
+        variant="default"
+        size="lg"
+        filled
+        color="primary"
+      >
+        {{ t('actions.go_back_home') }}
+      </ButtonLink>
       <RuiButton
+        v-else
         class="self-center lg:self-start"
         variant="default"
         size="lg"

--- a/packages/website/app/pages/jobs/[id].vue
+++ b/packages/website/app/pages/jobs/[id].vue
@@ -20,7 +20,10 @@ else {
     description: open ? description : t('jobs.role_unavailable.description', { title }),
   };
 
-  usePageSeo(meta.title, meta.description, path);
+  // Closed roles are prerendered so their URLs resolve (the static handler hard
+  // 404s anything not built), but they must not be indexed: surfacing a job
+  // page for a role nobody can apply to is worse than no result.
+  usePageSeo(meta.title, meta.description, path, { noIndex: !open });
 
   if (open) {
     useHead({

--- a/packages/website/app/pages/not-found.vue
+++ b/packages/website/app/pages/not-found.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import NotFoundError from '~/components/error/NotFoundError.vue';
+import { usePageSeoNoIndex } from '~/composables/use-page-seo';
+
+// Statically rendered 404 body. `404.html` cannot serve this purpose: Nuxt's
+// nitro-server always prerenders it as an un-hydrated SPA fallback shell, so it
+// is blank without JavaScript. This page is a normal route, so SSR bakes the
+// real markup in, and the Go static handler returns it with a 404 status
+// (see `notFound` in spa-routes.json).
+//
+// No <NuxtLayout> wrapper here: unlike app/error.vue, which sits outside the
+// layout system and must add one, a page already gets the default layout, so
+// wrapping would render the header and footer twice.
+//
+// `link-home` renders the call to action as an anchor rather than a click
+// handler, because the served 404 body has its scripts stripped and no
+// JavaScript runs.
+const { t } = useI18n({ useScope: 'global' });
+
+usePageSeoNoIndex(t('not_found.title'));
+</script>
+
+<template>
+  <div class="container text-center">
+    <NotFoundError
+      :status-code="404"
+      link-home
+    />
+  </div>
+</template>

--- a/packages/website/app/utils/jobs-prerender.ts
+++ b/packages/website/app/utils/jobs-prerender.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const JOBS_DIR = path.resolve(import.meta.dirname, '../../content/jobs');
+
+function jobFiles(): string[] {
+  return readdirSync(JOBS_DIR).filter(file => file.endsWith('.md') && !file.startsWith('_'));
+}
+
+/** Nuxt Content strips the numeric ordering prefix: `1.backend.md` -> `/jobs/backend`. */
+function jobRoute(file: string): string {
+  return `/jobs/${file.replace(/\.md$/, '').replace(/^\d+\./, '')}`;
+}
+
+/**
+ * Build-time helper: resolves the list of `/jobs/<slug>` routes to prerender
+ * from the markdown files in `content/jobs`. Mirrors the comparisons and
+ * features helpers.
+ *
+ * Needed because the jobs listing only links to roles with `open: true`, so
+ * `crawlLinks` discovers nothing when every role is closed. Without this the
+ * detail pages are absent from the build and the static handler hard-404s them.
+ *
+ * Nuxt Content strips the numeric ordering prefix, so `1.backend.md` is served
+ * at `/jobs/backend`.
+ */
+export function jobsPrerenderRoutes(): string[] {
+  return jobFiles().map(file => jobRoute(file));
+}
+
+/**
+ * Build-time helper: routes for roles with `open: false` in their frontmatter.
+ *
+ * Prerendering every role means closed ones are now built and would otherwise
+ * be listed in the sitemap, advertising positions nobody can apply to. They stay
+ * prerendered so the URLs resolve, but are kept out of the sitemap and carry
+ * `noindex` (see app/pages/jobs/[id].vue).
+ */
+export function closedJobRoutes(): string[] {
+  return jobFiles()
+    .filter((file) => {
+      const frontmatter = readFileSync(path.join(JOBS_DIR, file), 'utf8').split('---')[1] ?? '';
+      return /^open:\s*false\s*$/m.test(frontmatter);
+    })
+    .map(file => jobRoute(file));
+}

--- a/packages/website/app/utils/spa-routes.ts
+++ b/packages/website/app/utils/spa-routes.ts
@@ -1,0 +1,69 @@
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Client-only routes: `ssr: false` keeps them SPA in BOTH dev and build (so dev
+ * matches the production 200.html SPA fallback, and no session/redirect is ever
+ * server-rendered). Reasons: auth, guest-only, tokens, OAuth, payment.
+ *
+ * These routes are deliberately absent from the generated output, so the Go
+ * static handler must fall back to the SPA shell for them. It reads that list
+ * from the `spa-routes.json` manifest and hard-404s everything else, so adding a
+ * client-only route here is the ONLY thing needed to keep the backend in sync.
+ */
+export const clientOnlyRoutes: string[] = [
+  '/home/**',
+  '/checkout/pay/method',
+  '/checkout/pay/paypal',
+  '/checkout/pay/crypto',
+  '/checkout/pay/request-crypto',
+  '/checkout/pay/3d-secure',
+  // Payment confirmation, gated on a sessionStorage flag.
+  '/checkout/success',
+  // Guest-only route (bakes in a redirect for authenticated users otherwise).
+  '/login',
+  // OAuth callbacks, read window.location and sessionStorage (PKCE) at setup.
+  '/oauth/**',
+  // Dynamic token routes + recover/send/changed forms (runtime backend state).
+  '/activate/**',
+  '/password/**',
+  // Web3-wallet utility page, noindex, no SEO value, so keep it client-only.
+  '/sponsor/submit-name',
+];
+
+/**
+ * Nested standalone SPAs copied into the static output after `nuxt generate`
+ * (see `build:copy` in the root package.json). They own their subtree and ship
+ * their own index.html, so deep links inside them must fall back to that file
+ * rather than to the Nuxt shell.
+ */
+export const nestedApps: { prefix: string; index: string }[] = [
+  { prefix: '/checkout/pay/card', index: 'checkout/pay/card/index.html' },
+];
+
+/** Route rules marking every client-only route as unrendered. */
+export function clientOnlyRouteRules(): Record<string, { ssr: boolean; prerender: boolean }> {
+  return Object.fromEntries(
+    clientOnlyRoutes.map(route => [route, { ssr: false, prerender: false }]),
+  );
+}
+
+/**
+ * Build-time helper: writes the SPA fallback manifest the Go static handler
+ * reads at startup. Derived from `clientOnlyRoutes` so the backend can never
+ * drift from the routes Nuxt actually leaves unrendered. Without this file the
+ * handler refuses to start rather than silently serving 200 for every path.
+ */
+export function writeSpaManifest(publicDir: string): void {
+  const manifest = {
+    // Generated file. Edit `clientOnlyRoutes` in app/utils/spa-routes.ts instead.
+    spaShell: '200.html',
+    // The prerendered `/not-found` page, NOT `404.html`. Nuxt always emits
+    // `404.html` as an un-hydrated SPA fallback shell, which is blank without
+    // JavaScript; `not-found/index.html` has the real markup baked in.
+    notFound: 'not-found/index.html',
+    spaRoutes: clientOnlyRoutes,
+    nestedApps,
+  };
+  writeFileSync(path.join(publicDir, 'spa-routes.json'), `${JSON.stringify(manifest, undefined, 2)}\n`);
+}

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -4,7 +4,9 @@ import rotkiTheme from '@rotki/ui-library/theme';
 import { comparisonPrerenderRoutes } from './app/utils/comparison-prerender';
 import { featurePrerenderRoutes } from './app/utils/feature-prerender';
 import { integrationPrerenderRoutes } from './app/utils/integration-prerender';
+import { closedJobRoutes, jobsPrerenderRoutes } from './app/utils/jobs-prerender';
 import { llms } from './app/utils/llms-config';
+import { clientOnlyRouteRules, writeSpaManifest } from './app/utils/spa-routes';
 
 // Build identifier for unique chunk names per deployment
 const buildId = process.env.GIT_SHA?.slice(0, 8) || Date.now();
@@ -59,6 +61,7 @@ const nonIndexed = [
   '/checkout/pay/request-crypto',
   '/checkout/success',
   '/account-deleted',
+  '/not-found',
   '/sponsor/submit-name',
   '/md/',
   '/documents/',
@@ -199,26 +202,13 @@ export default defineNuxtConfig({
   routeRules: {
     // Redirect /pricing to /checkout/pay
     '/pricing': { redirect: { to: '/checkout/pay', statusCode: 301 } },
-    // Client-only routes: `ssr: false` keeps them SPA in BOTH dev and build (so
-    // dev matches the production 200.html SPA fallback — no session/redirect is
-    // ever server-rendered). Reasons: auth, guest-only, tokens, OAuth, payment.
-    '/home/**': { ssr: false, prerender: false },
-    '/checkout/pay/method': { ssr: false, prerender: false },
-    '/checkout/pay/paypal': { ssr: false, prerender: false },
-    '/checkout/pay/crypto': { ssr: false, prerender: false },
-    '/checkout/pay/request-crypto': { ssr: false, prerender: false },
-    '/checkout/pay/3d-secure': { ssr: false, prerender: false },
-    // Payment confirmation — gated on a sessionStorage flag.
-    '/checkout/success': { ssr: false, prerender: false },
-    // Guest-only route (bakes in a redirect for authenticated users otherwise).
-    '/login': { ssr: false, prerender: false },
-    // OAuth callbacks — read window.location and sessionStorage (PKCE) at setup.
-    '/oauth/**': { ssr: false, prerender: false },
-    // Dynamic token routes + recover/send/changed forms (runtime backend state).
-    '/activate/**': { ssr: false, prerender: false },
-    '/password/**': { ssr: false, prerender: false },
-    // Web3-wallet utility page, noindex — no SEO value, so keep it client-only.
-    '/sponsor/submit-name': { ssr: false, prerender: false },
+    // The 404 body is served at whatever URL the visitor requested, so the Nuxt
+    // runtime must not boot on it: it would hydrate against a payload for
+    // /not-found, logging a mismatch and rewriting the address bar so the
+    // visitor loses the URL they asked for. `noScripts` omits the runtime at
+    // render time, which is why this page is prerendered but inert.
+    '/not-found': { noScripts: true },
+    ...clientOnlyRouteRules(),
   },
 
   future: {
@@ -249,7 +239,10 @@ export default defineNuxtConfig({
       crawlLinks: true,
       // Guardrail: fail the build if an indexable route errors while rendering — make it ssr:false instead.
       failOnError: true,
-      routes: [...integrationPrerenderRoutes(), ...comparisonPrerenderRoutes(), ...featurePrerenderRoutes()],
+      // `/not-found` is the statically rendered 404 body the Go handler serves.
+      // (`/200.html` and `/404.html` are added automatically by Nuxt's
+      // nitro-server for static presets, and are un-hydrated SPA shells.)
+      routes: ['/not-found', ...integrationPrerenderRoutes(), ...comparisonPrerenderRoutes(), ...featurePrerenderRoutes(), ...jobsPrerenderRoutes()],
     },
   },
 
@@ -317,6 +310,18 @@ export default defineNuxtConfig({
     },
   },
   hooks: {
+    // Emit the SPA fallback manifest the Go static handler reads at startup.
+    // Derived from `clientOnlyRoutes` so the backend can never drift from the
+    // routes Nuxt actually leaves unrendered. Without this file the handler
+    // refuses to start rather than silently serving 200 for every path.
+    //
+    // Hooked on `prerender:done` so the manifest is written against the
+    // finished output rather than at `rollup:before`, when nothing exists yet.
+    'nitro:init': (nitro) => {
+      nitro.hooks.hook('prerender:done', () => {
+        writeSpaManifest(nitro.options.output.publicDir);
+      });
+    },
     'build:manifest': (manifest) => {
       // Disable prefetch and modulepreload for all chunks except fonts
       // This prevents unnecessary network requests on initial page load
@@ -357,7 +362,9 @@ export default defineNuxtConfig({
   // llms.txt / llms-full.txt / raw markdown endpoint for AI crawlers (see llms.config.ts).
   llms,
 
-  sitemap: { exclude: nonIndexed },
+  // Closed roles are prerendered so their URLs resolve, but must not be
+  // advertised in the sitemap (they also carry noindex).
+  sitemap: { exclude: [...nonIndexed, ...closedJobRoutes()] },
 
   tailwindcss: {
     config: {

--- a/scripts/check-routes.mjs
+++ b/scripts/check-routes.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * Guardrail for the static handler's hard-404 behaviour.
+ *
+ * The Go handler (backend/internal/server/static.go) serves the SPA shell only
+ * for routes listed in `spa-routes.json` and hard-404s everything else. That
+ * makes an un-prerendered route a user-visible 404 instead of a silent
+ * client-side render, so every route the Vue router can reach must either be
+ * built to disk or be covered by the manifest.
+ *
+ * This replicates the handler's resolution order against the build output, so
+ * it needs no running server. Run after `pnpm generate`.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import consola from 'consola';
+
+const PAGES_DIR = './packages/website/app/pages';
+const OUTPUT_DIR = './packages/website/.output/public';
+const MANIFEST = 'spa-routes.json';
+
+// Values substituted for dynamic segments when probing for a bogus slug.
+const BOGUS = 'zzz-definitely-not-a-real-slug';
+
+/** app/pages/foo/[id].vue -> /foo/[id] */
+function fileToRoute(relPath) {
+  const withoutExt = relPath.slice(0, -'.vue'.length);
+  let parts = withoutExt === 'index' ? [] : withoutExt.split(path.sep);
+  if (parts.at(-1) === 'index')
+    parts = parts.slice(0, -1);
+  return `/${parts.join('/')}`;
+}
+
+function collectRoutes(dir, base = dir) {
+  const routes = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory())
+      routes.push(...collectRoutes(full, base));
+    else if (entry.name.endsWith('.vue'))
+      routes.push(fileToRoute(path.relative(base, full)));
+  }
+  return routes;
+}
+
+function matchesPattern(pattern, url) {
+  if (pattern.endsWith('/**')) {
+    const base = pattern.slice(0, -3);
+    return url === base || url.startsWith(`${base}/`);
+  }
+  return url === pattern;
+}
+
+function manifestCovers(manifest, url) {
+  return manifest.spaRoutes.some(p => matchesPattern(p, url))
+    || (manifest.nestedApps ?? []).some(a => url === a.prefix || url.startsWith(`${a.prefix}/`));
+}
+
+/** Mirrors staticHandler.ServeHTTP: does this URL resolve to 200? */
+function resolves(manifest, url) {
+  const onDisk = path.join(OUTPUT_DIR, url);
+  if (existsSync(onDisk)) {
+    if (!statSync(onDisk).isDirectory())
+      return true;
+    if (existsSync(path.join(onDisk, 'index.html')))
+      return true;
+  }
+  if (path.extname(url) !== '')
+    return false;
+  return manifestCovers(manifest, url);
+}
+
+/** First real slug built on disk under a dynamic route's parent, if any. */
+function builtSlug(route) {
+  const parent = route.slice(0, route.lastIndexOf('/'));
+  const dir = path.join(OUTPUT_DIR, parent);
+  if (!existsSync(dir))
+    return undefined;
+  const entry = readdirSync(dir, { withFileTypes: true })
+    .filter(e => e.isDirectory() && !e.name.startsWith('_'))
+    .map(e => e.name)
+    .sort()[0];
+  return entry ? `${parent}/${entry}` : undefined;
+}
+
+/** Checks one router route, pushing any problems onto `failures`. */
+function checkRoute(manifest, route, failures) {
+  const concrete = route.replaceAll(/\[[^\]]+\]/g, BOGUS);
+
+  if (!route.includes('[')) {
+    if (!resolves(manifest, route || '/'))
+      failures.push(`${route}: does not resolve; prerender it or add it to clientOnlyRoutes`);
+    return 1;
+  }
+
+  // A token route the build cannot enumerate must be covered wholesale.
+  if (manifestCovers(manifest, concrete))
+    return 1;
+
+  // Otherwise a real slug must be on disk, and a bogus one must 404.
+  const real = builtSlug(route);
+  if (!real)
+    failures.push(`${route}: no page built under it, every URL in this subtree will 404`);
+  else if (!resolves(manifest, real))
+    failures.push(`${route}: built slug ${real} does not resolve`);
+
+  if (resolves(manifest, concrete))
+    failures.push(`${route}: bogus slug resolves, expected a 404`);
+
+  return 2;
+}
+
+function main() {
+  const manifestPath = path.join(OUTPUT_DIR, MANIFEST);
+  if (!existsSync(manifestPath)) {
+    consola.error(`${manifestPath} not found. Run \`pnpm generate\` first.`);
+    process.exit(1);
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+  const routes = [...new Set(collectRoutes(PAGES_DIR))].sort();
+  const failures = [];
+  let checks = 0;
+
+  // The manifest naming a file proves nothing on its own. `build:copy` can fail
+  // to copy the card-payment app, and no `pages/` route maps to that subtree, so
+  // nothing below would catch its absence.
+  for (const rel of [manifest.spaShell, manifest.notFound, ...(manifest.nestedApps ?? []).map(a => a.index)]) {
+    checks++;
+    if (!existsSync(path.join(OUTPUT_DIR, rel)))
+      failures.push(`manifest references ${rel}, which is not in the build output`);
+  }
+
+  for (const route of routes)
+    checks += checkRoute(manifest, route, failures);
+
+  if (failures.length > 0) {
+    consola.error(`${failures.length} route problem(s):`);
+    for (const f of failures)
+      consola.error(`  ${f}`);
+    process.exit(1);
+  }
+
+  consola.success(`${checks} checks passed across ${routes.length} router routes`);
+}
+
+main();


### PR DESCRIPTION
Closes #640.

## The bug

The static handler served `200.html` with HTTP **200** for any extensionless path that did not resolve to a file on disk, so every nonexistent directory-style URL was a soft-404:

```bash
curl -sS https://rotki.com/webcart/ | wc -c                  # 3641
curl -sS https://rotki.com/zzz-nonexistent-a1b2c3/ | wc -c   # 3641, identical
```

Soft-404s are an SEO penalty, and they make status-code-only vulnerability scanners report phantom findings. A recent scan flagged CVE-1999-0610 (Webcart) and CVE-2000-0127 (WebSpeed) purely on those 200 responses. Both were verified as false positives (no CGI on the host, every real data path already 404ed, and the 200 bodies were byte-identical to a control path), but the underlying behaviour was real.

## Why the fallback could not just be dropped

`routeRules` marks a set of routes `ssr: false`, so they are intentionally absent from the build and genuinely need the SPA shell: `/home/**`, `/login`, `/oauth/**`, `/activate/**`, `/password/**`, `/sponsor/submit-name` and the `/checkout/pay/*` group. A blanket 404 would break auth, OAuth callbacks and checkout.

The build now emits `spa-routes.json` from that same list, and the handler serves the shell only for routes it names. Deriving the manifest from `clientOnlyRoutes` means the backend cannot drift from what Nuxt actually leaves unrendered: adding a client-only route there is the only step needed. A missing manifest, or one naming files absent from the build, fails startup rather than silently restoring the old behaviour.

## The 404 body

`404.html` cannot serve this purpose. Nuxt's nitro-server always adds `/200.html` and `/404.html` to the prerender routes for static presets and renders both as un-hydrated SPA shells, so `404.html` is blank without JavaScript.

A `/not-found` route is prerendered instead, with the `noScripts` route rule so Nuxt omits the runtime at render time. Were it to boot, the app would hydrate against a payload for `/not-found`, which logs a hydration mismatch and rewrites the address bar, so the visitor loses the URL they actually requested.

Missing **assets** keep the bare text 404: answering a stale `/_nuxt/<hash>.js` request with the ~49 KB document is a ~2500x amplification of content the browser cannot parse, and after a deploy every client holding old markup makes several such requests.

## Also in this PR

- **Job detail pages are prerendered.** The listing only links roles with `open: true`, and all three are currently closed, so `crawlLinks` discovered none and every `/jobs/<slug>` would have hard-404ed. Closed roles carry `noindex` and are excluded from the sitemap, so resolving their URLs does not advertise positions nobody can apply to.
- **The nested card-payment SPA** at `/checkout/pay/card` serves its own `index.html` for deep links rather than the Nuxt shell.
- **`pnpm check:routes`**, run in CI after the build. It replicates the handler's resolution order against the build output and asserts every router route either resolves or is manifest-covered, that bogus content slugs 404, and that every file the manifest names is present. It was verified to fail when the job pages or the card-payment app are missing.

## Verification

Every route in `app/pages` was enumerated and tested against a real server running the new handler on the generated output, rather than spot-checked. That is what caught the `/jobs/<slug>` regression above.

| Request | Result |
|---|---|
| `/webcart/`, `/webcart/orders/`, `/cgi-bin/`, `/scripts/`, `/zzz-nonexistent/` | 404, rendered page |
| `/missing.css`, `/_nuxt/stale.abc123.js` | 404, 19 bytes |
| `/home/subscription`, `/login`, `/oauth/callback`, `/checkout/success` | 200, SPA shell |
| `/activate/uid/tok`, `/password/reset/uid/tok` | 200, SPA shell |
| `/checkout/pay/card`, `/checkout/pay/card/confirm` | 200, card app |
| `/jobs/backend`, `/integrations/0x`, `/compare/awaken` | 200 |
| `/jobs/nonexistent`, `/integrations/fake` | 404 |

Checked in a browser against the built output: 404 status, single header and footer, URL preserved, and no console errors beyond the intended document 404.

`go build` / `go test` pass, `golangci-lint` reports 0 issues, `pnpm check:routes` passes 55 checks across 48 routes.

## Known regression

With no runtime on the 404 page, `app/error.vue` no longer fires the sigil `PAGE_NOT_FOUND` event for server-served 404s. The sigil script itself survives, so those hits still register as pageviews at the requested URL, and the Go request log records path and status for every 404 including from non-JS clients and bots, which the client-side event never saw. Restoring the custom event would need an inline script with CSP nonce implications, so it is left as a follow-up decision.

## Review notes

An initial version stripped the runtime by regex-replacing the script tags in the built HTML. CodeQL flagged that (`js/incomplete-multi-character-sanitization`) and, while the input is our own build output rather than untrusted data, the underlying complaint was fair: a silent miss would have quietly reintroduced the address-bar rewrite. Replaced with Nuxt's native `noScripts` route rule, which produces byte-equivalent output with no hand-rolled HTML manipulation.

## Deploy note

Worth watching Search Console for URLs currently indexed via the old fallback that will start 404ing. Anything legitimate belongs in the prerender routes, not in the SPA manifest.
