### PR TITLE
fix(checkout): keep Braintree error detail in logs, and show buyers copy they can act on

### DIFF
--- a/backend/internal/api/paymentlog/handler.go
+++ b/backend/internal/api/paymentlog/handler.go
@@ -106,7 +106,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Sanitize free-text fields
 	ev.ErrorMessage = validate.SanitizeString(ev.ErrorMessage, 500)
-	ev.ErrorCode = validate.SanitizeString(ev.ErrorCode, 32)
+	// 64, not 32: the longest BraintreeError codes we forward are 35 chars
+	// (e.g. THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT).
+	ev.ErrorCode = validate.SanitizeString(ev.ErrorCode, 64)
 
 	// Log as structured event
 	attrs := []any{

--- a/packages/card-payment/src/components/AddCardDialog.vue
+++ b/packages/card-payment/src/components/AddCardDialog.vue
@@ -48,7 +48,7 @@ async function handleAddCard(): Promise<void> {
     set(open, false);
   }
   catch (caughtError: unknown) {
-    set(addCardError, userPaymentMessage(caughtError));
+    set(addCardError, userPaymentMessage(caughtError, 'card'));
   }
   finally {
     set(isAddingCard, false);

--- a/packages/card-payment/src/components/AddCardDialog.vue
+++ b/packages/card-payment/src/components/AddCardDialog.vue
@@ -3,6 +3,7 @@ import type { Client } from 'braintree-web/client';
 import { get, set } from '@vueuse/core';
 import { ref, useTemplateRef, watch } from 'vue';
 import { addCard } from '@/utils/card-api';
+import { userPaymentMessage } from '@/utils/payment-error';
 import BaseButton from './BaseButton.vue';
 import BaseDialog from './BaseDialog.vue';
 import NewCardForm from './NewCardForm.vue';
@@ -46,8 +47,8 @@ async function handleAddCard(): Promise<void> {
     emit('card-added', newCardToken);
     set(open, false);
   }
-  catch (caughtError: any) {
-    set(addCardError, caughtError.message || 'Failed to add card');
+  catch (caughtError: unknown) {
+    set(addCardError, userPaymentMessage(caughtError));
   }
   finally {
     set(isAddingCard, false);

--- a/packages/card-payment/src/components/CardPayment.vue
+++ b/packages/card-payment/src/components/CardPayment.vue
@@ -9,7 +9,7 @@ import { type Client, create } from 'braintree-web/client';
 import { create as createVaultManager, type VaultManager } from 'braintree-web/vault-manager';
 import { computed, onMounted, onUnmounted, ref, shallowRef, useTemplateRef, watch } from 'vue';
 import { paths } from '@/config/paths';
-import { addCard, createCardNonce, trackCardPaymentFailure, trackCardPaymentSubmitted } from '@/utils/card-api';
+import { addCard, createCardNonce, reportCardFailure, trackCardPaymentSubmitted } from '@/utils/card-api';
 import AddCardDialog from './AddCardDialog.vue';
 import CardSelectionDialog from './CardSelectionDialog.vue';
 import DiscountCodeInput from './DiscountCodeInput.vue';
@@ -134,16 +134,14 @@ async function initializeBraintreeClient(): Promise<void> {
     });
     set(client, clientInstance);
   }
-  catch (error_: any) {
-    emit('fatal-error', `Failed to initialize payment client: ${error_.message}`);
+  catch (error_: unknown) {
     console.error(error_);
-    trackCardPaymentFailure({
+    emit('fatal-error', reportCardFailure(error_, {
       failure: 'BRAINTREE_INIT_FAILED',
-      errorMessage: error_?.message ?? String(error_),
       planId: selectedPlan.planId,
       isUpgrade: !!upgradeSubId,
       step: 'init',
-    });
+    }));
   }
 }
 
@@ -278,19 +276,16 @@ async function processPayment(): Promise<void> {
     sessionStorage.setItem('threeDSecureData', JSON.stringify(threeDSecureParams));
     emit('payment-success');
   }
-  catch (error_: any) {
-    set(transactionError, error_.message || 'Payment failed. Please try again.');
-    set(isProcessing, false);
-    trackCardPaymentFailure({
+  catch (error_: unknown) {
+    set(transactionError, reportCardFailure(error_, {
       failure: 'CARD_PAYMENT_API_ERROR',
-      errorMessage: error_?.message ?? String(error_),
-      errorCode: error_?.code ? String(error_.code) : undefined,
       planId: selectedPlan.planId,
       isUpgrade: !!upgradeSubId,
       step: 'submit',
       cardType,
       discountApplied,
-    });
+    }));
+    set(isProcessing, false);
   }
 }
 

--- a/packages/card-payment/src/i18n/en.ts
+++ b/packages/card-payment/src/i18n/en.ts
@@ -1,0 +1,16 @@
+// User-facing copy for the card-payment SPA. This package has no i18n runtime
+// (it ships a single locale), so strings live here rather than being scattered
+// through components: one place to review the wording, and the same shape a
+// translation layer would need if one is ever added.
+//
+// Keep the payment wording in step with `subscription.error.*` in the website's
+// `i18n/locales/en.json` — both render the same failures.
+
+export const en = {
+  payment: {
+    networkFailure: 'We couldn\'t reach the payment provider. Check your connection and try again.',
+    unexpectedFailure: 'We couldn\'t complete your payment. Please try again, or contact support if it keeps happening.',
+    unexpectedFailureWithReference: (code: string): string =>
+      `We couldn't complete your payment. Please try again, or contact support quoting reference ${code}.`,
+  },
+} as const;

--- a/packages/card-payment/src/i18n/en.ts
+++ b/packages/card-payment/src/i18n/en.ts
@@ -3,8 +3,10 @@
 // through components: one place to review the wording, and the same shape a
 // translation layer would need if one is ever added.
 //
-// Keep the payment wording in step with `subscription.error.*` in the website's
-// `i18n/locales/en.json` — both render the same failures.
+// Keep in step with `subscription.error.*` in the website's
+// `i18n/locales/en.json` — both render the same failures, and `payment` vs
+// `card` mirrors the `PaymentErrorContext` split there. Nothing is being
+// charged when a card is being saved, so the two must not share wording.
 
 export const en = {
   payment: {
@@ -12,5 +14,11 @@ export const en = {
     unexpectedFailure: 'We couldn\'t complete your payment. Please try again, or contact support if it keeps happening.',
     unexpectedFailureWithReference: (code: string): string =>
       `We couldn't complete your payment. Please try again, or contact support quoting reference ${code}.`,
+  },
+  card: {
+    networkFailure: 'We couldn\'t reach the payment provider. Check your connection and try again.',
+    unexpectedFailure: 'We couldn\'t save this card. Please try again, or contact support if it keeps happening.',
+    unexpectedFailureWithReference: (code: string): string =>
+      `We couldn't save this card. Please try again, or contact support quoting reference ${code}.`,
   },
 } as const;

--- a/packages/card-payment/src/utils/card-api.ts
+++ b/packages/card-payment/src/utils/card-api.ts
@@ -7,7 +7,7 @@ import {
   SavedCardSchema,
 } from '@rotki/card-payment-common/schemas/payment';
 import { convertKeys } from '@rotki/card-payment-common/utils/object';
-import { type CardType, type CheckoutStep, monthsToPlanDuration, parseBraintreeError, type PaymentFailureKey, PaymentFailures, postPaymentLog, SigilEvents, sigilTrack, toSnakeCaseKeys } from '@rotki/sigil';
+import { type CardType, type CheckoutStep, monthsToPlanDuration, parseBraintreeError, type PaymentFailureKey, PaymentFailures, PaymentUserError, postPaymentLog, SigilEvents, sigilTrack, toSnakeCaseKeys } from '@rotki/sigil';
 import { paths } from '@/config/paths';
 import { paymentMessageFor } from '@/utils/payment-error';
 import { fetchWithCSRF } from './api';
@@ -119,21 +119,24 @@ export async function addCard(payload: AddCardPayload): Promise<string> {
     if (!response.ok) {
       const errorText = await response.text();
       const backendMessage = extractErrorMessage(errorText);
-      // 400s on this endpoint are either schema/JSON-decode errors (programmer-side) or
-      // raw Braintree gateway dumps ("Do Not Honor" etc.) — replace with a friendly
-      // message; raw cause is kept in the console.error below for debugging.
-      // 429 surfaces the backend's already-user-friendly rate-limit message verbatim.
-      let message: string;
+      // 400s on this endpoint are either schema/JSON-decode errors (programmer-side)
+      // or raw Braintree gateway dumps ("Do Not Honor" etc.), so they get friendly
+      // copy with the raw cause kept in logDetail. 429 surfaces the backend's
+      // already-user-friendly rate-limit message verbatim. Both are written for the
+      // customer, hence PaymentUserError, which is what lets them reach the screen;
+      // anything else is an HTTP dump and stays opaque.
       if (response.status === 400) {
-        message = 'We couldn\'t add this card. Please double-check the details or try a different card.';
+        throw new PaymentUserError(
+          'We couldn\'t add this card. Please double-check the details or try a different card.',
+          { logDetail: backendMessage },
+        );
       }
-      else if (response.status === 429) {
-        message = backendMessage;
+
+      if (response.status === 429) {
+        throw new PaymentUserError(backendMessage);
       }
-      else {
-        message = `HTTP ${response.status}: ${backendMessage}`;
-      }
-      throw new Error(message);
+
+      throw new Error(`HTTP ${response.status}: ${backendMessage}`);
     }
 
     const data = await response.json();
@@ -149,9 +152,13 @@ export async function addCard(payload: AddCardPayload): Promise<string> {
     }
     return parsedCard.data.token;
   }
-  catch (error: any) {
+  catch (error: unknown) {
     console.error('Failed to add card:', error);
-    throw new Error(error.message || 'Failed to add card');
+    // Rethrow as-is: re-wrapping in a plain Error would strip the
+    // PaymentUserError marker and turn customer copy into generic copy.
+    throw error instanceof PaymentUserError
+      ? error
+      : new Error(error instanceof Error ? error.message : 'Failed to add card');
   }
 }
 

--- a/packages/card-payment/src/utils/card-api.ts
+++ b/packages/card-payment/src/utils/card-api.ts
@@ -7,8 +7,9 @@ import {
   SavedCardSchema,
 } from '@rotki/card-payment-common/schemas/payment';
 import { convertKeys } from '@rotki/card-payment-common/utils/object';
-import { type CardType, type CheckoutStep, monthsToPlanDuration, type PaymentFailureKey, PaymentFailures, postPaymentLog, SigilEvents, sigilTrack, toSnakeCaseKeys } from '@rotki/sigil';
+import { type CardType, type CheckoutStep, monthsToPlanDuration, parseBraintreeError, type PaymentFailureKey, PaymentFailures, postPaymentLog, SigilEvents, sigilTrack, toSnakeCaseKeys } from '@rotki/sigil';
 import { paths } from '@/config/paths';
+import { paymentMessageFor } from '@/utils/payment-error';
 import { fetchWithCSRF } from './api';
 
 interface CardSubmittedInput {
@@ -72,6 +73,30 @@ export function trackCardPaymentFailure({ failure, errorMessage, planId, isUpgra
     cardType,
     discountApplied,
   }));
+}
+
+/**
+ * Report a failed card operation and return the copy to show the buyer.
+ *
+ * The two halves belong together: the SDK's own message is what gets logged
+ * (with the Cardinal detail `parseBraintreeError` recovers), and is exactly
+ * what must not reach the buyer unless `paymentErrorCopy` says so. Deriving
+ * both from one parse keeps a caller from logging one thing and rendering
+ * another.
+ */
+export function reportCardFailure(
+  error: unknown,
+  context: Omit<CardFailureInput, 'errorMessage' | 'errorCode'>,
+): string {
+  const parsed = parseBraintreeError(error);
+
+  trackCardPaymentFailure({
+    ...context,
+    errorMessage: parsed.logMessage,
+    errorCode: parsed.code,
+  });
+
+  return paymentMessageFor(parsed);
 }
 
 function extractErrorMessage(errorText: string): string {

--- a/packages/card-payment/src/utils/payment-error.ts
+++ b/packages/card-payment/src/utils/payment-error.ts
@@ -2,6 +2,13 @@ import { parseBraintreeError, type ParsedPaymentError, paymentErrorCopy } from '
 import { en } from '@/i18n/en';
 
 /**
+ * What the buyer was doing when the error happened. Nothing is charged while a
+ * card is being saved, so "we couldn't complete your payment" would be both
+ * wrong and alarming there. Mirrors `PaymentErrorContext` on the website.
+ */
+export type PaymentErrorContext = 'payment' | 'card';
+
+/**
  * Put words to the copy `paymentErrorCopy` picked for a payment error.
  *
  * The decision, above all whether the SDK's own message may be shown at all,
@@ -9,21 +16,23 @@ import { en } from '@/i18n/en';
  * `usePaymentErrorMessage`. This only supplies the strings, which this package
  * carries literally because it ships a single locale and no i18n runtime.
  */
-export function paymentMessageFor(parsed: ParsedPaymentError): string {
+export function paymentMessageFor(parsed: ParsedPaymentError, context: PaymentErrorContext = 'payment'): string {
   const copy = paymentErrorCopy(parsed);
 
   if (copy.kind === 'verbatim')
     return copy.message;
 
+  const strings = context === 'card' ? en.card : en.payment;
+
   if (copy.kind === 'network')
-    return en.payment.networkFailure;
+    return strings.networkFailure;
 
   return copy.code
-    ? en.payment.unexpectedFailureWithReference(copy.code)
-    : en.payment.unexpectedFailure;
+    ? strings.unexpectedFailureWithReference(copy.code)
+    : strings.unexpectedFailure;
 }
 
 /** `paymentMessageFor` for callers holding a raw rejection and nothing to log. */
-export function userPaymentMessage(error: unknown): string {
-  return paymentMessageFor(parseBraintreeError(error));
+export function userPaymentMessage(error: unknown, context: PaymentErrorContext = 'payment'): string {
+  return paymentMessageFor(parseBraintreeError(error), context);
 }

--- a/packages/card-payment/src/utils/payment-error.ts
+++ b/packages/card-payment/src/utils/payment-error.ts
@@ -1,0 +1,29 @@
+import { parseBraintreeError, type ParsedPaymentError, paymentErrorCopy } from '@rotki/sigil';
+import { en } from '@/i18n/en';
+
+/**
+ * Put words to the copy `paymentErrorCopy` picked for a payment error.
+ *
+ * The decision, above all whether the SDK's own message may be shown at all,
+ * lives in sigil so the website reaches the same conclusion through
+ * `usePaymentErrorMessage`. This only supplies the strings, which this package
+ * carries literally because it ships a single locale and no i18n runtime.
+ */
+export function paymentMessageFor(parsed: ParsedPaymentError): string {
+  const copy = paymentErrorCopy(parsed);
+
+  if (copy.kind === 'verbatim')
+    return copy.message;
+
+  if (copy.kind === 'network')
+    return en.payment.networkFailure;
+
+  return copy.code
+    ? en.payment.unexpectedFailureWithReference(copy.code)
+    : en.payment.unexpectedFailure;
+}
+
+/** `paymentMessageFor` for callers holding a raw rejection and nothing to log. */
+export function userPaymentMessage(error: unknown): string {
+  return paymentMessageFor(parseBraintreeError(error));
+}

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -24,6 +24,12 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest run"
   },
+  "peerDependencies": {
+    "zod": "^3.0.0 || ^4.0.0"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "@tsconfig/node24": "catalog:",
     "@types/node": "catalog:",

--- a/packages/sigil/src/failures.ts
+++ b/packages/sigil/src/failures.ts
@@ -5,6 +5,7 @@
 // sync.
 
 import type { EnumValueOf } from './common';
+import { z } from 'zod';
 
 export const PaymentFailures = {
   BRAINTREE_INIT_FAILED: { serverEvent: 'braintree_init_failed', reason: 'braintree_init' },
@@ -97,4 +98,122 @@ export function classifyCryptoTxError(error: unknown): PaymentFailureKey {
     return 'CRYPTO_USER_REJECTED';
 
   return 'CRYPTO_TX_FAILED';
+}
+
+// The schemas below describe third-party error objects we do not control, so
+// every field is `.catch(undefined)`: one unexpected field type degrades that
+// field only, and never discards the rest of an otherwise usable error.
+
+/**
+ * Cardinal's original error, attached by braintree-web as
+ * `details.originalError` when Songbird reports `ActionCode: "ERROR"`.
+ * See braintree-web `three-d-secure/external/frameworks/songbird.js`: `code`
+ * is Cardinal's numeric `ErrorNumber`, `description` its `ErrorDescription`.
+ */
+const cardinalOriginalErrorSchema = z.object({
+  code: z.union([z.string(), z.number()]).optional().catch(undefined),
+  description: z.string().optional().catch(undefined),
+});
+
+/** A nested `Error`-like rejection, e.g. the gateway request failure that
+ * `_performJWTValidation` wraps into `details.originalError`. */
+const nestedErrorSchema = z.object({
+  message: z.string().optional().catch(undefined),
+});
+
+/**
+ * Shape of a `BraintreeError` (braintree-web `lib/braintree-error`). Described
+ * structurally so neither sigil nor its consumers need a braintree-web
+ * dependency. `details.originalError` stays `unknown`: it is narrowed
+ * separately, since its shape depends on which layer failed.
+ */
+const braintreeErrorSchema = z.object({
+  code: z.string().optional().catch(undefined),
+  type: z.string().optional().catch(undefined),
+  message: z.string().optional().catch(undefined),
+  details: z.object({ originalError: z.unknown() }).optional().catch(undefined),
+});
+
+export interface ParsedPaymentError {
+  /** Plain message, safe to surface in the UI. */
+  message: string;
+  /** `message` plus the Cardinal original error. Log this, don't render it. */
+  logMessage: string;
+  /** BraintreeError `code` (e.g. `THREEDS_CARDINAL_SDK_ERROR`), when the error is one. */
+  code?: string;
+}
+
+/**
+ * Describe `details.originalError`. Cardinal's `{ code, description }` is the
+ * interesting case: braintree-web collapses every unmapped Cardinal
+ * `ErrorNumber` into the single generic `THREEDS_CARDINAL_SDK_ERROR` code, so
+ * the number here is the only thing that identifies the actual failure.
+ */
+function describeCardinalError(original: unknown): string | undefined {
+  const cardinal = cardinalOriginalErrorSchema.safeParse(original);
+  if (!cardinal.success)
+    return undefined;
+
+  const { code, description } = cardinal.data;
+  const parts: string[] = [];
+
+  if (code !== undefined && code !== '')
+    parts.push(`cardinal ${code}`);
+
+  if (description)
+    parts.push(description);
+
+  return parts.length > 0 ? parts.join(': ') : undefined;
+}
+
+function describeOriginalError(original: unknown): string | undefined {
+  if (original === undefined || original === null)
+    return undefined;
+
+  if (typeof original === 'string')
+    return original || undefined;
+
+  const cardinal = describeCardinalError(original);
+  if (cardinal)
+    return cardinal;
+
+  const nested = nestedErrorSchema.safeParse(original);
+  return nested.success ? nested.data.message : undefined;
+}
+
+/**
+ * Turn an unknown rejection from the Braintree/Cardinal 3D Secure flow into a
+ * loggable message plus a stable error code.
+ *
+ * The SDK rejects with a `BraintreeError` whose `message` is prose and whose
+ * real discriminator lives on `code` and `details.originalError`. Logging only
+ * `error.message` throws that away, and a non-`Error` rejection degrades to a
+ * bare `String(error)` (this is how an `error_message` of `"26"` reaches the
+ * logs with nothing left to identify it).
+ */
+export function parseBraintreeError(error: unknown): ParsedPaymentError {
+  if (typeof error === 'string') {
+    const message = error || 'Unknown error';
+    return { message, logMessage: message };
+  }
+
+  const parsed = braintreeErrorSchema.safeParse(error);
+  if (!parsed.success) {
+    const message = String(error);
+    return { message, logMessage: message };
+  }
+
+  const { code, type, message, details } = parsed.data;
+  const original = describeOriginalError(details?.originalError);
+
+  // Fall back through code/type before the raw stringification, so an object
+  // with no `message` still logs something the backend will accept (it rejects
+  // an empty `error_message` with a 400).
+  const base = message || code || type || String(error);
+
+  return {
+    message: base,
+    logMessage: original ? `${base} (${original})` : base,
+    ...(code ? { code } : {}),
+  };
 }

--- a/packages/sigil/src/failures.ts
+++ b/packages/sigil/src/failures.ts
@@ -110,14 +110,14 @@ export function classifyCryptoTxError(error: unknown): PaymentFailureKey {
  * See braintree-web `three-d-secure/external/frameworks/songbird.js`: `code`
  * is Cardinal's numeric `ErrorNumber`, `description` its `ErrorDescription`.
  */
-const cardinalOriginalErrorSchema = z.object({
+const CardinalOriginalErrorSchema = z.object({
   code: z.union([z.string(), z.number()]).optional().catch(undefined),
   description: z.string().optional().catch(undefined),
 });
 
 /** A nested `Error`-like rejection, e.g. the gateway request failure that
  * `_performJWTValidation` wraps into `details.originalError`. */
-const nestedErrorSchema = z.object({
+const NestedErrorSchema = z.object({
   message: z.string().optional().catch(undefined),
 });
 
@@ -127,7 +127,7 @@ const nestedErrorSchema = z.object({
  * dependency. `details.originalError` stays `unknown`: it is narrowed
  * separately, since its shape depends on which layer failed.
  */
-const braintreeErrorSchema = z.object({
+const BraintreeErrorSchema = z.object({
   code: z.string().optional().catch(undefined),
   type: z.string().optional().catch(undefined),
   message: z.string().optional().catch(undefined),
@@ -224,7 +224,7 @@ export function paymentErrorCopy({ message, code, audience }: ParsedPaymentError
  * the number here is the only thing that identifies the actual failure.
  */
 function describeCardinalError(original: unknown): string | undefined {
-  const cardinal = cardinalOriginalErrorSchema.safeParse(original);
+  const cardinal = CardinalOriginalErrorSchema.safeParse(original);
   if (!cardinal.success)
     return undefined;
 
@@ -251,7 +251,7 @@ function describeOriginalError(original: unknown): string | undefined {
   if (cardinal)
     return cardinal;
 
-  const nested = nestedErrorSchema.safeParse(original);
+  const nested = NestedErrorSchema.safeParse(original);
   return nested.success ? nested.data.message : undefined;
 }
 
@@ -273,7 +273,7 @@ export function parseBraintreeError(error: unknown): ParsedPaymentError {
     return { message, logMessage: message, audience: PaymentErrorAudiences.OPAQUE };
   }
 
-  const parsed = braintreeErrorSchema.safeParse(error);
+  const parsed = BraintreeErrorSchema.safeParse(error);
   if (!parsed.success) {
     const message = String(error);
     return { message, logMessage: message, audience: PaymentErrorAudiences.OPAQUE };

--- a/packages/sigil/src/failures.ts
+++ b/packages/sigil/src/failures.ts
@@ -134,13 +134,87 @@ const braintreeErrorSchema = z.object({
   details: z.object({ originalError: z.unknown() }).optional().catch(undefined),
 });
 
+/**
+ * Who a parsed error's `message` was written for, and therefore whether it can
+ * be rendered as-is. Derived from the BraintreeError `type`, which is the only
+ * signal the SDK gives about its own copy: braintree-web writes `CUSTOMER`
+ * messages for the buyer and the rest for whoever is integrating it.
+ */
+export const PaymentErrorAudiences = {
+  /** Not a BraintreeError, so we threw it and `message` is already our copy. */
+  OWN: 'own',
+  /** The buyer or their bank caused it, and can act on it. Safe to render. */
+  CUSTOMER: 'customer',
+  /** A connectivity failure. Render our own retry copy. */
+  NETWORK: 'network',
+  /** `MERCHANT`/`INTERNAL`/`UNKNOWN`, or unrecognisable: developer prose. Never render it. */
+  OPAQUE: 'opaque',
+} as const;
+
+export type PaymentErrorAudience = EnumValueOf<typeof PaymentErrorAudiences>;
+
 export interface ParsedPaymentError {
-  /** Plain message, safe to surface in the UI. */
+  /** Plain message. Render it only when `audience` allows, see `PaymentErrorAudiences`. */
   message: string;
   /** `message` plus the Cardinal original error. Log this, don't render it. */
   logMessage: string;
   /** BraintreeError `code` (e.g. `THREEDS_CARDINAL_SDK_ERROR`), when the error is one. */
   code?: string;
+  /** Whether `message` is fit to show the buyer. */
+  audience: PaymentErrorAudience;
+}
+
+/**
+ * An error with neither `code` nor `type` did not come from the SDK, so it is
+ * one of ours and its message is already user-facing copy. Everything else is
+ * classified by the BraintreeError `type`.
+ */
+function audienceFor(code: string | undefined, type: string | undefined): PaymentErrorAudience {
+  if (!code && !type)
+    return PaymentErrorAudiences.OWN;
+
+  if (type === 'CUSTOMER')
+    return PaymentErrorAudiences.CUSTOMER;
+
+  if (type === 'NETWORK')
+    return PaymentErrorAudiences.NETWORK;
+
+  return PaymentErrorAudiences.OPAQUE;
+}
+
+/**
+ * What a buyer should be told about a parsed payment error, minus the words.
+ *
+ * The words themselves cannot live here: the website translates through
+ * vue-i18n while the card-payment SPA carries literal English. What both need
+ * is the same decision about *which* of the three things to say, above all
+ * whether the SDK's own message may be rendered at all, so that lives here and
+ * each app only supplies copy.
+ */
+export type PaymentErrorCopy =
+  /** Show `message` as-is: either we wrote it, or it is a `CUSTOMER` error the buyer can act on. */
+  | { kind: 'verbatim'; message: string }
+  /** Show connectivity copy, e.g. "check your connection and try again". */
+  | { kind: 'network' }
+  /**
+   * Show generic copy. The SDK's message is developer prose and must not be
+   * rendered; `code` is a stable caps-string identifier ("THREEDS_CARDINAL_SDK_ERROR")
+   * that is safe to quote as a support reference when present.
+   */
+  | { kind: 'unexpected'; code?: string };
+
+/**
+ * Decide what to tell the buyer about a parsed error. Pair it with
+ * `parseBraintreeError`, whose `logMessage` is what you send to the logs.
+ */
+export function paymentErrorCopy({ message, code, audience }: ParsedPaymentError): PaymentErrorCopy {
+  if (audience === PaymentErrorAudiences.OWN || audience === PaymentErrorAudiences.CUSTOMER)
+    return { kind: 'verbatim', message };
+
+  if (audience === PaymentErrorAudiences.NETWORK)
+    return { kind: 'network' };
+
+  return code ? { kind: 'unexpected', code } : { kind: 'unexpected' };
 }
 
 /**
@@ -192,15 +266,17 @@ function describeOriginalError(original: unknown): string | undefined {
  * logs with nothing left to identify it).
  */
 export function parseBraintreeError(error: unknown): ParsedPaymentError {
+  // A bare string or a non-object rejection is unattributable: it may be
+  // third-party prose, or the `26` that started all this. Log it, never show it.
   if (typeof error === 'string') {
     const message = error || 'Unknown error';
-    return { message, logMessage: message };
+    return { message, logMessage: message, audience: PaymentErrorAudiences.OPAQUE };
   }
 
   const parsed = braintreeErrorSchema.safeParse(error);
   if (!parsed.success) {
     const message = String(error);
-    return { message, logMessage: message };
+    return { message, logMessage: message, audience: PaymentErrorAudiences.OPAQUE };
   }
 
   const { code, type, message, details } = parsed.data;
@@ -215,5 +291,6 @@ export function parseBraintreeError(error: unknown): ParsedPaymentError {
     message: base,
     logMessage: original ? `${base} (${original})` : base,
     ...(code ? { code } : {}),
+    audience: audienceFor(code, type),
   };
 }

--- a/packages/sigil/src/failures.ts
+++ b/packages/sigil/src/failures.ts
@@ -135,13 +135,44 @@ const BraintreeErrorSchema = z.object({
 });
 
 /**
+ * An error whose message we wrote for the buyer.
+ *
+ * Throw this instead of a plain `Error` when the message is meant to be read by
+ * a customer. Being told so is the only way `parseBraintreeError` can know: an
+ * ofetch `FetchError`, a `TypeError` from a bug of ours and a deliberate piece
+ * of copy are all just `Error`s with a `message`, and only one of them may be
+ * rendered.
+ *
+ * @param logDetail diagnostic to append to `logMessage` only. The message is
+ * customer copy, so it rarely says which card or plan was involved; this is
+ * where that goes.
+ */
+export class PaymentUserError extends Error {
+  /** Structural marker: survives bundling and duplicate package copies, unlike `instanceof`. */
+  readonly userFacing = true;
+  readonly logDetail?: string;
+
+  constructor(message: string, options?: { logDetail?: string }) {
+    super(message);
+    this.name = 'PaymentUserError';
+    this.logDetail = options?.logDetail;
+  }
+}
+
+const UserErrorSchema = z.object({
+  userFacing: z.literal(true).optional().catch(undefined),
+  logDetail: z.string().optional().catch(undefined),
+  message: z.string().optional().catch(undefined),
+});
+
+/**
  * Who a parsed error's `message` was written for, and therefore whether it can
  * be rendered as-is. Derived from the BraintreeError `type`, which is the only
  * signal the SDK gives about its own copy: braintree-web writes `CUSTOMER`
  * messages for the buyer and the rest for whoever is integrating it.
  */
 export const PaymentErrorAudiences = {
-  /** Not a BraintreeError, so we threw it and `message` is already our copy. */
+  /** A `PaymentUserError`, so `message` is copy we wrote for the buyer. */
   OWN: 'own',
   /** The buyer or their bank caused it, and can act on it. Safe to render. */
   CUSTOMER: 'customer',
@@ -165,14 +196,14 @@ export interface ParsedPaymentError {
 }
 
 /**
- * An error with neither `code` nor `type` did not come from the SDK, so it is
- * one of ours and its message is already user-facing copy. Everything else is
- * classified by the BraintreeError `type`.
+ * Classify by the BraintreeError `type`.
+ *
+ * Note what this deliberately does not do: infer `OWN` from the *absence* of
+ * `code` and `type`. Everything that is not a BraintreeError lacks both, so
+ * that test would hand a `FetchError`'s `[POST] "/webapi/...": 500` straight to
+ * the buyer. `OWN` is only ever granted to a `PaymentUserError`, which says so.
  */
-function audienceFor(code: string | undefined, type: string | undefined): PaymentErrorAudience {
-  if (!code && !type)
-    return PaymentErrorAudiences.OWN;
-
+function audienceFor(type: string | undefined): PaymentErrorAudience {
   if (type === 'CUSTOMER')
     return PaymentErrorAudiences.CUSTOMER;
 
@@ -256,6 +287,39 @@ function describeOriginalError(original: unknown): string | undefined {
 }
 
 /**
+ * Recognise copy we wrote, the only thing that earns `OWN`.
+ *
+ * Tried before the BraintreeError shape, because a `PaymentUserError` matches
+ * that schema too (both are objects with a `message`) and would otherwise be
+ * classified as opaque developer prose.
+ */
+function parseUserError(error: unknown): ParsedPaymentError | undefined {
+  const own = UserErrorSchema.safeParse(error);
+  if (!own.success || own.data.userFacing !== true || !own.data.message)
+    return undefined;
+
+  const { message, logDetail } = own.data;
+
+  return {
+    message,
+    logMessage: logDetail ? `${message} (${logDetail})` : message,
+    audience: PaymentErrorAudiences.OWN,
+  };
+}
+
+/**
+ * The best single line describing a BraintreeError.
+ *
+ * Falls back through `code` and `type` before the raw stringification, so an
+ * object with no `message` still logs something the backend will accept (it
+ * rejects an empty `error_message` with a 400). None of the fallbacks is a
+ * sentence anyone wrote, which is why reaching them can never mean `OWN`.
+ */
+function describeBraintreeError(error: unknown, parsed: z.infer<typeof BraintreeErrorSchema>): string {
+  return parsed.message || parsed.code || parsed.type || String(error);
+}
+
+/**
  * Turn an unknown rejection from the Braintree/Cardinal 3D Secure flow into a
  * loggable message plus a stable error code.
  *
@@ -273,24 +337,24 @@ export function parseBraintreeError(error: unknown): ParsedPaymentError {
     return { message, logMessage: message, audience: PaymentErrorAudiences.OPAQUE };
   }
 
+  const own = parseUserError(error);
+  if (own)
+    return own;
+
   const parsed = BraintreeErrorSchema.safeParse(error);
   if (!parsed.success) {
     const message = String(error);
     return { message, logMessage: message, audience: PaymentErrorAudiences.OPAQUE };
   }
 
-  const { code, type, message, details } = parsed.data;
+  const { code, type, details } = parsed.data;
   const original = describeOriginalError(details?.originalError);
-
-  // Fall back through code/type before the raw stringification, so an object
-  // with no `message` still logs something the backend will accept (it rejects
-  // an empty `error_message` with a 400).
-  const base = message || code || type || String(error);
+  const base = describeBraintreeError(error, parsed.data);
 
   return {
     message: base,
     logMessage: original ? `${base} (${original})` : base,
     ...(code ? { code } : {}),
-    audience: audienceFor(code, type),
+    audience: audienceFor(type),
   };
 }

--- a/packages/sigil/src/index.spec.ts
+++ b/packages/sigil/src/index.spec.ts
@@ -11,6 +11,7 @@ import {
   paymentErrorCopy,
   PaymentFailures,
   PaymentServerEvents,
+  PaymentUserError,
   postPaymentLog,
   randomSessionId,
   reasonForServerEvent,
@@ -557,7 +558,7 @@ describe('parseBraintreeError', () => {
   });
 
   it('handles a plain Error with no braintree fields', () => {
-    const parsed = parseBraintreeError(new Error('3DS liability did not shift, please try again'));
+    const parsed = parseBraintreeError(new PaymentUserError('3DS liability did not shift, please try again'));
 
     expect(parsed.message).toBe('3DS liability did not shift, please try again');
     expect(parsed.logMessage).toBe('3DS liability did not shift, please try again');
@@ -589,9 +590,40 @@ describe('parseBraintreeError', () => {
   });
 
   describe('audience', () => {
-    it('marks an error we threw ourselves as our own copy', () => {
-      // No `code` and no `type`, so it did not come out of the SDK.
-      expect(parseBraintreeError(new Error('3DS liability did not shift')).audience).toBe('own');
+    it('marks a PaymentUserError as our own copy', () => {
+      expect(parseBraintreeError(new PaymentUserError('3DS liability did not shift')).audience).toBe('own');
+    });
+
+    it('appends a PaymentUserError logDetail to the log message only', () => {
+      const parsed = parseBraintreeError(new PaymentUserError('We could not find that card.', {
+        logDetail: 'no vault entry for card ending 4242',
+      }));
+
+      expect(parsed.message).toBe('We could not find that card.');
+      expect(parsed.logMessage).toBe('We could not find that card. (no vault entry for card ending 4242)');
+    });
+
+    it('does not trust a plain Error, which may be any failure at all', () => {
+      // The trap this replaced: inferring "ours" from the absence of braintree
+      // fields hands the buyer whatever an unrelated throw happened to say.
+      expect(parseBraintreeError(new Error('kaboom')).audience).toBe('opaque');
+    });
+
+    it('does not trust a FetchError from our own API', () => {
+      const fetchError = Object.assign(new Error('[POST] "/webapi/2/braintree/payments": 500 Internal Server Error'), {
+        statusCode: 500,
+      });
+
+      expect(parseBraintreeError(fetchError).audience).toBe('opaque');
+    });
+
+    it('does not trust the [object Object] fallback', () => {
+      // `message || code || type || String(error)` can only reach the last arm
+      // when nobody wrote a message, so it is never fit to render.
+      const parsed = parseBraintreeError({});
+
+      expect(parsed.message).toBe('[object Object]');
+      expect(parsed.audience).toBe('opaque');
     });
 
     it('trusts the SDK message only for CUSTOMER errors', () => {
@@ -624,7 +656,7 @@ describe('parseBraintreeError', () => {
 
 describe('paymentErrorCopy', () => {
   it('passes through a message we wrote ourselves', () => {
-    const copy = paymentErrorCopy(parseBraintreeError(new Error('3DS liability did not shift')));
+    const copy = paymentErrorCopy(parseBraintreeError(new PaymentUserError('3DS liability did not shift')));
 
     expect(copy).toEqual({ kind: 'verbatim', message: '3DS liability did not shift' });
   });

--- a/packages/sigil/src/index.spec.ts
+++ b/packages/sigil/src/index.spec.ts
@@ -8,6 +8,7 @@ import {
   parseQueryParam,
   parseUtmFromQuery,
   PAYMENT_LOG_ENDPOINT,
+  paymentErrorCopy,
   PaymentFailures,
   PaymentServerEvents,
   postPaymentLog,
@@ -563,9 +564,9 @@ describe('parseBraintreeError', () => {
     expect(parsed.code).toBeUndefined();
   });
 
-  it('stringifies a bare non-error rejection', () => {
+  it('stringifies a bare non-error rejection, and never shows it', () => {
     // The regression that produced `error_message: "26"` with nothing else.
-    expect(parseBraintreeError(26)).toEqual({ message: '26', logMessage: '26' });
+    expect(parseBraintreeError(26)).toEqual({ message: '26', logMessage: '26', audience: 'opaque' });
   });
 
   it('never returns an empty message, which the backend rejects with a 400', () => {
@@ -585,5 +586,78 @@ describe('parseBraintreeError', () => {
 
     expect(parsed.message).toBe('kept');
     expect(parsed.code).toBeUndefined();
+  });
+
+  describe('audience', () => {
+    it('marks an error we threw ourselves as our own copy', () => {
+      // No `code` and no `type`, so it did not come out of the SDK.
+      expect(parseBraintreeError(new Error('3DS liability did not shift')).audience).toBe('own');
+    });
+
+    it('trusts the SDK message only for CUSTOMER errors', () => {
+      const parsed = parseBraintreeError({
+        code: 'THREEDS_LOOKUP_VALIDATION_ERROR',
+        type: 'CUSTOMER',
+        message: 'The card number is not valid.',
+      });
+
+      expect(parsed.audience).toBe('customer');
+    });
+
+    it('separates network failures so they get retry copy', () => {
+      expect(parseBraintreeError({ code: 'CLIENT_GATEWAY_NETWORK', type: 'NETWORK' }).audience).toBe('network');
+    });
+
+    it.each(['MERCHANT', 'INTERNAL', 'UNKNOWN', 'SOMETHING_NEW'])('hides %s prose behind generic copy', (type) => {
+      expect(parseBraintreeError({ code: 'THREEDS_CARDINAL_SDK_ERROR', type, message: 'developer prose' }).audience).toBe('opaque');
+    });
+
+    it('is opaque when a code arrives with no type at all', () => {
+      expect(parseBraintreeError({ code: 'THREEDS_LOOKUP_ERROR' }).audience).toBe('opaque');
+    });
+
+    it('never trusts a bare string rejection', () => {
+      expect(parseBraintreeError('some third-party prose').audience).toBe('opaque');
+    });
+  });
+});
+
+describe('paymentErrorCopy', () => {
+  it('passes through a message we wrote ourselves', () => {
+    const copy = paymentErrorCopy(parseBraintreeError(new Error('3DS liability did not shift')));
+
+    expect(copy).toEqual({ kind: 'verbatim', message: '3DS liability did not shift' });
+  });
+
+  it('passes through a CUSTOMER message from the SDK', () => {
+    const copy = paymentErrorCopy(parseBraintreeError({
+      code: 'HOSTED_FIELDS_FIELDS_EMPTY',
+      type: 'CUSTOMER',
+      message: 'All fields are empty. Cannot tokenize empty card fields.',
+    }));
+
+    expect(copy).toEqual({ kind: 'verbatim', message: 'All fields are empty. Cannot tokenize empty card fields.' });
+  });
+
+  it('asks for connectivity copy on a network failure', () => {
+    const copy = paymentErrorCopy(parseBraintreeError({ code: 'CLIENT_GATEWAY_NETWORK', type: 'NETWORK' }));
+
+    expect(copy).toEqual({ kind: 'network' });
+  });
+
+  it('hides developer prose and offers the code as a support reference', () => {
+    const copy = paymentErrorCopy(parseBraintreeError({
+      code: 'THREEDS_CARDINAL_SDK_ERROR',
+      type: 'UNKNOWN',
+      message: 'Something went wrong.',
+      details: { originalError: { code: 26 } },
+    }));
+
+    expect(copy).toEqual({ kind: 'unexpected', code: 'THREEDS_CARDINAL_SDK_ERROR' });
+  });
+
+  it('omits the reference when there is no code to quote', () => {
+    // The `26` that started this: nothing to show, nothing to quote.
+    expect(paymentErrorCopy(parseBraintreeError(26))).toEqual({ kind: 'unexpected' });
   });
 });

--- a/packages/sigil/src/index.spec.ts
+++ b/packages/sigil/src/index.spec.ts
@@ -4,6 +4,7 @@ import {
   classifyCryptoTxError,
   createTrackingSession,
   monthsToPlanDuration,
+  parseBraintreeError,
   parseQueryParam,
   parseUtmFromQuery,
   PAYMENT_LOG_ENDPOINT,
@@ -516,5 +517,73 @@ describe('sigilEvents', () => {
     }
 
     expect(Object.keys(exhaustiveCheck)).toHaveLength(Object.keys(SigilEvents).length);
+  });
+});
+
+describe('parseBraintreeError', () => {
+  it('keeps the Cardinal original error out of the user-facing message', () => {
+    const parsed = parseBraintreeError({
+      code: 'THREEDS_CARDINAL_SDK_ERROR',
+      type: 'UNKNOWN',
+      message: 'Something went wrong.',
+      details: { originalError: { code: 26, description: 'Merchant configuration error' } },
+    });
+
+    expect(parsed.message).toBe('Something went wrong.');
+    expect(parsed.logMessage).toBe('Something went wrong. (cardinal 26: Merchant configuration error)');
+    expect(parsed.code).toBe('THREEDS_CARDINAL_SDK_ERROR');
+  });
+
+  it('surfaces a Cardinal code with no description', () => {
+    const parsed = parseBraintreeError({
+      code: 'THREEDS_CARDINAL_SDK_ERROR',
+      message: 'Something went wrong.',
+      details: { originalError: { code: 10011 } },
+    });
+
+    expect(parsed.logMessage).toBe('Something went wrong. (cardinal 10011)');
+  });
+
+  it('falls back to a nested error message when originalError is an Error', () => {
+    const parsed = parseBraintreeError({
+      code: 'THREEDS_JWT_AUTHENTICATION_FAILED',
+      message: 'Something went wrong authenticating the JWT from Cardinal',
+      details: { originalError: new Error('gateway 422') },
+    });
+
+    expect(parsed.logMessage).toBe('Something went wrong authenticating the JWT from Cardinal (gateway 422)');
+    expect(parsed.code).toBe('THREEDS_JWT_AUTHENTICATION_FAILED');
+  });
+
+  it('handles a plain Error with no braintree fields', () => {
+    const parsed = parseBraintreeError(new Error('3DS liability did not shift, please try again'));
+
+    expect(parsed.message).toBe('3DS liability did not shift, please try again');
+    expect(parsed.logMessage).toBe('3DS liability did not shift, please try again');
+    expect(parsed.code).toBeUndefined();
+  });
+
+  it('stringifies a bare non-error rejection', () => {
+    // The regression that produced `error_message: "26"` with nothing else.
+    expect(parseBraintreeError(26)).toEqual({ message: '26', logMessage: '26' });
+  });
+
+  it('never returns an empty message, which the backend rejects with a 400', () => {
+    expect(parseBraintreeError('').message).toBe('Unknown error');
+    expect(parseBraintreeError({}).message).toBe('[object Object]');
+    expect(parseBraintreeError(undefined).message).toBe('undefined');
+    expect(parseBraintreeError(null).message).toBe('null');
+  });
+
+  it('falls back to code, then type, when there is no message', () => {
+    expect(parseBraintreeError({ code: 'THREEDS_LOOKUP_ERROR' }).message).toBe('THREEDS_LOOKUP_ERROR');
+    expect(parseBraintreeError({ type: 'NETWORK' }).message).toBe('NETWORK');
+  });
+
+  it('ignores non-conforming field types rather than throwing', () => {
+    const parsed = parseBraintreeError({ code: 1234, message: 'kept' });
+
+    expect(parsed.message).toBe('kept');
+    expect(parsed.code).toBeUndefined();
   });
 });

--- a/packages/website/app/components/account/home/payment-methods/AddCardDialog.vue
+++ b/packages/website/app/components/account/home/payment-methods/AddCardDialog.vue
@@ -24,7 +24,7 @@ const logger = useLogger('add-card-dialog');
 
 const { addCard } = usePaymentCards();
 const { userMessageFor } = usePaymentErrorMessage();
-const { client, clientError, initializeClient, teardownClient } = useBraintreeClient();
+const { client, clientError, initializeClient, teardownClient } = useBraintreeClient('card');
 
 const isFormValid = logicAnd(cardFormValid, logicNot(isProcessing));
 
@@ -61,7 +61,7 @@ async function handleAddCard() {
     logger.error('Failed to add card:', caughtError);
     set(error, {
       title: t('common.error'),
-      message: userMessageFor(parseBraintreeError(caughtError)),
+      message: userMessageFor(parseBraintreeError(caughtError), 'card'),
     });
   }
   finally {

--- a/packages/website/app/components/account/home/payment-methods/AddCardDialog.vue
+++ b/packages/website/app/components/account/home/payment-methods/AddCardDialog.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
+import { parseBraintreeError } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { ref } from 'vue';
 import CardForm from '~/components/account/home/payment-methods/CardForm.vue';
 import { useBraintreeClient } from '~/modules/checkout/composables/use-braintree-client';
 import { usePaymentCards } from '~/modules/checkout/composables/use-payment-cards';
+import { usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
 import { useLogger } from '~/utils/use-logger';
 
 const showDialog = defineModel<boolean>({ required: true });
@@ -21,6 +23,7 @@ const { t } = useI18n({ useScope: 'global' });
 const logger = useLogger('add-card-dialog');
 
 const { addCard } = usePaymentCards();
+const { userMessageFor } = usePaymentErrorMessage();
 const { client, clientError, initializeClient, teardownClient } = useBraintreeClient();
 
 const isFormValid = logicAnd(cardFormValid, logicNot(isProcessing));
@@ -54,11 +57,11 @@ async function handleAddCard() {
     // Reset form state
     set(error, undefined);
   }
-  catch (caughtError: any) {
+  catch (caughtError: unknown) {
     logger.error('Failed to add card:', caughtError);
     set(error, {
       title: t('common.error'),
-      message: caughtError.message || t('common.error_occurred'),
+      message: userMessageFor(parseBraintreeError(caughtError)),
     });
   }
   finally {

--- a/packages/website/app/components/account/home/payment-methods/ThreeDSecureModal.vue
+++ b/packages/website/app/components/account/home/payment-methods/ThreeDSecureModal.vue
@@ -11,6 +11,8 @@ export interface ThreeDSecureVerificationData {
   cardToken: string;
   /** Identifies the card in the Braintree vault, which holds all of them. */
   cardLast4: string;
+  /** Disambiguates two vault entries that share a last four. */
+  cardExpiresAt: string;
   subscriptionData: Pick<Subscription, 'nextBillingAmount' | 'nextActionDate' | 'durationInMonths'>;
 }
 
@@ -69,10 +71,11 @@ async function startVerification(): Promise<void> {
   set(errorMessage, undefined);
 
   try {
-    const { cardToken, cardLast4, subscriptionData: { nextBillingAmount } } = verificationData;
+    const { cardToken, cardLast4, cardExpiresAt, subscriptionData: { nextBillingAmount } } = verificationData;
     await verifyAndSetDefaultCard({
       cardToken,
       cardLast4,
+      cardExpiresAt,
       amount: nextBillingAmount,
       onChallengeRequired: handleChallengeRequired,
       onVerificationComplete: handleVerificationComplete,

--- a/packages/website/app/components/account/home/payment-methods/ThreeDSecureModal.vue
+++ b/packages/website/app/components/account/home/payment-methods/ThreeDSecureModal.vue
@@ -9,6 +9,8 @@ import { formatCurrency } from '~/utils/text';
 
 export interface ThreeDSecureVerificationData {
   cardToken: string;
+  /** Identifies the card in the Braintree vault, which holds all of them. */
+  cardLast4: string;
   subscriptionData: Pick<Subscription, 'nextBillingAmount' | 'nextActionDate' | 'durationInMonths'>;
 }
 
@@ -67,19 +69,20 @@ async function startVerification(): Promise<void> {
   set(errorMessage, undefined);
 
   try {
-    const { cardToken, subscriptionData: { nextBillingAmount } } = verificationData;
-    await verifyAndSetDefaultCard(
+    const { cardToken, cardLast4, subscriptionData: { nextBillingAmount } } = verificationData;
+    await verifyAndSetDefaultCard({
       cardToken,
-      nextBillingAmount,
-      handleChallengeRequired,
-      handleVerificationComplete,
-    );
+      cardLast4,
+      amount: nextBillingAmount,
+      onChallengeRequired: handleChallengeRequired,
+      onVerificationComplete: handleVerificationComplete,
+    });
 
     emit('success');
     close();
   }
   catch (error: unknown) {
-    set(errorMessage, userMessageFor(parseBraintreeError(error)));
+    set(errorMessage, userMessageFor(parseBraintreeError(error), 'card'));
     emit('error', error instanceof Error ? error : new Error(String(error)));
   }
   finally {

--- a/packages/website/app/components/account/home/payment-methods/ThreeDSecureModal.vue
+++ b/packages/website/app/components/account/home/payment-methods/ThreeDSecureModal.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import type { Subscription } from '@rotki/card-payment-common/schemas/subscription';
+import { parseBraintreeError } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useCardThreeDSecure } from '~/modules/checkout/composables/use-card-three-d-secure';
+import { usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
 import { formatDate } from '~/utils/date';
 import { formatCurrency } from '~/utils/text';
 
@@ -29,6 +31,7 @@ const challengeShown = ref<boolean>(false);
 const errorMessage = ref<string>();
 
 const { verifyAndSetDefaultCard, teardown } = useCardThreeDSecure();
+const { userMessageFor } = usePaymentErrorMessage();
 
 const billingPeriod = computed<string>(() => {
   const { durationInMonths } = verificationData.subscriptionData;
@@ -76,8 +79,7 @@ async function startVerification(): Promise<void> {
     close();
   }
   catch (error: unknown) {
-    const message = error instanceof Error ? error.message : t('common.error_occurred');
-    set(errorMessage, message);
+    set(errorMessage, userMessageFor(parseBraintreeError(error)));
     emit('error', error instanceof Error ? error : new Error(String(error)));
   }
   finally {

--- a/packages/website/app/modules/checkout/composables/use-braintree-client.ts
+++ b/packages/website/app/modules/checkout/composables/use-braintree-client.ts
@@ -1,5 +1,5 @@
 import type { Client } from 'braintree-web/client';
-import { CheckoutPaymentMethods, CheckoutSteps, PaymentServerEvents } from '@rotki/sigil';
+import { CheckoutPaymentMethods, CheckoutSteps, parseBraintreeError, PaymentServerEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
@@ -61,15 +61,17 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
       set(client, newClient);
       return true;
     }
-    catch (error: any) {
+    catch (error: unknown) {
       logger.error('Failed to initialize Braintree client with token:', error);
+      const { message, logMessage, code } = parseBraintreeError(error);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.BRAINTREE_INIT_FAILED,
-        errorMessage: error.message || 'unknown',
+        errorMessage: logMessage,
+        errorCode: code,
         step: CheckoutSteps.INIT,
       });
-      set(clientError, error.message || t('subscription.error.init_error'));
+      set(clientError, message || t('subscription.error.init_error'));
       return false;
     }
     finally {
@@ -106,15 +108,17 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
       set(client, newClient);
       return true;
     }
-    catch (error: any) {
+    catch (error: unknown) {
       logger.error('Failed to initialize Braintree client:', error);
+      const { message, logMessage, code } = parseBraintreeError(error);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.BRAINTREE_INIT_FAILED,
-        errorMessage: error.message || 'unknown',
+        errorMessage: logMessage,
+        errorCode: code,
         step: CheckoutSteps.INIT,
       });
-      set(clientError, error.message || t('subscription.error.init_error'));
+      set(clientError, message || t('subscription.error.init_error'));
       return false;
     }
     finally {

--- a/packages/website/app/modules/checkout/composables/use-braintree-client.ts
+++ b/packages/website/app/modules/checkout/composables/use-braintree-client.ts
@@ -2,7 +2,7 @@ import type { Client } from 'braintree-web/client';
 import { CheckoutPaymentMethods, CheckoutSteps, parseBraintreeError, PaymentServerEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
-import { usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
+import { type PaymentErrorContext, usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
 import { usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { useLogger } from '~/utils/use-logger';
 
@@ -23,8 +23,11 @@ interface UseBraintreeClientReturn {
 /**
  * Braintree client composable for account management and checkout
  * Handles fetching client token and initializing Braintree client
+ *
+ * @param errorContext phrasing for `clientError`. The account pages use this
+ * client to save a card, where payment wording would be wrong.
  */
-export function useBraintreeClient(): UseBraintreeClientReturn {
+export function useBraintreeClient(errorContext: PaymentErrorContext = 'payment'): UseBraintreeClientReturn {
   const client = shallowRef<Client>();
   const clientError = ref<string>();
   const clientInitializing = shallowRef<boolean>(false);
@@ -73,7 +76,7 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
         errorCode: parsed.code,
         step: CheckoutSteps.INIT,
       });
-      set(clientError, userMessageFor(parsed));
+      set(clientError, userMessageFor(parsed, errorContext));
       return false;
     }
     finally {
@@ -120,7 +123,7 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
         errorCode: parsed.code,
         step: CheckoutSteps.INIT,
       });
-      set(clientError, userMessageFor(parsed));
+      set(clientError, userMessageFor(parsed, errorContext));
       return false;
     }
     finally {

--- a/packages/website/app/modules/checkout/composables/use-braintree-client.ts
+++ b/packages/website/app/modules/checkout/composables/use-braintree-client.ts
@@ -2,6 +2,7 @@ import type { Client } from 'braintree-web/client';
 import { CheckoutPaymentMethods, CheckoutSteps, parseBraintreeError, PaymentServerEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
+import { usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
 import { usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { useLogger } from '~/utils/use-logger';
 
@@ -31,6 +32,7 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
   const logger = useLogger('braintree-client');
   const { fetchWithCsrf } = useFetchWithCsrf();
   const { logPaymentEvent } = usePaymentLogger();
+  const { userMessageFor } = usePaymentErrorMessage();
   const { t } = useI18n({ useScope: 'global' });
 
   /**
@@ -63,15 +65,15 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
     }
     catch (error: unknown) {
       logger.error('Failed to initialize Braintree client with token:', error);
-      const { message, logMessage, code } = parseBraintreeError(error);
+      const parsed = parseBraintreeError(error);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.BRAINTREE_INIT_FAILED,
-        errorMessage: logMessage,
-        errorCode: code,
+        errorMessage: parsed.logMessage,
+        errorCode: parsed.code,
         step: CheckoutSteps.INIT,
       });
-      set(clientError, message || t('subscription.error.init_error'));
+      set(clientError, userMessageFor(parsed));
       return false;
     }
     finally {
@@ -110,15 +112,15 @@ export function useBraintreeClient(): UseBraintreeClientReturn {
     }
     catch (error: unknown) {
       logger.error('Failed to initialize Braintree client:', error);
-      const { message, logMessage, code } = parseBraintreeError(error);
+      const parsed = parseBraintreeError(error);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.BRAINTREE_INIT_FAILED,
-        errorMessage: logMessage,
-        errorCode: code,
+        errorMessage: parsed.logMessage,
+        errorCode: parsed.code,
         step: CheckoutSteps.INIT,
       });
-      set(clientError, message || t('subscription.error.init_error'));
+      set(clientError, userMessageFor(parsed));
       return false;
     }
     finally {

--- a/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
@@ -1,6 +1,6 @@
 import type { Client } from 'braintree-web/client';
 import type { ThreeDSecure, ThreeDSecureVerificationData, ThreeDSecureVerifyOptions } from 'braintree-web/three-d-secure';
-import { CheckoutPaymentMethods, CheckoutSteps, PaymentServerEvents } from '@rotki/sigil';
+import { CheckoutPaymentMethods, CheckoutSteps, parseBraintreeError, PaymentServerEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { usePaymentCards } from '~/modules/checkout/composables/use-payment-cards';
@@ -192,10 +192,12 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     }
     catch (error: unknown) {
       logger.error('3DS verification failed:', error);
+      const { logMessage, code } = parseBraintreeError(error);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.THREE_DS_VERIFICATION_FAILED,
-        errorMessage: error instanceof Error ? error.message : String(error),
+        errorMessage: logMessage,
+        errorCode: code,
         step: CheckoutSteps.VERIFY,
       });
       throw error;

--- a/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
@@ -15,14 +15,22 @@ interface BraintreeClientTokenResponse {
   braintreeClientToken: string;
 }
 
+export interface CardVerificationRequest {
+  cardToken: string;
+  /**
+   * Last four digits of the card being verified. The vault holds every card
+   * the customer has saved, so this is what ties the BIN sent to 3DS to the
+   * card the nonce was created from.
+   */
+  cardLast4: string;
+  amount: number;
+  onChallengeRequired: () => void;
+  onVerificationComplete?: () => void;
+}
+
 interface UseCardThreeDSecureReturn {
-  initialize: (cardToken: string, amount: number, braintreeToken: string, onChallengeRequired: () => void) => Promise<string>;
-  verifyAndSetDefaultCard: (
-    cardToken: string,
-    amount: number,
-    onChallengeRequired: () => void,
-    onVerificationComplete?: () => void,
-  ) => Promise<void>;
+  initialize: (request: Omit<CardVerificationRequest, 'onVerificationComplete'> & { braintreeToken: string }) => Promise<string>;
+  verifyAndSetDefaultCard: (request: CardVerificationRequest) => Promise<void>;
   teardown: () => void;
 }
 
@@ -100,7 +108,16 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     return { iframeHandler, lookupHandler };
   }
 
-  async function fetchPaymentMethodBin(client: Client): Promise<string> {
+  /**
+   * Find the BIN of the card being verified.
+   *
+   * Matching on `lastFour` rather than taking the first credit card in the
+   * vault matters once a customer has more than one saved: 3DS would otherwise
+   * look up a different card's issuer than the one the nonce came from, and
+   * both the challenge and the liability-shift decision would be made against
+   * the wrong card.
+   */
+  async function fetchPaymentMethodBin(client: Client, cardLast4: string): Promise<string> {
     logger.debug('Creating VaultManager instance');
     const { create: createVaultManager } = await import('braintree-web/vault-manager');
     const vmInstance = await createVaultManager({ client });
@@ -109,12 +126,17 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
       const paymentMethods = await vmInstance.fetchPaymentMethods();
       logger.debug(`Fetched ${paymentMethods.length} payment methods from vault`);
 
-      const paymentMethod = paymentMethods.find(({ type }) => type === 'CreditCard');
+      const paymentMethod = paymentMethods.find(({ type, details }) =>
+        type === 'CreditCard' &&
+        details &&
+        'lastFour' in details &&
+        details.lastFour === cardLast4,
+      );
       logger.debug('Found payment method:', paymentMethod);
 
       if (!paymentMethod?.details || !('bin' in paymentMethod.details) || !paymentMethod.details.bin) {
-        logger.error('BIN not found in payment method details');
-        throw new Error('BIN not found in payment method details');
+        logger.error(`BIN not found for card ending ${cardLast4}`);
+        throw new Error('We could not find that card. Please refresh the page and try again.');
       }
 
       const bin = paymentMethod.details.bin;
@@ -166,12 +188,8 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     return paymentMethodNonce;
   }
 
-  async function initialize(
-    cardToken: string,
-    amount: number,
-    braintreeToken: string,
-    onChallengeRequired: () => void,
-  ): Promise<string> {
+  async function initialize({ cardToken, cardLast4, amount, braintreeToken, onChallengeRequired }:
+  Omit<CardVerificationRequest, 'onVerificationComplete'> & { braintreeToken: string }): Promise<string> {
     const client = await createBraintreeClient(braintreeToken);
 
     try {
@@ -182,7 +200,7 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
         instance.on('lookup-complete', lookupHandler);
         instance.on('authentication-iframe-available', iframeHandler);
 
-        const bin = await fetchPaymentMethodBin(client);
+        const bin = await fetchPaymentMethodBin(client, cardLast4);
         return await verifyCardWith3DS(instance, cardToken, bin, amount);
       }
       finally {
@@ -204,12 +222,7 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     }
   }
 
-  async function verifyAndSetDefaultCard(
-    cardToken: string,
-    amount: number,
-    onChallengeRequired: () => void,
-    onVerificationComplete?: () => void,
-  ): Promise<void> {
+  async function verifyAndSetDefaultCard({ cardToken, cardLast4, amount, onChallengeRequired, onVerificationComplete }: CardVerificationRequest): Promise<void> {
     logger.debug('Starting complete 3DS verification and card setup flow');
 
     // Fetch Braintree client token
@@ -221,12 +234,13 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     );
 
     // Run 3DS verification
-    const enrichedNonce = await initialize(
+    const enrichedNonce = await initialize({
       cardToken,
+      cardLast4,
       amount,
-      tokenResponse.braintreeClientToken,
+      braintreeToken: tokenResponse.braintreeClientToken,
       onChallengeRequired,
-    );
+    });
 
     // Notify that verification is complete, now setting card as default
     logger.debug('3DS verification complete, setting card as default');

--- a/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-card-three-d-secure.ts
@@ -1,6 +1,6 @@
 import type { Client } from 'braintree-web/client';
 import type { ThreeDSecure, ThreeDSecureVerificationData, ThreeDSecureVerifyOptions } from 'braintree-web/three-d-secure';
-import { CheckoutPaymentMethods, CheckoutSteps, parseBraintreeError, PaymentServerEvents } from '@rotki/sigil';
+import { CheckoutPaymentMethods, CheckoutSteps, parseBraintreeError, PaymentServerEvents, PaymentUserError } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { usePaymentCards } from '~/modules/checkout/composables/use-payment-cards';
@@ -23,6 +23,8 @@ export interface CardVerificationRequest {
    * card the nonce was created from.
    */
   cardLast4: string;
+  /** Card expiry as `MM/YY`, used to separate two vault entries sharing a last four. */
+  cardExpiresAt: string;
   amount: number;
   onChallengeRequired: () => void;
   onVerificationComplete?: () => void;
@@ -32,6 +34,31 @@ interface UseCardThreeDSecureReturn {
   initialize: (request: Omit<CardVerificationRequest, 'onVerificationComplete'> & { braintreeToken: string }) => Promise<string>;
   verifyAndSetDefaultCard: (request: CardVerificationRequest) => Promise<void>;
   teardown: () => void;
+}
+
+/**
+ * Compare a vault entry's expiry against a `SavedCard.expiresAt` (`MM/YY` or
+ * `MM/YYYY`). Two-digit years are compared on their last two digits, which is
+ * all a card prints.
+ */
+function expiryMatches(details: object, expiresAt: string): boolean {
+  const parts = /^(\d{2})\/(\d{2,4})$/.exec(expiresAt);
+  if (!parts)
+    return false;
+
+  // Narrowed with `in` rather than a cast: `details` is a union of every
+  // payment-method shape braintree-web can return, and only the card ones
+  // carry an expiry.
+  if (!('expirationMonth' in details) || !('expirationYear' in details))
+    return false;
+
+  const [, month, year] = parts;
+  const { expirationMonth: vaultMonth, expirationYear: vaultYear } = details;
+
+  if (typeof vaultMonth !== 'string' || typeof vaultYear !== 'string')
+    return false;
+
+  return vaultMonth.padStart(2, '0') === month && vaultYear.slice(-2) === year!.slice(-2);
 }
 
 export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
@@ -111,13 +138,17 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
   /**
    * Find the BIN of the card being verified.
    *
-   * Matching on `lastFour` rather than taking the first credit card in the
-   * vault matters once a customer has more than one saved: 3DS would otherwise
-   * look up a different card's issuer than the one the nonce came from, and
-   * both the challenge and the liability-shift decision would be made against
-   * the wrong card.
+   * Matching rather than taking the first credit card in the vault matters once
+   * a customer has more than one saved: 3DS would otherwise look up a different
+   * card's issuer than the one the nonce came from, and both the challenge and
+   * the liability-shift decision would be made against the wrong card.
+   *
+   * The vault payload carries no vault token (`FetchPaymentMethodsPayload` is
+   * nonce/type/details/description/binData), so `lastFour` is the coarsest key
+   * available and expiry is what separates two cards that share it. If both
+   * still match, it is the same card saved twice and the BIN is identical.
    */
-  async function fetchPaymentMethodBin(client: Client, cardLast4: string): Promise<string> {
+  async function fetchPaymentMethodBin(client: Client, cardLast4: string, cardExpiresAt: string): Promise<string> {
     logger.debug('Creating VaultManager instance');
     const { create: createVaultManager } = await import('braintree-web/vault-manager');
     const vmInstance = await createVaultManager({ client });
@@ -126,17 +157,24 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
       const paymentMethods = await vmInstance.fetchPaymentMethods();
       logger.debug(`Fetched ${paymentMethods.length} payment methods from vault`);
 
-      const paymentMethod = paymentMethods.find(({ type, details }) =>
+      const matches = paymentMethods.filter(({ type, details }) =>
         type === 'CreditCard' &&
         details &&
         'lastFour' in details &&
         details.lastFour === cardLast4,
       );
+
+      const paymentMethod = matches.length > 1
+        ? matches.find(({ details }) => details && expiryMatches(details, cardExpiresAt)) ?? matches[0]
+        : matches[0];
       logger.debug('Found payment method:', paymentMethod);
 
       if (!paymentMethod?.details || !('bin' in paymentMethod.details) || !paymentMethod.details.bin) {
         logger.error(`BIN not found for card ending ${cardLast4}`);
-        throw new Error('We could not find that card. Please refresh the page and try again.');
+        throw new PaymentUserError(
+          'We could not find that card. Please refresh the page and try again.',
+          { logDetail: `no vault entry for card ending ${cardLast4} among ${paymentMethods.length} methods` },
+        );
       }
 
       const bin = paymentMethod.details.bin;
@@ -178,7 +216,7 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     logger.debug('3DS liability shift possible:', liabilityShiftPossible);
 
     if (liabilityShiftPossible && !liabilityShifted) {
-      throw new Error('3DS liability did not shift, please try again');
+      throw new PaymentUserError('3DS liability did not shift, please try again');
     }
 
     if (!paymentMethodNonce) {
@@ -188,7 +226,7 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     return paymentMethodNonce;
   }
 
-  async function initialize({ cardToken, cardLast4, amount, braintreeToken, onChallengeRequired }:
+  async function initialize({ cardToken, cardLast4, cardExpiresAt, amount, braintreeToken, onChallengeRequired }:
   Omit<CardVerificationRequest, 'onVerificationComplete'> & { braintreeToken: string }): Promise<string> {
     const client = await createBraintreeClient(braintreeToken);
 
@@ -200,7 +238,7 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
         instance.on('lookup-complete', lookupHandler);
         instance.on('authentication-iframe-available', iframeHandler);
 
-        const bin = await fetchPaymentMethodBin(client, cardLast4);
+        const bin = await fetchPaymentMethodBin(client, cardLast4, cardExpiresAt);
         return await verifyCardWith3DS(instance, cardToken, bin, amount);
       }
       finally {
@@ -222,7 +260,7 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     }
   }
 
-  async function verifyAndSetDefaultCard({ cardToken, cardLast4, amount, onChallengeRequired, onVerificationComplete }: CardVerificationRequest): Promise<void> {
+  async function verifyAndSetDefaultCard({ cardToken, cardLast4, cardExpiresAt, amount, onChallengeRequired, onVerificationComplete }: CardVerificationRequest): Promise<void> {
     logger.debug('Starting complete 3DS verification and card setup flow');
 
     // Fetch Braintree client token
@@ -237,6 +275,7 @@ export function useCardThreeDSecure(): UseCardThreeDSecureReturn {
     const enrichedNonce = await initialize({
       cardToken,
       cardLast4,
+      cardExpiresAt,
       amount,
       braintreeToken: tokenResponse.braintreeClientToken,
       onChallengeRequired,

--- a/packages/website/app/modules/checkout/composables/use-payment-error-message.ts
+++ b/packages/website/app/modules/checkout/composables/use-payment-error-message.ts
@@ -1,0 +1,32 @@
+import { type ParsedPaymentError, paymentErrorCopy } from '@rotki/sigil';
+
+interface UsePaymentErrorMessageReturn {
+  userMessageFor: (parsed: ParsedPaymentError) => string;
+}
+
+/**
+ * Translate the copy `paymentErrorCopy` picked for a payment error.
+ *
+ * The decision, above all whether the SDK's own message may be rendered at
+ * all, lives in sigil so the card-payment SPA reaches the same conclusion
+ * through `userPaymentMessage`. This only supplies the words.
+ */
+export function usePaymentErrorMessage(): UsePaymentErrorMessageReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  function userMessageFor(parsed: ParsedPaymentError): string {
+    const copy = paymentErrorCopy(parsed);
+
+    if (copy.kind === 'verbatim')
+      return copy.message;
+
+    if (copy.kind === 'network')
+      return t('subscription.error.network_failure');
+
+    return copy.code
+      ? t('subscription.error.unexpected_failure_with_reference', { code: copy.code })
+      : t('subscription.error.unexpected_failure');
+  }
+
+  return { userMessageFor };
+}

--- a/packages/website/app/modules/checkout/composables/use-payment-error-message.ts
+++ b/packages/website/app/modules/checkout/composables/use-payment-error-message.ts
@@ -1,7 +1,14 @@
 import { type ParsedPaymentError, paymentErrorCopy } from '@rotki/sigil';
 
+/**
+ * What the buyer was doing when the error happened. Nothing is being charged
+ * in the `card` flows: they save a card or re-authorise an existing one, so
+ * "we couldn't complete your payment" would be both wrong and alarming.
+ */
+export type PaymentErrorContext = 'payment' | 'card';
+
 interface UsePaymentErrorMessageReturn {
-  userMessageFor: (parsed: ParsedPaymentError) => string;
+  userMessageFor: (parsed: ParsedPaymentError, context?: PaymentErrorContext) => string;
 }
 
 /**
@@ -14,18 +21,31 @@ interface UsePaymentErrorMessageReturn {
 export function usePaymentErrorMessage(): UsePaymentErrorMessageReturn {
   const { t } = useI18n({ useScope: 'global' });
 
-  function userMessageFor(parsed: ParsedPaymentError): string {
+  function cardMessage(copy: Exclude<ReturnType<typeof paymentErrorCopy>, { kind: 'verbatim' }>): string {
+    if (copy.kind === 'network')
+      return t('subscription.error.card.network_failure');
+
+    return copy.code
+      ? t('subscription.error.card.unexpected_failure_with_reference', { code: copy.code })
+      : t('subscription.error.card.unexpected_failure');
+  }
+
+  function paymentMessage(copy: Exclude<ReturnType<typeof paymentErrorCopy>, { kind: 'verbatim' }>): string {
+    if (copy.kind === 'network')
+      return t('subscription.error.payment.network_failure');
+
+    return copy.code
+      ? t('subscription.error.payment.unexpected_failure_with_reference', { code: copy.code })
+      : t('subscription.error.payment.unexpected_failure');
+  }
+
+  function userMessageFor(parsed: ParsedPaymentError, context: PaymentErrorContext = 'payment'): string {
     const copy = paymentErrorCopy(parsed);
 
     if (copy.kind === 'verbatim')
       return copy.message;
 
-    if (copy.kind === 'network')
-      return t('subscription.error.network_failure');
-
-    return copy.code
-      ? t('subscription.error.unexpected_failure_with_reference', { code: copy.code })
-      : t('subscription.error.unexpected_failure');
+    return context === 'card' ? cardMessage(copy) : paymentMessage(copy);
   }
 
   return { userMessageFor };

--- a/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
+++ b/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
@@ -3,7 +3,7 @@ import type { PayPalCheckout } from 'braintree-web';
 import type { DeepReadonly, Ref } from 'vue';
 import { ActionResultResponseSchema } from '@rotki/card-payment-common/schemas/api';
 import { convertKeys } from '@rotki/card-payment-common/utils/object';
-import { CheckoutPaymentMethods, CheckoutSteps, PaymentServerEvents } from '@rotki/sigil';
+import { CheckoutPaymentMethods, CheckoutSteps, parseBraintreeError, PaymentServerEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { FetchError } from 'ofetch';
 import { useAccountRefresh } from '~/composables/use-app-events';
@@ -135,18 +135,20 @@ export function usePaypalPaymentFlow(options: UsePaypalPaymentFlowOptions = {}):
       set(initialized, true);
       return { success: true };
     }
-    catch (error: any) {
+    catch (error: unknown) {
       logger.error('Failed to initialize PayPal SDK:', error);
       const ctx = getContext();
+      const { message, logMessage, code } = parseBraintreeError(error);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.PAYPAL,
         event: PaymentServerEvents.PAYPAL_SDK_INIT_FAILED,
-        errorMessage: error.message || 'unknown',
+        errorMessage: logMessage,
+        errorCode: code,
         step: CheckoutSteps.INIT,
         planId: ctx.planId,
         isUpgrade: ctx.isUpgrade,
       });
-      return { success: false, error: error.message };
+      return { success: false, error: message };
     }
   }
 
@@ -180,13 +182,15 @@ export function usePaypalPaymentFlow(options: UsePaypalPaymentFlowOptions = {}):
           callbacks.onPaymentSuccess(vaultedNonce);
           return { nonce: vaultedNonce, tokenResponse };
         }
-        catch (error: any) {
-          callbacks.onPaymentError(error?.message ?? String(error));
+        catch (error: unknown) {
+          const { message, logMessage, code } = parseBraintreeError(error);
+          callbacks.onPaymentError(message);
           const ctx = getContext();
           logPaymentEvent({
             paymentMethod: CheckoutPaymentMethods.PAYPAL,
             event: PaymentServerEvents.PAYPAL_PAYMENT_ERROR,
-            errorMessage: error?.message ?? String(error),
+            errorMessage: logMessage,
+            errorCode: code,
             step: CheckoutSteps.CALLBACK,
             planId: ctx.planId,
             isUpgrade: ctx.isUpgrade,

--- a/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
+++ b/packages/website/app/modules/checkout/composables/use-paypal-payment-flow.ts
@@ -9,6 +9,7 @@ import { FetchError } from 'ofetch';
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { useFetchWithCsrf } from '~/composables/use-fetch-with-csrf';
 import { useBraintreeClient } from '~/modules/checkout/composables/use-braintree-client';
+import { usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
 import { usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { usePaypalApi } from '~/modules/checkout/composables/use-paypal-api';
 import { assert } from '~/utils/assert';
@@ -85,6 +86,7 @@ export function usePaypalPaymentFlow(options: UsePaypalPaymentFlowOptions = {}):
   const { requestRefresh } = useAccountRefresh();
   const logger = useLogger('paypal-payment-flow');
   const { logPaymentEvent } = usePaymentLogger();
+  const { userMessageFor } = usePaymentErrorMessage();
 
   function getContext(): PaypalTrackingContext {
     return options.getTrackingContext?.() ?? { isUpgrade: false };
@@ -138,17 +140,17 @@ export function usePaypalPaymentFlow(options: UsePaypalPaymentFlowOptions = {}):
     catch (error: unknown) {
       logger.error('Failed to initialize PayPal SDK:', error);
       const ctx = getContext();
-      const { message, logMessage, code } = parseBraintreeError(error);
+      const parsed = parseBraintreeError(error);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.PAYPAL,
         event: PaymentServerEvents.PAYPAL_SDK_INIT_FAILED,
-        errorMessage: logMessage,
-        errorCode: code,
+        errorMessage: parsed.logMessage,
+        errorCode: parsed.code,
         step: CheckoutSteps.INIT,
         planId: ctx.planId,
         isUpgrade: ctx.isUpgrade,
       });
-      return { success: false, error: message };
+      return { success: false, error: userMessageFor(parsed) };
     }
   }
 
@@ -183,14 +185,14 @@ export function usePaypalPaymentFlow(options: UsePaypalPaymentFlowOptions = {}):
           return { nonce: vaultedNonce, tokenResponse };
         }
         catch (error: unknown) {
-          const { message, logMessage, code } = parseBraintreeError(error);
-          callbacks.onPaymentError(message);
+          const parsed = parseBraintreeError(error);
+          callbacks.onPaymentError(userMessageFor(parsed));
           const ctx = getContext();
           logPaymentEvent({
             paymentMethod: CheckoutPaymentMethods.PAYPAL,
             event: PaymentServerEvents.PAYPAL_PAYMENT_ERROR,
-            errorMessage: logMessage,
-            errorCode: code,
+            errorMessage: parsed.logMessage,
+            errorCode: parsed.code,
             step: CheckoutSteps.CALLBACK,
             planId: ctx.planId,
             isUpgrade: ctx.isUpgrade,

--- a/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
@@ -7,7 +7,7 @@ import {
   ThreeDSecureParamsSchema,
   type ThreeDSecureState,
 } from '@rotki/card-payment-common/schemas/three-d-secure';
-import { CheckoutPaymentMethods, CheckoutSteps, monthsToPlanDuration, PaymentServerEvents, SigilEvents } from '@rotki/sigil';
+import { CheckoutPaymentMethods, CheckoutSteps, monthsToPlanDuration, parseBraintreeError, PaymentServerEvents, SigilEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useAccountRefresh } from '~/composables/use-app-events';
@@ -109,15 +109,17 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
       set(state, 'ready');
       logger.info('3D Secure initialized successfully');
     }
-    catch (initError: any) {
-      const errorMsg = `Initialization failed: ${initError.message}`;
+    catch (initError: unknown) {
+      const { message, logMessage, code } = parseBraintreeError(initError);
+      const errorMsg = `Initialization failed: ${message}`;
       set(error, errorMsg);
       set(state, 'error');
       logger.error(errorMsg, initError);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.THREE_DS_VERIFICATION_FAILED,
-        errorMessage: initError.message || 'unknown',
+        errorMessage: `Initialization failed: ${logMessage}`,
+        errorCode: code,
         step: CheckoutSteps.INIT,
         planId: params.planId,
         isUpgrade: !!params.upgradeSubId,
@@ -221,17 +223,18 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
         throw new Error(errorMsg);
       }
     }
-    catch (verifyError: any) {
+    catch (verifyError: unknown) {
       set(challengeVisible, false);
       set(state, 'error');
-      const errorMsg = verifyError.message || 'Verification failed';
+      const { message, logMessage, code } = parseBraintreeError(verifyError);
 
-      set(error, errorMsg);
+      set(error, message);
       logger.error('3D Secure verification error:', verifyError);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.THREE_DS_VERIFICATION_FAILED,
-        errorMessage: errorMsg,
+        errorMessage: logMessage,
+        errorCode: code,
         step: CheckoutSteps.VERIFY,
         planId: params.planId,
         isUpgrade: !!params.upgradeSubId,

--- a/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
@@ -12,6 +12,7 @@ import { get, set } from '@vueuse/shared';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useAccountRefresh } from '~/composables/use-app-events';
 import { usePaymentApi } from '~/modules/checkout/composables/use-payment-api';
+import { usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
 import { usePaymentLogger } from '~/modules/checkout/composables/use-payment-logger';
 import { PAYMENT_COMPLETED_KEY } from '~/modules/checkout/constants';
 import { PaymentError } from '~/types/codes';
@@ -37,6 +38,7 @@ interface UseThreeDSecureReturn {
 export function useThreeDSecure(): UseThreeDSecureReturn {
   const logger = useLogger('three-d-secure');
   const { logPaymentEvent } = usePaymentLogger();
+  const { userMessageFor } = usePaymentErrorMessage();
   const { chronicle } = useSigilEvents();
 
   const state = shallowRef<ThreeDSecureState>('initializing');
@@ -110,16 +112,15 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
       logger.info('3D Secure initialized successfully');
     }
     catch (initError: unknown) {
-      const { message, logMessage, code } = parseBraintreeError(initError);
-      const errorMsg = `Initialization failed: ${message}`;
-      set(error, errorMsg);
+      const parsed = parseBraintreeError(initError);
+      set(error, userMessageFor(parsed));
       set(state, 'error');
-      logger.error(errorMsg, initError);
+      logger.error(`Initialization failed: ${parsed.message}`, initError);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.THREE_DS_VERIFICATION_FAILED,
-        errorMessage: `Initialization failed: ${logMessage}`,
-        errorCode: code,
+        errorMessage: `Initialization failed: ${parsed.logMessage}`,
+        errorCode: parsed.code,
         step: CheckoutSteps.INIT,
         planId: params.planId,
         isUpgrade: !!params.upgradeSubId,
@@ -226,15 +227,15 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
     catch (verifyError: unknown) {
       set(challengeVisible, false);
       set(state, 'error');
-      const { message, logMessage, code } = parseBraintreeError(verifyError);
+      const parsed = parseBraintreeError(verifyError);
 
-      set(error, message);
+      set(error, userMessageFor(parsed));
       logger.error('3D Secure verification error:', verifyError);
       logPaymentEvent({
         paymentMethod: CheckoutPaymentMethods.CARD,
         event: PaymentServerEvents.THREE_DS_VERIFICATION_FAILED,
-        errorMessage: logMessage,
-        errorCode: code,
+        errorMessage: parsed.logMessage,
+        errorCode: parsed.code,
         step: CheckoutSteps.VERIFY,
         planId: params.planId,
         isUpgrade: !!params.upgradeSubId,

--- a/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
+++ b/packages/website/app/modules/checkout/composables/use-three-d-secure.ts
@@ -7,7 +7,7 @@ import {
   ThreeDSecureParamsSchema,
   type ThreeDSecureState,
 } from '@rotki/card-payment-common/schemas/three-d-secure';
-import { CheckoutPaymentMethods, CheckoutSteps, monthsToPlanDuration, parseBraintreeError, PaymentServerEvents, SigilEvents } from '@rotki/sigil';
+import { CheckoutPaymentMethods, CheckoutSteps, monthsToPlanDuration, parseBraintreeError, PaymentServerEvents, PaymentUserError, SigilEvents } from '@rotki/sigil';
 import { get, set } from '@vueuse/shared';
 import { useSigilEvents } from '~/composables/chronicling/use-sigil-events';
 import { useAccountRefresh } from '~/composables/use-app-events';
@@ -140,6 +140,9 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
 
     set(state, 'verifying');
     set(error, '');
+    // Set once a specific failure has already been reported, so the catch does
+    // not log the same failure a second time under a generic event.
+    let failureLogged = false;
     const lookupHandler = (_data: any, next: any) => {
       logger.debug('3D Secure lookup complete');
       next();
@@ -221,7 +224,11 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
           isUpgrade: !!params.upgradeSubId,
           discountApplied: params.discountTrackingInfo !== undefined,
         });
-        throw new Error(errorMsg);
+        // Logged as a liability-shift failure right above. The catch below must
+        // not log it again as a generic verification failure, or every one of
+        // these is counted twice.
+        failureLogged = true;
+        throw new PaymentUserError(errorMsg);
       }
     }
     catch (verifyError: unknown) {
@@ -231,16 +238,18 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
 
       set(error, userMessageFor(parsed));
       logger.error('3D Secure verification error:', verifyError);
-      logPaymentEvent({
-        paymentMethod: CheckoutPaymentMethods.CARD,
-        event: PaymentServerEvents.THREE_DS_VERIFICATION_FAILED,
-        errorMessage: parsed.logMessage,
-        errorCode: parsed.code,
-        step: CheckoutSteps.VERIFY,
-        planId: params.planId,
-        isUpgrade: !!params.upgradeSubId,
-        discountApplied: params.discountTrackingInfo !== undefined,
-      });
+      if (!failureLogged) {
+        logPaymentEvent({
+          paymentMethod: CheckoutPaymentMethods.CARD,
+          event: PaymentServerEvents.THREE_DS_VERIFICATION_FAILED,
+          errorMessage: parsed.logMessage,
+          errorCode: parsed.code,
+          step: CheckoutSteps.VERIFY,
+          planId: params.planId,
+          isUpgrade: !!params.upgradeSubId,
+          discountApplied: params.discountTrackingInfo !== undefined,
+        });
+      }
       throw verifyError;
     }
     finally {
@@ -278,8 +287,13 @@ export function useThreeDSecure(): UseThreeDSecureReturn {
       if (result.code === PaymentError.SERVER_ERROR) {
         requestRefresh();
         set(serverError, true);
+        // The full-screen overlay explains this one; the raw message is a 5xx
+        // dump, so it stays opaque.
+        throw new Error(result.error.message);
       }
-      throw new Error(result.error.message);
+      // A 400 carries the backend's own `ActionResultResponse.message`, which is
+      // written for the customer ("Do Not Honor", declines, validation).
+      throw new PaymentUserError(result.error.message);
     }
 
     // Use discount tracking info passed from card payment page via session storage

--- a/packages/website/app/pages/home/saved-cards.vue
+++ b/packages/website/app/pages/home/saved-cards.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { SavedCard } from '@rotki/card-payment-common/schemas/payment';
 import { PaymentProvider } from '@rotki/card-payment-common/schemas/subscription';
+import { parseBraintreeError } from '@rotki/sigil';
 import { objectPick } from '@vueuse/core';
 import { get, set } from '@vueuse/shared';
 import AddCardDialog from '~/components/account/home/payment-methods/AddCardDialog.vue';
@@ -12,6 +13,7 @@ import { useUserSubscriptions } from '~/composables/subscription/use-user-subscr
 import { useEmailConfirmedCookie } from '~/composables/use-fetch-with-csrf';
 import { usePageSeoNoIndex } from '~/composables/use-page-seo';
 import { usePaymentCards } from '~/modules/checkout/composables/use-payment-cards';
+import { usePaymentErrorMessage } from '~/modules/checkout/composables/use-payment-error-message';
 import { useMainStore } from '~/store';
 import { useLogger } from '~/utils/use-logger';
 
@@ -30,6 +32,7 @@ definePageMeta({
 
 const { t } = useI18n({ useScope: 'global' });
 const logger = useLogger('payment-methods');
+const { userMessageFor } = usePaymentErrorMessage();
 
 const showAddCardDialog = ref<boolean>(false);
 const showDeleteDialog = ref<boolean>(false);
@@ -103,6 +106,7 @@ async function initiate3DSVerification(card: SavedCard, isReauth: boolean): Prom
 
     set(verificationData, {
       cardToken: card.token,
+      cardLast4: card.last4,
       subscriptionData: objectPick(active, ['nextBillingAmount', 'nextActionDate', 'durationInMonths']),
     });
     set(showThreeDSecureModal, true);
@@ -140,7 +144,7 @@ function handleThreeDSecureError(verifyError: Error): void {
   logger.error('3DS verification failed:', verifyError);
   set(error, {
     title: t('common.error'),
-    message: verifyError.message || t('common.error_occurred'),
+    message: userMessageFor(parseBraintreeError(verifyError), 'card'),
   });
   set(showThreeDSecureModal, false);
   set(verificationData, undefined);

--- a/packages/website/app/pages/home/saved-cards.vue
+++ b/packages/website/app/pages/home/saved-cards.vue
@@ -107,6 +107,7 @@ async function initiate3DSVerification(card: SavedCard, isReauth: boolean): Prom
     set(verificationData, {
       cardToken: card.token,
       cardLast4: card.last4,
+      cardExpiresAt: card.expiresAt,
       subscriptionData: objectPick(active, ['nextBillingAmount', 'nextActionDate', 'durationInMonths']),
     });
     set(showThreeDSecureModal, true);

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -1269,9 +1269,16 @@
     "error": {
       "init_error": "Initialization Error",
       "payment_failure": "Payment Failure",
-      "network_failure": "We couldn't reach the payment provider. Check your connection and try again.",
-      "unexpected_failure": "We couldn't complete your payment. Please try again, or contact support if it keeps happening.",
-      "unexpected_failure_with_reference": "We couldn't complete your payment. Please try again, or contact support quoting reference {code}.",
+      "payment": {
+        "network_failure": "We couldn't reach the payment provider. Check your connection and try again.",
+        "unexpected_failure": "We couldn't complete your payment. Please try again, or contact support if it keeps happening.",
+        "unexpected_failure_with_reference": "We couldn't complete your payment. Please try again, or contact support quoting reference {code}."
+      },
+      "card": {
+        "network_failure": "We couldn't reach the payment provider. Check your connection and try again.",
+        "unexpected_failure": "We couldn't verify this card. Please try again, or contact support if it keeps happening.",
+        "unexpected_failure_with_reference": "We couldn't verify this card. Please try again, or contact support quoting reference {code}."
+      },
       "unverified_email": "You cannot currently buy a premium subscription. You need to first verify your e-mail address.",
       "server_error_warning": "Something went wrong while processing your payment. Your subscription may have been activated. Please check your subscription status before trying again to avoid duplicate charges.",
       "check_subscription": "Check Subscription Status",

--- a/packages/website/i18n/locales/en.json
+++ b/packages/website/i18n/locales/en.json
@@ -1269,6 +1269,9 @@
     "error": {
       "init_error": "Initialization Error",
       "payment_failure": "Payment Failure",
+      "network_failure": "We couldn't reach the payment provider. Check your connection and try again.",
+      "unexpected_failure": "We couldn't complete your payment. Please try again, or contact support if it keeps happening.",
+      "unexpected_failure_with_reference": "We couldn't complete your payment. Please try again, or contact support quoting reference {code}.",
       "unverified_email": "You cannot currently buy a premium subscription. You need to first verify your e-mail address.",
       "server_error_warning": "Something went wrong while processing your payment. Your subscription may have been activated. Please check your subscription status before trying again to avoid duplicate charges.",
       "check_subscription": "Check Subscription Status",

--- a/packages/website/tests/unit/composables/use-paypal-payment-flow.spec.ts
+++ b/packages/website/tests/unit/composables/use-paypal-payment-flow.spec.ts
@@ -27,6 +27,15 @@ vi.mock('~/modules/checkout/composables/use-braintree-client', () => ({
   }),
 }));
 
+// Needs a component setup context for `useI18n`, and these tests call the
+// composable directly. The real mapping is covered by sigil's `paymentErrorCopy`
+// tests.
+vi.mock('~/modules/checkout/composables/use-payment-error-message', () => ({
+  usePaymentErrorMessage: () => ({
+    userMessageFor: ({ message }: { message: string }) => message,
+  }),
+}));
+
 vi.mock('~/modules/checkout/composables/use-paypal-api', () => ({
   usePaypalApi: () => ({
     addPaypalAccount: vi.fn(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,10 @@ importers:
         version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
 
   packages/sigil:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
     devDependencies:
       '@tsconfig/node24':
         specifier: 'catalog:'


### PR DESCRIPTION
A prod payment log recorded `3ds_verification_failed` with `error_message: "26"` and nothing else. "26" is not a Braintree code: the log sites only sent `error.message`, so a non-`Error` rejection collapsed to `String(error)` and the real discriminator was thrown away. Chasing that turned up three related problems.

### 1. The logs threw away the error detail

`parseBraintreeError` (sigil) describes the `BraintreeError` shape structurally with zod, so neither sigil nor its consumers need a braintree-web dependency, and no casts or `instanceof` are involved. It returns a plain `message`, a `logMessage` carrying the Cardinal original error, and the `code`.

The Cardinal detail matters because braintree-web collapses every unmapped Cardinal `ErrorNumber` into the single generic `THREEDS_CARDINAL_SDK_ERROR`, so that number is the only thing identifying the actual failure.

Every schema field is `.optional().catch(undefined)` on purpose: these are third-party objects, and a plain `z.object` fails the whole parse on one bad field type, so `{ code: 1234, message: 'kept' }` would silently lose a usable message. A test covers it.

Wired into every site that logs a Braintree SDK error: 3DS init and verify, card 3DS verify, both client-init paths, the PayPal SDK init and tokenize callbacks, and the SPA's client-init and payment paths. All of them now also send `errorCode`, which none of the client-init or PayPal sites did before.

The backend `error_code` sanitize limit goes from 32 to 64: the longest code we forward, `THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT`, is 35 chars.

### 2. Buyers were shown developer prose

The checkout rendered whatever the SDK put on `error.message`. "Something went wrong authenticating the JWT from Cardinal" is noise on a payment page, and that bare "26" reached the screen too.

`paymentErrorCopy` decides what the buyer should be told, keyed off an `audience` derived from the BraintreeError `type`:

| audience | when | shown |
|---|---|---|
| `own` | no `code` and no `type`, so we threw it | the message verbatim |
| `customer` | `type: 'CUSTOMER'` | the SDK message verbatim, braintree-web writes those for buyers |
| `network` | `type: 'NETWORK'` | connectivity/retry copy |
| `opaque` | `MERCHANT`/`INTERNAL`/`UNKNOWN`, unrecognised, or a bare string/number | generic copy plus the code as a support reference |

It returns a descriptor rather than a string, because the two front ends cannot share words: the website translates through vue-i18n, while `packages/card-payment` has no i18n runtime and keeps literal English in `src/i18n/en.ts`. Only the copy differs; the rule about when an SDK message may be shown is written and tested once.

The `code` is a stable caps-string identifier, so quoting it gives support something to trace while the Cardinal detail stays in the logs.

### 3. Saved-cards 3DS verified the wrong card

`use-card-three-d-secure` took the BIN from `paymentMethods.find(({ type }) => type === 'CreditCard')`, the first credit card in the vault, while the nonce came from the card the user clicked. With more than one saved card those are different cards, so the 3DS lookup ran against the wrong issuer and both the challenge and the liability-shift decision were made for a card nobody was verifying. It now matches on `lastFour`, which is what the checkout SPA already did.

Error copy on those screens was wrong too: nothing is being charged when you save a card or re-authorise one, so `userMessageFor` takes a context and picks between `subscription.error.payment.*` and `subscription.error.card.*`.

### Notes

- `packages/card-payment`'s `Buttons.onError` is left alone: `@types/paypal-checkout-components` types it `(error: string) => void`, so there is no code or original error to recover. The braintree-web `paypal-checkout` errors are real `BraintreeError`s and are covered.
- zod is added to sigil as a peer dep of `^3.0.0 || ^4.0.0` so it works either side of the zod 4 bump.
- The PayPal flow tests mock the new composable: it calls `useI18n`, which needs a setup context those direct-call tests do not have.

### Checks

typecheck clean in all five packages, lint 0 errors, 498 tests pass (70 in sigil, 15 of them new), `go build` and the paymentlog tests pass.

### Follow-up, not in this PR

The SPA hands 3DS params to the website through `sessionStorage`, which CodeQL flags (`js/clear-text-storage-of-sensitive-data`, alert #3) for storing the payment nonce in clear text. The fix is to store only references and let the 3DS page mint the nonce and resolve the BIN itself, which removes the flagged call entirely and needs no backend change. Kept separate so this PR stays about error handling.