### PR TITLE
Reduce the per-request cost of serving the site

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rotki/rotki.com/backend/internal/config"
+	"github.com/rotki/rotki.com/backend/internal/memlimit"
 	"github.com/rotki/rotki.com/backend/internal/server"
 	"github.com/rotki/rotki.com/backend/internal/version"
 )
@@ -63,6 +64,10 @@ func main() {
 		"version", version.Version,
 		"git_sha", version.GitSHA,
 	)
+
+	// Must run before the server starts taking traffic: the Go runtime does not
+	// derive a memory limit from the cgroup on its own.
+	memlimit.Apply(logger)
 
 	srv, deps, srvErr := server.New(cfg, logger)
 	if srvErr != nil {

--- a/backend/internal/csp/inject_test.go
+++ b/backend/internal/csp/inject_test.go
@@ -1,0 +1,192 @@
+package csp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The single pass has to handle both tag types interleaved. The previous
+// implementation made one pass per tag type, so ordering could not matter;
+// now it can.
+func TestInjectNonceInterleavedTags(t *testing.T) {
+	html := []byte(`<head>` +
+		`<link rel="modulepreload" href="/a.js">` +
+		`<script src="/b.js"></script>` +
+		`<link rel="stylesheet" href="/c.css">` +
+		`<script>inline()</script>` +
+		`</head>`)
+
+	got := string(injectNonce(html, "N"))
+
+	if n := strings.Count(got, `nonce="N"`); n != 3 {
+		t.Errorf("expected 3 nonces (2 script + 1 modulepreload), got %d in %q", n, got)
+	}
+	// The stylesheet link must not get one.
+	if strings.Contains(got, `<link nonce="N" rel="stylesheet"`) {
+		t.Error("nonce injected into a non-modulepreload link")
+	}
+	// Closing tags must never be touched.
+	if strings.Contains(got, `</script nonce`) {
+		t.Error("nonce injected into a closing tag")
+	}
+}
+
+// A tag that never closes must not lose content or spin. Malformed HTML can
+// reach here from a truncated build artefact.
+func TestInjectNonceUnterminatedTag(t *testing.T) {
+	html := []byte(`<p>before</p><script src="/x.js"`)
+
+	got := string(injectNonce(html, "N"))
+
+	if !strings.Contains(got, "before") {
+		t.Errorf("content before the unterminated tag was lost: %q", got)
+	}
+	if !strings.HasSuffix(got, `<script src="/x.js"`) {
+		t.Errorf("unterminated tail not copied verbatim: %q", got)
+	}
+}
+
+// Content with no tags at all must pass through byte for byte.
+func TestInjectNoncePlainContent(t *testing.T) {
+	html := []byte("no markup here at all")
+
+	if got := string(injectNonce(html, "N")); got != string(html) {
+		t.Errorf("plain content altered: %q", got)
+	}
+}
+
+// Buffers are pooled and reused, so a response must never carry bytes left
+// over from the one before it.
+func TestMiddlewarePooledBuffersDoNotLeakBetweenRequests(t *testing.T) {
+	// Markers contain a hyphen so they cannot collide with a base64 nonce,
+	// whose alphabet is alphanumeric plus + / =.
+	bodies := []string{
+		"<html><script>payload-one</script></html>",
+		"<html><script>payload-two</script></html>",
+		"<html><script>payload-three-considerably-longer-than-the-others</script></html>",
+		"<html><script>payload-four</script></html>",
+	}
+
+	var current string
+	h := Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(current))
+	}))
+
+	for i, want := range bodies {
+		current = want
+		t.Run(fmt.Sprintf("request-%d", i), func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			got := rec.Body.String()
+			// The nonce is injected, so compare on the payload rather than exactly.
+			inner := want[len("<html><script>") : len(want)-len("</script></html>")]
+			if !strings.Contains(got, inner) {
+				t.Errorf("body %d lost its content: %q", i, got)
+			}
+			for j, other := range bodies {
+				if j == i {
+					continue
+				}
+				stale := other[len("<html><script>") : len(other)-len("</script></html>")]
+				if strings.Contains(got, stale) {
+					t.Errorf("response %d contained bytes from response %d: %q", i, j, got)
+				}
+			}
+		})
+	}
+}
+
+// Pooled buffers are shared across goroutines; run the middleware concurrently
+// so the race detector has something to look at.
+func TestMiddlewareConcurrent(t *testing.T) {
+	h := Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><script>x</script></html>"))
+	}))
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+			if !strings.Contains(rec.Body.String(), `nonce=`) {
+				t.Error("no nonce injected")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// An oversized buffer must not be retained, or one large response would pin
+// that memory for the life of the process.
+func TestPutBufDropsOversizedBuffers(t *testing.T) {
+	big := new(bytes.Buffer)
+	big.Grow(maxBufferSize + 1)
+	putBuf(big)
+
+	// Not a guarantee about pool internals, just that we did not hand it back:
+	// getBuf must not return a buffer with that capacity.
+	for range 10 {
+		if got := getBuf(); got.Cap() > maxBufferSize {
+			t.Fatalf("pool handed back an oversized buffer: cap=%d", got.Cap())
+		}
+	}
+}
+
+// buildPage produces a document shaped like the real 404 page: mostly markup,
+// a couple of scripts, a modulepreload link.
+func buildPage(size int) []byte {
+	var sb strings.Builder
+	sb.WriteString(`<html><head><script>window.__NUXT__={}</script>`)
+	sb.WriteString(`<link rel="modulepreload" href="/_nuxt/entry.js">`)
+	sb.WriteString(`<link rel="stylesheet" href="/_nuxt/style.css">`)
+	sb.WriteString(`</head><body>`)
+	for sb.Len() < size {
+		sb.WriteString(`<div class="prose"><p>not found</p></div>`)
+	}
+	sb.WriteString(`<script>console.log(1)</script></body></html>`)
+
+	return []byte(sb.String())
+}
+
+func BenchmarkInjectNonce(b *testing.B) {
+	page := buildPage(47 * 1024)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		buf := getBuf()
+		injectNonceTo(buf, page, "benchmarkNonce123456")
+		putBuf(buf)
+	}
+}
+
+// End to end through the middleware, which is what production pays.
+func BenchmarkMiddlewareHTML(b *testing.B) {
+	page := buildPage(47 * 1024)
+
+	h := Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Length", fmt.Sprint(len(page)))
+		_, _ = w.Write(page)
+	}))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/some-page", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+	}
+}

--- a/backend/internal/csp/middleware.go
+++ b/backend/internal/csp/middleware.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"net/http"
 	stdpath "path"
+	"strconv"
 	"strings"
+	"sync"
 )
 
 // maxBufferSize is the maximum HTML response size that will be buffered for
@@ -31,10 +33,16 @@ func Middleware(next http.Handler, devConnectSrc ...string) http.Handler {
 		}
 
 		// Buffer the response to inspect content-type and modify HTML
+		capture := getBuf()
+		defer putBuf(capture)
+
 		bw := &bufferedWriter{
 			ResponseWriter: w,
-			buf:            &bytes.Buffer{},
+			buf:            capture,
 			header:         w.Header().Clone(),
+			// A handler that writes nothing never reaches Write or WriteHeader,
+			// and WriteHeader(0) further down would be invalid.
+			statusCode: http.StatusOK,
 		}
 		next.ServeHTTP(bw, r)
 
@@ -52,7 +60,10 @@ func Middleware(next http.Handler, devConnectSrc ...string) http.Handler {
 
 		// Generate nonce and inject into HTML
 		nonce := GenerateNonce()
-		modified := injectNonce(body, nonce)
+
+		out := getBuf()
+		defer putBuf(out)
+		injectNonceTo(out, body, nonce)
 
 		// Determine CSP policy for this route
 		policy := DefaultCSP
@@ -91,7 +102,7 @@ func Middleware(next http.Handler, devConnectSrc ...string) http.Handler {
 		// Fix content-length for modified body
 		w.Header().Del("Content-Length")
 		w.WriteHeader(bw.statusCode)
-		_, _ = w.Write(modified)
+		_, _ = w.Write(out.Bytes())
 	})
 }
 
@@ -116,97 +127,106 @@ func shouldInjectCSP(path string) bool {
 	return true
 }
 
-// injectNonce adds nonce="..." attributes to <script> and
-// <link rel="modulepreload"> tags in the HTML body.
-func injectNonce(html []byte, nonce string) []byte {
-	nonceAttr := []byte(` nonce="` + nonce + `"`)
+var (
+	scriptTag       = []byte("<script")
+	linkTag         = []byte("<link")
+	modulePreload   = []byte("modulepreload")
+	nonceAttrMarker = []byte("nonce=")
+)
 
-	// Inject nonce into <script> tags (but not those that already have a nonce)
-	html = injectAttr(html, []byte("<script"), nonceAttr)
+// injectNonceTo writes html into dst, adding nonce="..." to every <script> and
+// every <link rel="modulepreload"> that does not already carry one.
+//
+// One pass. The previous implementation scanned and copied the whole document
+// twice, once per tag type, allocating a full-size buffer for each. On the ~47 KB
+// 404 page that was two redundant copies on every request.
+func injectNonceTo(dst *bytes.Buffer, html []byte, nonce string) {
+	dst.Grow(len(html) + 256)
 
-	// Inject nonce into <link rel="modulepreload"> tags
-	html = injectAttrFiltered(html, []byte("<link"), []byte("modulepreload"), nonceAttr)
-
-	return html
-}
-
-// injectAttr adds attrBytes after every occurrence of tagOpen in html,
-// unless the tag already contains "nonce=".
-func injectAttr(html, tagOpen, attrBytes []byte) []byte {
-	result := make([]byte, 0, len(html)+256)
-	remaining := html
+	nonceAttr := ` nonce="` + nonce + `"`
+	rest := html
 
 	for {
-		idx := bytes.Index(remaining, tagOpen)
+		idx := bytes.IndexByte(rest, '<')
 		if idx == -1 {
-			result = append(result, remaining...)
-			break
+			dst.Write(rest)
+			return
 		}
 
-		// Find end of opening tag
-		tagEnd := bytes.IndexByte(remaining[idx:], '>')
-		if tagEnd == -1 {
-			result = append(result, remaining...)
-			break
-		}
-		tagEnd += idx
+		tail := rest[idx:]
 
-		tag := remaining[idx : tagEnd+1]
+		var tagLen int
+		var requireModulePreload bool
 
-		// Skip if already has nonce
-		if bytes.Contains(tag, []byte("nonce=")) {
-			result = append(result, remaining[:tagEnd+1]...)
-			remaining = remaining[tagEnd+1:]
+		switch {
+		case bytes.HasPrefix(tail, scriptTag):
+			tagLen = len(scriptTag)
+		case bytes.HasPrefix(tail, linkTag):
+			tagLen = len(linkTag)
+			requireModulePreload = true
+		default:
+			// Not a tag we touch. Copy through this '<' and keep scanning.
+			dst.Write(rest[:idx+1])
+			rest = rest[idx+1:]
 			continue
 		}
 
-		// Insert nonce attribute right after the tag name
-		insertPos := idx + len(tagOpen)
-		result = append(result, remaining[:insertPos]...)
-		result = append(result, attrBytes...)
-		result = append(result, remaining[insertPos:tagEnd+1]...)
-		remaining = remaining[tagEnd+1:]
-	}
+		end := bytes.IndexByte(tail, '>')
+		if end == -1 {
+			// Unterminated tag: copy the remainder verbatim rather than guess.
+			dst.Write(rest)
+			return
+		}
 
-	return result
+		tag := tail[:end+1]
+		inject := !bytes.Contains(tag, nonceAttrMarker) &&
+			(!requireModulePreload || bytes.Contains(tag, modulePreload))
+
+		if inject {
+			dst.Write(rest[:idx+tagLen])
+			dst.WriteString(nonceAttr)
+			dst.Write(tail[tagLen : end+1])
+		} else {
+			dst.Write(rest[:idx+end+1])
+		}
+
+		rest = rest[idx+end+1:]
+	}
 }
 
-// injectAttrFiltered adds attrBytes after tagOpen occurrences that also
-// contain filterBytes in the tag body (e.g., <link ... modulepreload ...>).
-func injectAttrFiltered(html, tagOpen, filterBytes, attrBytes []byte) []byte {
-	result := make([]byte, 0, len(html)+256)
-	remaining := html
+// injectNonce is the allocating form, kept for tests. The middleware uses
+// injectNonceTo with a pooled buffer.
+func injectNonce(html []byte, nonce string) []byte {
+	var buf bytes.Buffer
+	injectNonceTo(&buf, html, nonce)
 
-	for {
-		idx := bytes.Index(remaining, tagOpen)
-		if idx == -1 {
-			result = append(result, remaining...)
-			break
-		}
+	return buf.Bytes()
+}
 
-		tagEnd := bytes.IndexByte(remaining[idx:], '>')
-		if tagEnd == -1 {
-			result = append(result, remaining...)
-			break
-		}
-		tagEnd += idx
+// bufPool reuses response buffers across requests. Capturing a ~47 KB page into
+// a zero-capacity bytes.Buffer grows it by doubling through roughly eleven
+// reallocations, which dominated the allocation cost of serving any HTML.
+var bufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
 
-		tag := remaining[idx : tagEnd+1]
-
-		// Only inject if filter matches and no existing nonce
-		if bytes.Contains(tag, filterBytes) && !bytes.Contains(tag, []byte("nonce=")) {
-			insertPos := idx + len(tagOpen)
-			result = append(result, remaining[:insertPos]...)
-			result = append(result, attrBytes...)
-			result = append(result, remaining[insertPos:tagEnd+1]...)
-		} else {
-			result = append(result, remaining[:tagEnd+1]...)
-		}
-
-		remaining = remaining[tagEnd+1:]
+func getBuf() *bytes.Buffer {
+	buf, ok := bufPool.Get().(*bytes.Buffer)
+	if !ok {
+		return new(bytes.Buffer)
 	}
+	buf.Reset()
 
-	return result
+	return buf
+}
+
+// putBuf returns a buffer to the pool, dropping any that grew past what we are
+// willing to hold, so a single large response cannot pin memory indefinitely.
+func putBuf(buf *bytes.Buffer) {
+	if buf.Cap() > maxBufferSize {
+		return
+	}
+	bufPool.Put(buf)
 }
 
 // bufferedWriter captures the response body and status code.
@@ -234,6 +254,16 @@ func (bw *bufferedWriter) Write(b []byte) (int, error) {
 		bw.statusCode = http.StatusOK
 		bw.wroteCode = true
 	}
+
+	// Size the buffer from Content-Length on the first write. ServeContent sets
+	// it before writing, so a pooled buffer that is still too small grows once
+	// here rather than by doubling on the way up.
+	if bw.buf.Len() == 0 {
+		if n, err := strconv.Atoi(bw.header.Get("Content-Length")); err == nil && n > 0 && n <= maxBufferSize {
+			bw.buf.Grow(n)
+		}
+	}
+
 	return bw.buf.Write(b)
 }
 

--- a/backend/internal/memlimit/memlimit.go
+++ b/backend/internal/memlimit/memlimit.go
@@ -1,0 +1,111 @@
+// Package memlimit derives GOMEMLIMIT from the container's cgroup memory limit.
+//
+// The Go runtime reads the cgroup CPU quota to pick GOMAXPROCS, but it does not
+// do the equivalent for memory: GOMEMLIMIT defaults to "no limit" regardless of
+// what the container was given. Without it, GC keeps targeting a GOGC=100
+// doubling of live heap and will happily grow past the cgroup ceiling, at which
+// point the kernel OOM-kills the process instead of the collector working
+// harder. Setting a soft limit turns that abrupt failure into back pressure.
+package memlimit
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+const (
+	// cgroup v2 and v1 locations for the memory ceiling, in preference order.
+	cgroupV2Path = "/sys/fs/cgroup/memory.max"
+	cgroupV1Path = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+	// headroomRatio leaves room for memory GOMEMLIMIT does not govern. The
+	// limit covers the Go heap plus runtime structures, but not goroutine
+	// stacks that have not been reused, and the cgroup also accounts for page
+	// cache the process touches. Aiming at the full ceiling means the soft
+	// limit and the kernel's hard limit trip at the same moment, which defeats
+	// the point of having a soft one.
+	headroomRatio = 0.9
+
+	// unlimitedThreshold treats implausibly large values as "no limit set".
+	// cgroup v1 reports unlimited as a near-int64-max sentinel rather than a
+	// keyword, and the exact value varies by kernel and page size.
+	unlimitedThreshold = 1 << 62
+
+	// minLimit guards against a misread producing a limit so small the process
+	// cannot start. Below this, leaving GC alone is the safer failure.
+	minLimit = 64 << 20
+)
+
+// Apply sets the Go soft memory limit from the cgroup memory limit, and reports
+// what it did. An explicit GOMEMLIMIT in the environment always wins: the
+// runtime has already applied it by the time this runs, and an operator who set
+// it deliberately should not be second-guessed.
+func Apply(logger *slog.Logger) {
+	if v, ok := os.LookupEnv("GOMEMLIMIT"); ok && strings.TrimSpace(v) != "" {
+		logger.Info("memory limit taken from GOMEMLIMIT", "value", v)
+		return
+	}
+
+	limit, err := readCgroupLimit(cgroupV2Path, cgroupV1Path)
+	if err != nil {
+		// Not a container, or an unreadable cgroup. Neither is fatal: the
+		// process runs exactly as it did before.
+		logger.Debug("no cgroup memory limit found, leaving GOMEMLIMIT unset", "error", err)
+		return
+	}
+
+	soft := int64(float64(limit) * headroomRatio)
+	debug.SetMemoryLimit(soft)
+	logger.Info("GOMEMLIMIT derived from cgroup",
+		"cgroup_limit_bytes", limit,
+		"soft_limit_bytes", soft,
+	)
+}
+
+// errNoLimit reports that a cgroup file exists but describes no ceiling.
+var errNoLimit = errors.New("no memory limit set")
+
+// readCgroupLimit returns the container's memory ceiling in bytes, preferring
+// cgroup v2. Paths are parameters so the parsing is testable.
+func readCgroupLimit(v2Path, v1Path string) (int64, error) {
+	var lastErr error
+	for _, path := range []string{v2Path, v1Path} {
+		limit, err := parseLimitFile(path)
+		if err == nil {
+			return limit, nil
+		}
+		lastErr = err
+	}
+	return 0, lastErr
+}
+
+func parseLimitFile(path string) (int64, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // G304: fixed cgroup paths, or test fixtures
+	if err != nil {
+		return 0, err
+	}
+
+	text := strings.TrimSpace(string(raw))
+	// cgroup v2 spells "unlimited" as the literal "max".
+	if text == "max" {
+		return 0, fmt.Errorf("%s: %w", path, errNoLimit)
+	}
+
+	limit, err := strconv.ParseInt(text, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: parsing %q: %w", path, text, err)
+	}
+	if limit >= unlimitedThreshold {
+		return 0, fmt.Errorf("%s: %w", path, errNoLimit)
+	}
+	if limit < minLimit {
+		return 0, fmt.Errorf("%s: implausible limit %d bytes", path, limit)
+	}
+
+	return limit, nil
+}

--- a/backend/internal/memlimit/memlimit_test.go
+++ b/backend/internal/memlimit/memlimit_test.go
@@ -1,0 +1,131 @@
+package memlimit
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestParseLimitFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name    string
+		content string
+		want    int64
+		wantErr bool
+	}{
+		{"cgroup v2 value", "402653184\n", 402653184, false},
+		{"no trailing newline", "402653184", 402653184, false},
+		{"cgroup v2 unlimited", "max\n", 0, true},
+		{"cgroup v1 unlimited sentinel", "9223372036854771712\n", 0, true},
+		{"garbage", "not-a-number\n", 0, true},
+		{"empty", "", 0, true},
+		// A limit this small is far more likely a misread than a real cap, and
+		// honouring it would wedge the process at startup.
+		{"implausibly small", "1024\n", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeFile(t, dir, "limit-"+tc.name, tc.content)
+			got, err := parseLimitFile(p)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got limit %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// v2 is preferred, but a v2 file that is absent or says "max" must not stop the
+// v1 path from being consulted: both layouts exist in the wild.
+func TestReadCgroupLimit_PrefersV2ThenFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist")
+
+	t.Run("v2 wins when both are set", func(t *testing.T) {
+		v2 := writeFile(t, dir, "v2", "402653184")
+		v1 := writeFile(t, dir, "v1", "805306368")
+		got, err := readCgroupLimit(v2, v1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != 402653184 {
+			t.Errorf("got %d, want the v2 value", got)
+		}
+	})
+
+	t.Run("falls back to v1 when v2 is absent", func(t *testing.T) {
+		v1 := writeFile(t, dir, "v1-only", "805306368")
+		got, err := readCgroupLimit(missing, v1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != 805306368 {
+			t.Errorf("got %d, want the v1 value", got)
+		}
+	})
+
+	t.Run("falls back to v1 when v2 says max", func(t *testing.T) {
+		v2 := writeFile(t, dir, "v2-max", "max")
+		v1 := writeFile(t, dir, "v1-after-max", "805306368")
+		got, err := readCgroupLimit(v2, v1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != 805306368 {
+			t.Errorf("got %d, want the v1 value", got)
+		}
+	})
+
+	t.Run("no limit anywhere is an error, not a zero limit", func(t *testing.T) {
+		got, err := readCgroupLimit(missing, missing)
+		if err == nil {
+			t.Fatalf("expected an error, got limit %d", got)
+		}
+	})
+
+	t.Run("unlimited is reported as errNoLimit", func(t *testing.T) {
+		v2 := writeFile(t, dir, "v2-max-only", "max")
+		_, err := readCgroupLimit(v2, missing)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, errNoLimit) {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+// The soft limit must sit below the cgroup ceiling, otherwise the collector and
+// the OOM killer trip at the same point and the soft limit buys nothing.
+func TestHeadroomLeavesRoom(t *testing.T) {
+	cgroupLimit := int64(384 << 20)
+	soft := int64(float64(cgroupLimit) * headroomRatio)
+
+	if soft >= cgroupLimit {
+		t.Fatalf("soft limit %d is not below the cgroup limit %d", soft, cgroupLimit)
+	}
+	if soft < cgroupLimit/2 {
+		t.Errorf("soft limit %d wastes more than half of %d", soft, cgroupLimit)
+	}
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -98,7 +98,13 @@ func New(cfg *config.Config, logger *slog.Logger) (*http.Server, *Deps, error) {
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      60 * time.Second,
-		IdleTimeout:       120 * time.Second,
+		// Every idle keep-alive connection holds a goroutine and its read and
+		// write buffers. Traffic that opens many short-lived connections would
+		// pin that state for two full minutes past its last request, which is
+		// far longer than any client here reuses a connection for. 30s still
+		// covers ordinary browsing, where a page and its assets arrive within
+		// a few seconds of each other.
+		IdleTimeout: 30 * time.Second,
 	}, deps, nil
 }
 

--- a/backend/internal/server/server_test.go
+++ b/backend/internal/server/server_test.go
@@ -347,6 +347,9 @@ func TestStaticHandler_UnmatchedRouteHard404(t *testing.T) {
 	for _, p := range paths {
 		t.Run(p, func(t *testing.T) {
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, p, nil)
+			// The full HTML page goes only to clients that asked for HTML.
+			// See TestStaticHandler_NonBrowser404GetsBareBody for the rest.
+			req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 

--- a/backend/internal/server/static.go
+++ b/backend/internal/server/static.go
@@ -174,10 +174,43 @@ func (s *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.serveNotFound(w, r)
 }
 
+// wantsHTML reports whether the client asked for an HTML representation.
+//
+// A browser navigating to a page always lists text/html in Accept. Automated
+// clients — scanners, uptime probes, `curl`, and `fetch()` — send `*/*` or omit
+// the header entirely, and none of them render the page they get back.
+func wantsHTML(r *http.Request) bool {
+	for _, accept := range r.Header.Values("Accept") {
+		for media := range strings.SplitSeq(accept, ",") {
+			// Drop parameters (";q=0.9", ";charset=...") and compare the type.
+			mediaType, _, _ := strings.Cut(media, ";")
+			switch strings.ToLower(strings.TrimSpace(mediaType)) {
+			case "text/html", "application/xhtml+xml":
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // serveNotFound writes the pre-rendered 404 page with a real 404 status.
 // http.ServeContent cannot be used here: it always writes 200 and negotiates
 // Range/If-Modified-Since, so the body is written directly instead.
+//
+// Clients that did not ask for HTML get the bare text body instead. The
+// pre-rendered page is ~47 KB and uncacheable, and it flows through the CSP
+// middleware, which buffers and rewrites it on every request. Sweeps of
+// nonexistent paths are almost entirely non-browser traffic, so answering them
+// with the full document turns a ~100 byte request into tens of kilobytes of
+// response plus a buffer, a scan and a compression pass, for a body nothing
+// will ever display. The status code is identical either way, so crawlers and
+// SEO are unaffected.
 func (s *staticHandler) serveNotFound(w http.ResponseWriter, r *http.Request) {
+	if !wantsHTML(r) {
+		http.NotFound(w, r)
+		return
+	}
+
 	// Content-Length is left to net/http: the CSP middleware rewrites this body
 	// to inject nonces, so a length set here would be stale.
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/backend/internal/server/static.go
+++ b/backend/internal/server/static.go
@@ -134,6 +134,15 @@ func (s *staticHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The SPA manifest lands in the static root because that is where the build
+	// writes it, but it is a build artefact this handler reads from disk at
+	// startup. Nothing fetches it over HTTP, so publishing the client-only
+	// route list is surface area with no purpose.
+	if urlPath == "/"+spaManifestFile {
+		http.NotFound(w, r)
+		return
+	}
+
 	// Try to serve the exact file
 	filePath := filepath.Join(s.root, filepath.FromSlash(urlPath))
 
@@ -223,12 +232,25 @@ func (s *staticHandler) serveNotFound(w http.ResponseWriter, r *http.Request) {
 
 func (s *staticHandler) serveFile(w http.ResponseWriter, r *http.Request, filePath string, urlPath string) {
 	// Set cache headers based on path
-	if strings.HasPrefix(urlPath, "/_nuxt/") || strings.HasPrefix(urlPath, "/_fonts/") {
-		// Hashed assets: cache for 1 year
+	switch {
+	case strings.HasPrefix(urlPath, "/_nuxt/"), strings.HasPrefix(urlPath, "/_fonts/"):
+		// Content-hashed filenames, so a change always arrives under a new URL.
 		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-	} else if strings.HasSuffix(filePath, ".html") {
+
+	case strings.HasSuffix(filePath, ".html"):
 		// HTML: no cache (allows nonce injection to work properly)
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+
+	default:
+		// Everything copied verbatim from public/: /img, favicons, manifests.
+		// These carry no Cache-Control at all today, so a browser revalidates
+		// them on every navigation even though they almost never change.
+		//
+		// Their filenames are stable rather than content-hashed, so "immutable"
+		// would strand a replaced asset in caches for a year. A short fresh
+		// window plus a long stale-while-revalidate keeps navigation request
+		// free while still letting a deploy propagate within the hour.
+		w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	}
 
 	f, err := os.Open(filePath) //nolint:gosec // G304: path validated by ServeHTTP (rejects ".." paths)

--- a/backend/internal/server/static_cache_test.go
+++ b/backend/internal/server/static_cache_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Assets copied verbatim from public/ (logos, favicons, manifests) had no
+// Cache-Control at all, so browsers revalidated them on every navigation.
+func TestStaticHandler_PublicAssetsAreCacheable(t *testing.T) {
+	dir := setupStaticDir(t)
+
+	// A public/-style asset with a stable, non-hashed filename.
+	imgDir := filepath.Join(dir, "img")
+	if err := os.MkdirAll(imgDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(imgDir, "logo-small.svg"), []byte("<svg/>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newTestStaticHandler(t, dir)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/img/logo-small.svg", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	cc := rec.Header().Get("Cache-Control")
+	if cc == "" {
+		t.Fatal("public asset served with no Cache-Control")
+	}
+	if !strings.Contains(cc, "max-age=") {
+		t.Errorf("Cache-Control = %q, want a max-age", cc)
+	}
+	// Stable filenames must never be immutable: a replaced logo would be
+	// stranded in caches until the max-age expired.
+	if strings.Contains(cc, "immutable") {
+		t.Errorf("Cache-Control = %q, must not be immutable for non-hashed filenames", cc)
+	}
+}
+
+// The manifest is a build artefact read from disk at startup. Serving it over
+// HTTP publishes the client-only route list for no reason, and it sits in the
+// static root only because that is where the build writes it.
+func TestStaticHandler_ManifestNotServed(t *testing.T) {
+	dir := setupStaticDir(t)
+	h := newTestStaticHandler(t, dir)
+
+	// Present on disk, since newStaticHandler requires it to start at all.
+	if _, err := os.Stat(filepath.Join(dir, spaManifestFile)); err != nil {
+		t.Fatalf("fixture should have the manifest on disk: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/"+spaManifestFile, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for %s, got %d", spaManifestFile, rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "spaRoutes") {
+		t.Error("manifest contents leaked in the response body")
+	}
+}
+
+// The hashed-asset and HTML policies must not regress: a new URL every build is
+// what makes "immutable" safe there, and HTML still carries a per-request nonce.
+func TestStaticHandler_CachePolicyByPath(t *testing.T) {
+	dir := setupStaticDir(t)
+	h := newTestStaticHandler(t, dir)
+
+	cases := []struct {
+		path          string
+		wantImmutable bool
+		wantNoStore   bool
+	}{
+		{"/_nuxt/app.abc123.js", true, false},
+		{"/", false, true},
+		{"/activate/token", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			cc := rec.Header().Get("Cache-Control")
+			if got := strings.Contains(cc, "immutable"); got != tc.wantImmutable {
+				t.Errorf("Cache-Control = %q, immutable = %v, want %v", cc, got, tc.wantImmutable)
+			}
+			if got := strings.Contains(cc, "no-store"); got != tc.wantNoStore {
+				t.Errorf("Cache-Control = %q, no-store = %v, want %v", cc, got, tc.wantNoStore)
+			}
+		})
+	}
+}

--- a/backend/internal/server/static_notfound_test.go
+++ b/backend/internal/server/static_notfound_test.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cspmod "github.com/rotki/rotki.com/backend/internal/csp"
+)
+
+// Clients that never render HTML must not be handed the full 404 document.
+// It is ~47 KB in production, uncacheable, and rewritten per request by the CSP
+// middleware, so serving it to scanners and probes is pure cost for a body that
+// is discarded.
+func TestStaticHandler_NonBrowser404GetsBareBody(t *testing.T) {
+	dir := setupStaticDir(t)
+	h := newTestStaticHandler(t, dir)
+
+	cases := []struct {
+		name   string
+		accept string
+	}{
+		{"no accept header", ""},
+		{"wildcard", "*/*"},
+		{"curl default", "*/*"},
+		{"json client", "application/json"},
+		{"image probe", "image/webp,image/apng"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/zzz-nonexistent", nil)
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			// The status is what crawlers and monitoring act on, and it is
+			// unchanged. Only the body differs.
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("expected 404, got %d", rec.Code)
+			}
+			if strings.Contains(rec.Body.String(), "not-found") {
+				t.Errorf("served the full HTML page (%d bytes) to a non-HTML client", rec.Body.Len())
+			}
+		})
+	}
+}
+
+// Browsers must keep getting the designed page.
+func TestStaticHandler_BrowserStillGets404Page(t *testing.T) {
+	dir := setupStaticDir(t)
+	h := newTestStaticHandler(t, dir)
+
+	// Real Accept headers, as sent by Firefox, Chrome and Googlebot.
+	accepts := []string{
+		"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+		"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+		"application/xhtml+xml",
+	}
+
+	for i, accept := range accepts {
+		t.Run(fmt.Sprintf("accept-%d", i), func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/zzz-nonexistent", nil)
+			req.Header.Set("Accept", accept)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("expected 404, got %d", rec.Code)
+			}
+			if body := rec.Body.String(); body != "<html>not-found</html>" {
+				t.Errorf("expected the 404 page, got %q", body)
+			}
+		})
+	}
+}
+
+func TestWantsHTML(t *testing.T) {
+	cases := []struct {
+		accept string
+		want   bool
+	}{
+		{"text/html", true},
+		{"TEXT/HTML", true},
+		{"text/html;q=0.9", true},
+		{" text/html , */* ", true},
+		{"application/xhtml+xml", true},
+		{"application/xml;q=0.9,*/*;q=0.8", false},
+		{"*/*", false},
+		{"application/json", false},
+		{"", false},
+		// Substring matches must not count: these are distinct media types.
+		{"text/htmlish", false},
+		{"application/text/html-fragment", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.accept, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			if got := wantsHTML(req); got != tc.want {
+				t.Errorf("wantsHTML(%q) = %v, want %v", tc.accept, got, tc.want)
+			}
+		})
+	}
+}
+
+// setupLargeNotFoundDir mirrors setupStaticDir but with a 404 body sized like
+// the real one, so the benchmark measures the cost that actually matters.
+func setupLargeNotFoundDir(tb testing.TB, bodySize int) string {
+	tb.Helper()
+	dir := tb.TempDir()
+
+	write := func(name, content string) {
+		tb.Helper()
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			tb.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil { //nolint:gosec // G306: test fixture
+			tb.Fatal(err)
+		}
+	}
+
+	// Shape the body like the real page: markup with a couple of inline
+	// scripts, so the CSP middleware has something to find when it scans.
+	var sb strings.Builder
+	sb.WriteString(`<html><head><script>window.__NUXT__={}</script>`)
+	sb.WriteString(`<link rel="modulepreload" href="/_nuxt/entry.js">`)
+	sb.WriteString("</head><body>")
+	for sb.Len() < bodySize {
+		sb.WriteString(`<div class="prose"><p>not found</p></div>`)
+	}
+	sb.WriteString(`<script>console.log(1)</script></body></html>`)
+
+	write("index.html", "<html>root</html>")
+	write("200.html", "<html>spa-shell</html>")
+	write("not-found/index.html", sb.String())
+	write(spaManifestFile, `{
+  "spaShell": "200.html",
+  "notFound": "not-found/index.html",
+  "spaRoutes": ["/login"],
+  "nestedApps": []
+}`)
+
+	return dir
+}
+
+// BenchmarkNotFound measures a 404 through the same middleware chain
+// production uses, so the CSP buffer-and-rewrite pass is included.
+//
+// Browser and NonBrowser differ only in the Accept header.
+func BenchmarkNotFound(b *testing.B) {
+	const realisticBodySize = 47 * 1024
+
+	dir := setupLargeNotFoundDir(b, realisticBodySize)
+	h, err := newStaticHandler(dir)
+	if err != nil {
+		b.Fatalf("newStaticHandler: %v", err)
+	}
+	handler := cspmod.Middleware(h)
+
+	cases := []struct {
+		name   string
+		accept string
+	}{
+		{"Browser", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+		{"NonBrowser", "*/*"},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/zzz-nonexistent", nil)
+			req.Header.Set("Accept", tc.accept)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				b.SetBytes(int64(rec.Body.Len()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Four changes to what it costs to serve a request. Measured against production rather than estimated.

### Starting point

| response | identity | gzip | Cache-Control |
|---|---|---|---|
| `/login` (SPA shell) | 3,641 | 1,789 | `no-cache, no-store, must-revalidate` |
| any unmatched path (the 404 body) | **47,490** | 8,565 | `no-cache, no-store, must-revalidate` |
| `/` | ~150k | 23,611 | `no-cache, no-store, must-revalidate` |
| `/img/logo-small.svg` | 8,380 | — | **none at all** |

### Serve the bare 404 body to clients that did not ask for HTML

The prerendered 404 page is ~47 KB and uncacheable, so every request for a nonexistent path reads it, hands it to the CSP middleware to be buffered and rewritten for nonce injection, and has it compressed again at the proxy. Nothing in that chain can be cached or reused.

Most requests for nonexistent paths are not browsers. Scanners, uptime probes, `curl` and `fetch()` send `*/*` or omit `Accept` entirely, and none of them render the body they get back.

`serveNotFound` now checks `Accept` and falls back to net/http's bare text 404 when the client did not ask for HTML. Browsers and crawlers list `text/html` and keep the designed page. **The status code is identical on both paths**, so crawlers, monitoring and `pnpm check:routes` see no change.

Benchmarked through the real middleware chain with a production-sized body:

```
BenchmarkNotFound/Browser-16       97453 ns/op   202662 B/op   102 allocs/op
BenchmarkNotFound/NonBrowser-16     3252 ns/op     2129 B/op    22 allocs/op
```

30x faster and 95x less allocated. The allocation figure is the point: a 47 KB page cost 202 KB because the middleware buffered it and then built a rewritten copy, and the container runs with a memory limit.

(Those are the numbers as they stood at this commit. The last commit in this PR cuts the browser path further, to 76,783 ns/op and 55,151 B/op.)

Matching a media type rather than substring-searching `Accept` keeps `text/htmlish` from counting, which a `strings.Contains` check would accept.

### Derive GOMEMLIMIT from the cgroup, and shorten IdleTimeout

The Go runtime reads the cgroup CPU quota to choose `GOMAXPROCS`, but does not do the equivalent for memory: `GOMEMLIMIT` defaults to unlimited no matter what the container was given. So GC keeps targeting a GOGC=100 doubling of live heap and will grow straight past the ceiling, which today is enforced only by the kernel OOM-killing the process.

`memlimit.Apply` reads the cgroup limit (v2, falling back to v1) and sets the soft limit to 90% of it. The headroom matters: `GOMEMLIMIT` governs the Go heap and runtime structures while the cgroup also accounts for page cache, so aiming at the full ceiling would trip both limits together. An explicit `GOMEMLIMIT` in the environment always wins, and anything unreadable, absent or implausible leaves the runtime untouched.

Verified against real cgroups:

```
--memory=384m --cpus=1   unlimited -> 362387865 (90% of 402653184)
no limits                unlimited -> unlimited
-e GOMEMLIMIT=200MiB     209715200, left alone
```

`IdleTimeout` drops from 120s to 30s. Each idle keep-alive connection holds a goroutine and its read and write buffers, and two minutes is far longer than any client here reuses one for.

### Cache-Control for assets copied from public/

`serveFile` set a policy for `/_nuxt` and `/_fonts` and for HTML, and nothing at all for everything else. That left every file copied verbatim from `public/` with no `Cache-Control`, so browsers revalidated them on every navigation. `/img/logo-small.svg` is 8,380 bytes and appears on most pages.

Those filenames are stable rather than content-hashed, so `immutable` would strand a replaced asset in caches for a year. A one hour fresh window plus a day of `stale-while-revalidate` keeps navigation request-free while letting a deploy propagate promptly. The hashed-asset and HTML branches are unchanged, and tests now pin all three so they cannot drift into each other.

That new default branch would also have started caching `spa-routes.json`, which prompted a better question: why is it served at all? It lands in the static root only because that is where the build writes it, the handler reads it from disk at startup, and `check-routes.mjs` reads it from the output directory. Nothing fetches it over HTTP, so it now 404s instead of publishing the client-only route list.


### Inject nonces in one pass, and pool the response buffers

Serving any HTML page allocated ~202 KB for a ~47 KB document. Three causes, all in the nonce injection path every HTML response goes through:

- `bufferedWriter` captured the body into a zero-capacity `bytes.Buffer`, so a 47 KB page grew it by doubling through roughly eleven reallocations, about 131 KB on its own.
- `injectNonce` made **two** full passes, one for `<script>` and one for `<link rel=modulepreload>`, each allocating a fresh `len(html)+256` buffer and copying the whole document. The second pass existed only because the two tag types were handled by separate functions.
- Both buffers were discarded after every request.

Now a single pass handles both tag types, writing into a pooled buffer, and the capture buffer is pooled too and sized from `Content-Length` on first write. Buffers larger than `maxBufferSize` are dropped rather than pooled, so one oversized response cannot pin memory for the life of the process.

```
before   97453 ns/op   202662 B/op   102 allocs/op
after    76783 ns/op    55151 B/op    99 allocs/op

BenchmarkInjectNonce   46672 ns/op   2 B/op   0 allocs/op
```

73% less allocated and 21% faster, with the injection itself now allocation free. Much of the remaining 55 KB is `httptest.NewRecorder`'s own body buffer, which production does not pay.

**The four existing `injectNonce` tests are untouched.** That is deliberate: they pin the behaviour the rewrite had to preserve, and would be worth much less if edited to fit. `injectNonce` keeps its allocating signature for them and wraps the streaming form.

New tests cover what a single pass newly makes possible to get wrong: interleaved script and link tags (ordering could not matter when each had its own pass), unterminated tags, tag-free content, that pooled buffers never leak bytes between responses, and concurrent use under `-race`.

Also fixes a latent bug: `bufferedWriter` never initialised `statusCode`, so a handler that wrote nothing would have reached `w.WriteHeader(0)`.

### Two behaviour changes worth a reviewer's attention

- `curl https://rotki.com/nope` now prints `404 page not found` instead of the page. Anything scraping 404 bodies would notice. `fetch()` from our own frontend defaults to `Accept: */*`, so app-originated 404s get the text body too.
- `/spa-routes.json` returns 404 where it currently returns 200.

### Not included

The HTML `no-store` stays, because `cspmod.Middleware` stamps a fresh nonce into every document and a cached body would mean a reused nonce. Replacing per-request nonces with build-time `sha256` hashes is the follow-up that unblocks caching, precompression and ETags for HTML, and would delete the injection path above rather than making it cheaper. Only two inline scripts actually need allowlisting, and there is no `'strict-dynamic'`, so that change is cost removal rather than a security change.

Also noted while working on the cache policy: `ServeContent`'s `Last-Modified` comes from the file mtime, which in a `scratch` image is the build time and therefore changes on every deploy even for untouched files. A content-derived ETag would make revalidation actually cheap.

### Testing

20 packages pass under `-race`, `go vet` clean, `golangci-lint` clean. New tests cover the `Accept` negotiation both ways (including cases a naive substring match would get wrong), the cgroup parsing across v2, v1 fallback, the `max` keyword, the v1 sentinel, garbage and implausible values, and all three cache policies. Verified end to end in a container shaped like production (`--memory=384m --cpus=1`) against the real 47 KB 404 page.
