### PR TITLE
fix(home): discover showcase screenshots via a build-time virtual module

### DIFF
--- a/packages/website/app/components/common/AppShowcaseSlider.vue
+++ b/packages/website/app/components/common/AppShowcaseSlider.vue
@@ -2,6 +2,7 @@
 import type { Swiper } from 'swiper/types';
 import { set } from '@vueuse/shared';
 import { SwiperSlide } from 'swiper/vue';
+import screenshots from 'virtual:app-screenshots';
 import Carousel from '~/components/common/carousel/Carousel.vue';
 import CarouselControls from '~/components/common/carousel/CarouselControls.vue';
 import 'swiper/css/pagination';
@@ -39,18 +40,18 @@ function getAltText(path: string): string {
   return screenshotAltTexts[filename] ?? 'rotki application screenshot';
 }
 
-const images = ref<ScreenshotImage[]>([]);
-
-function scanImages(): void {
-  const assetContext = import.meta.glob(
-    '~~/public/img/screenshots/*.(png|jpe?g|webp)',
-  );
-  const assetPaths = Object.keys(assetContext);
-  set(images, assetPaths.map((src) => {
-    const publicSrc = src.replace(/.*\/public\//, '/');
-    return { src: publicSrc, alt: getAltText(src) };
-  }));
-}
+/**
+ * Slide list, discovered at build time by the `app-screenshots` module.
+ *
+ * This used to be an `import.meta.glob` over `public/img/screenshots`, which
+ * cannot work: Vite deliberately keeps `public/` out of the module graph. It
+ * looked fine because the dev server resolves such patterns off the filesystem,
+ * while the build compiled it down to `Object.assign({})` and the carousel
+ * rendered zero slides in production.
+ */
+const images = ref<ScreenshotImage[]>(
+  screenshots.map(src => ({ src, alt: getAltText(src) })),
+);
 
 function onSwiperUpdate(s: Swiper): void {
   set(swiperInstance, s);
@@ -74,8 +75,8 @@ function getFetchPriority(index: number): 'high' | 'auto' {
 
 /**
  * Responsive srcset for the first image only (the LCP element). Pre-generated
- * width variants live in a `responsive/` subfolder (kept out of the slide glob
- * above); the original webp is the 2880w source. Mobile pulls a ~14-40KB variant
+ * width variants live in a `responsive/` subfolder (the module only lists files
+ * directly in the screenshots folder); the original webp is the 2880w source. Mobile pulls a ~14-40KB variant
  * instead of the 78KB source.
  */
 function getSrcset(image: ScreenshotImage, index: number): string | undefined {
@@ -91,8 +92,6 @@ const firstImageSizes = '(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 120
 function getSizes(index: number): string | undefined {
   return index === 0 ? firstImageSizes : undefined;
 }
-
-scanImages();
 </script>
 
 <template>

--- a/packages/website/modules/app-screenshots/module.ts
+++ b/packages/website/modules/app-screenshots/module.ts
@@ -1,0 +1,88 @@
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { addTypeTemplate, addVitePlugin, defineNuxtModule } from '@nuxt/kit';
+
+const VIRTUAL_ID = 'virtual:app-screenshots';
+const RESOLVED_ID = `\0${VIRTUAL_ID}`;
+
+const SCREENSHOT_DIR = 'public/img/screenshots';
+const EXTENSIONS = new Set(['.webp', '.png', '.jpg', '.jpeg']);
+
+/**
+ * Enumerate the showcase screenshots at build time.
+ *
+ * These live under `public/`, which Vite deliberately keeps out of the module
+ * graph, so `import.meta.glob` cannot see them in a build. It used to be used
+ * here and looked fine, because the dev server resolves such patterns off the
+ * filesystem — but the production build compiled the call down to
+ * `Object.assign({})` and the homepage carousel silently rendered zero slides.
+ * Reading the directory ourselves keeps the list auto-discovered without
+ * depending on `public/` being part of the graph.
+ *
+ * The `responsive/` subfolder holds pre-generated width variants of the first
+ * slide, not slides of its own, so only files directly in the folder count.
+ */
+function readScreenshots(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  return entries
+    .filter(entry => entry.isFile() && EXTENSIONS.has(extname(entry.name)))
+    .map(entry => entry.name)
+    .sort((a, b) => a.localeCompare(b, 'en', { numeric: true }))
+    .map(name => `/img/screenshots/${name}`);
+}
+
+function extname(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot === -1 ? '' : name.slice(dot).toLowerCase();
+}
+
+export default defineNuxtModule({
+  meta: { name: 'app-screenshots' },
+  setup(_options, nuxt) {
+    const dir = resolve(nuxt.options.rootDir, SCREENSHOT_DIR);
+
+    addVitePlugin({
+      name: 'app-screenshots',
+      resolveId: (id: string) => (id === VIRTUAL_ID ? RESOLVED_ID : undefined),
+      load(id: string) {
+        if (id !== RESOLVED_ID)
+          return;
+
+        const screenshots = readScreenshots(dir);
+        if (screenshots.length === 0)
+          this.warn(`no screenshots found in ${SCREENSHOT_DIR} — the showcase carousel will be empty`);
+
+        return `export default ${JSON.stringify(screenshots)};`;
+      },
+      // Picking up an added or removed screenshot without restarting the dev server.
+      configureServer(server: any) {
+        server.watcher.add(dir);
+        const invalidate = (path: string): void => {
+          if (!path.startsWith(dir))
+            return;
+
+          const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
+          if (!mod)
+            return;
+
+          server.moduleGraph.invalidateModule(mod);
+          server.ws.send({ type: 'full-reload' });
+        };
+        server.watcher.on('add', invalidate);
+        server.watcher.on('unlink', invalidate);
+      },
+    });
+
+    addTypeTemplate({
+      filename: 'types/app-screenshots.d.ts',
+      getContents: () => [
+        `declare module '${VIRTUAL_ID}' {`,
+        '  /** Public URLs of the showcase screenshots, in display order. */',
+        '  const screenshots: string[];',
+        '  export default screenshots;',
+        '}',
+        '',
+      ].join('\n'),
+    });
+  },
+});

--- a/packages/website/nuxt.config.ts
+++ b/packages/website/nuxt.config.ts
@@ -85,6 +85,7 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     ['@pinia/nuxt', { disableVuex: true }],
     '@nuxt/test-utils/module',
+    './modules/app-screenshots/module.ts',
     './modules/integration-images/module.ts',
     './modules/integration-seo/module.ts',
     './modules/comparison-seo/module.ts',


### PR DESCRIPTION
The homepage showcase carousel renders nothing in production: no slides, the container collapsed to 2px, and the screenshot preloads reported as "preloaded but not used". The testimonial carousel on the same page, using the same swiper version, is fine.

## Not swiper

`AppShowcaseSlider` built its slide list with

```ts
import.meta.glob('~~/public/img/screenshots/*.(png|jpe?g|webp)')
```

`import.meta.glob` cannot see into `public/` — Vite deliberately keeps that directory out of the module graph. The dev server resolves such patterns off the filesystem, so it looks correct locally; the build has nothing to enumerate.

From the currently deployed bundle (`AppShowcaseSlider-579d3be2.dAERDHky.js`):

```js
function C(){let e=Object.keys(Object.assign({}));…}
```

The glob compiled to `Object.assign({})` — an empty object. So `images` was `[]` and the carousel had no slides to render. Vite 7 still resolved the pattern, which is why this only appeared with the vite 8 upgrade (#649).

## Fix

An `app-screenshots` Nuxt module reads the directory at build time and exposes it as `virtual:app-screenshots`, so the list stays auto-discovered rather than becoming a hand-maintained array someone has to remember to update.

- Sorted with `localeCompare(..., { numeric: true })`, so a future `10-…` sorts after `9-…` instead of after `1-…`.
- Only files directly in the folder count. The `responsive/` subfolder holds pre-generated width variants of the first slide, not slides of its own.
- The dev server watches the folder and invalidates the virtual module when a screenshot is added or removed.
- **If the folder resolves empty the build warns.** The original failure was silent, which is the part worth fixing beyond the immediate bug.

Alt text stays in the component, keyed by filename, since it is copy rather than build data.

## Verification

Against a real production build, comparing bundles:

| | deployed today | with this change |
|---|---|---|
| screenshot paths in client chunk | 0 | **7** |
| screenshot paths in server chunk | 0 | **7** |
| `Object.assign({})` empty-glob | present | gone |

And in the browser: **7 slides**, carousel 792px tall (was 2px), first screenshot visible, pagination and arrows working. Testimonial carousel unaffected at 14 slides.

typecheck clean, lint clean (68 pre-existing warnings, 0 errors), 502 tests pass.

## Note for reviewers

`pnpm generate` currently fails on my machine with a nitro CSS-chunk placeholder error (`Could not resolve "./entry-styles-3.mjs-<buildId>.!~{003}~.js"`). That reproduces on unmodified `main` too and does not happen in CI, so it is environmental and unrelated to this change — but worth knowing if you hit it locally.
